### PR TITLE
Allow providing LSP configurations globally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # 0.7.1 (unreleased)
 
+`NEW` Now language server configuration might be provided globally via the `<os-specific home dir>/.emmyrc.json`, `<os-specific config dir>/emmylua_ls/.emmyrc.json`, or by setting a variable `EMMYLUALS_CONFIG` with a path to the json configuration.
+Global configuration have less priority than the local one
+
 # 0.7.0 
 
 `CHG` Refactor `type infer`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,6 +574,7 @@ name = "emmylua_ls"
 version = "0.7.0"
 dependencies = [
  "chrono",
+ "dirs",
  "emmylua_code_analysis",
  "emmylua_parser",
  "fern",

--- a/crates/emmylua_ls/Cargo.toml
+++ b/crates/emmylua_ls/Cargo.toml
@@ -33,3 +33,4 @@ rust-i18n.workspace = true
 glob.workspace = true
 serde_yml.workspace = true
 itertools.workspace = true
+dirs.workspace = true

--- a/docs/config/emmyrc_json_EN.md
+++ b/docs/config/emmyrc_json_EN.md
@@ -4,6 +4,8 @@
 
 The language server reads the ".emmyrc.json" file in the project root directory. For compatibility, it also reads a ".luarc.json" file. The ".emmyrc.json" format is similar to ".luarc.json" but provides richer options, and any settings in ".emmyrc.json" will override those in ".luarc.json". The two formats are not fully compatible, so unsupported parts in ".luarc.json" are ignored.
 
+You might also setup provide language server configuration globally by creating ".emmyrc.json"/".luarc.json" in your home dir or by setting a `EMMYLUALS_CONFIG` variable with a path to the configuration.
+
 It primarily follows this format:
 ```json
 {


### PR DESCRIPTION
This patch adds support for setting up a global configuration for the language server.

This can be done in a various ways.
* Via `<os-specific home dir>/[.emmyrc.json|.luarc.json]`.
* Via `<os-specific config dir>/emmylua_ls/[.emmyrc.json|.luarc.json]`.
* By setting enviroment EMMYLUALS_CONFIG environment variable with a path to the desired JSON config.

This config files have less priority than the local ones.