### PR TITLE
feat: treat array index as nil-able

### DIFF
--- a/crates/emmylua_code_analysis/resources/schema.json
+++ b/crates/emmylua_code_analysis/resources/schema.json
@@ -142,6 +142,7 @@
     },
     "strict": {
       "default": {
+        "arrayIndex": true,
         "requirePath": false,
         "typeCall": false
       },
@@ -839,6 +840,11 @@
     "EmmyrcStrict": {
       "type": "object",
       "properties": {
+        "arrayIndex": {
+          "description": "Whether to enable strict mode array indexing.",
+          "default": true,
+          "type": "boolean"
+        },
         "requirePath": {
           "description": "Whether to enable strict mode require path.",
           "default": false,

--- a/crates/emmylua_code_analysis/src/config/configs/strict.rs
+++ b/crates/emmylua_code_analysis/src/config/configs/strict.rs
@@ -1,14 +1,21 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+fn default_true() -> bool {
+    true
+}
+
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct EmmyrcStrict {
     /// Whether to enable strict mode require path.
-    #[serde(default = "default_false")]
+    #[serde(default)]
     pub require_path: bool,
     #[serde(default)]
     pub type_call: bool,
+    /// Whether to enable strict mode array indexing.
+    #[serde(default = "default_true")]
+    pub array_index: bool,
 }
 
 impl Default for EmmyrcStrict {
@@ -16,10 +23,7 @@ impl Default for EmmyrcStrict {
         Self {
             require_path: false,
             type_call: false,
+            array_index: true,
         }
     }
-}
-
-fn default_false() -> bool {
-    false
 }

--- a/crates/emmylua_code_analysis/src/diagnostic/test/unnecessary_assert_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/unnecessary_assert_test.rs
@@ -35,6 +35,14 @@ mod test {
             assert(false)
 
             assert(nil and 5)
+
+            ---@type integer[]
+            local ints = {1, 2}
+            assert(ints[3])
+
+            ---@type [integer, integer]
+            local enum = {1, 2}
+            assert(enum[3])
         "#
         ));
     }
@@ -65,6 +73,15 @@ mod test {
             DiagnosticCode::UnnecessaryAssert,
             r#"
             assert({}, 'hi')
+            "#
+        ));
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::UnnecessaryAssert,
+            r#"
+            ---@type [integer, integer]
+            local enum = {1, 2}
+            assert(enum[2])
             "#
         ));
     }

--- a/crates/emmylua_code_analysis/src/semantic/infer/infer_index.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/infer_index.rs
@@ -167,12 +167,17 @@ fn infer_array_member(
     index_expr: LuaIndexMemberExpr,
 ) -> Result<LuaType, InferFailReason> {
     let key = index_expr.get_index_key().ok_or(InferFailReason::None)?;
+    let expression_type = if db.get_emmyrc().strict.array_index {
+        TypeOps::Union.apply(array_type, &LuaType::Nil)
+    } else {
+        array_type.clone()
+    };
     match key {
-        LuaIndexKey::Integer(_) => Ok(TypeOps::Union.apply(array_type, &LuaType::Nil)),
+        LuaIndexKey::Integer(_) => Ok(expression_type),
         LuaIndexKey::Expr(expr) => {
             let expr_type = infer_expr(db, cache, expr.clone())?;
             if expr_type.is_integer() {
-                Ok(TypeOps::Union.apply(array_type, &LuaType::Nil))
+                Ok(expression_type)
             } else {
                 Err(InferFailReason::FieldDotFound)
             }
@@ -665,13 +670,18 @@ fn infer_member_by_index_array(
     index_expr: LuaIndexMemberExpr,
 ) -> InferResult {
     let member_key = index_expr.get_index_key().ok_or(InferFailReason::None)?;
+    let expression_type = if db.get_emmyrc().strict.array_index {
+        TypeOps::Union.apply(base, &LuaType::Nil)
+    } else {
+        base.clone()
+    };
     if member_key.is_integer() {
-        return Ok(TypeOps::Union.apply(base, &LuaType::Nil));
+        return Ok(expression_type);
     } else if member_key.is_expr() {
         let expr = member_key.get_expr().ok_or(InferFailReason::None)?;
         let expr_type = infer_expr(db, cache, expr.clone())?;
         if check_type_compact(db, &LuaType::Number, &expr_type).is_ok() {
-            return Ok(TypeOps::Union.apply(base, &LuaType::Nil));
+            return Ok(expression_type);
         }
     }
 

--- a/crates/emmylua_code_analysis/src/semantic/infer/infer_index.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/infer_index.rs
@@ -168,15 +168,13 @@ fn infer_array_member(
 ) -> Result<LuaType, InferFailReason> {
     let key = index_expr.get_index_key().ok_or(InferFailReason::None)?;
     match key {
-        LuaIndexKey::Integer(_) => {
-            return Ok(array_type.clone());
-        }
+        LuaIndexKey::Integer(_) => Ok(TypeOps::Union.apply(array_type, &LuaType::Nil)),
         LuaIndexKey::Expr(expr) => {
             let expr_type = infer_expr(db, cache, expr.clone())?;
             if expr_type.is_integer() {
-                return Ok(array_type.clone());
+                Ok(TypeOps::Union.apply(array_type, &LuaType::Nil))
             } else {
-                return Err(InferFailReason::FieldDotFound);
+                Err(InferFailReason::FieldDotFound)
             }
         }
         _ => Err(InferFailReason::FieldDotFound),
@@ -668,12 +666,12 @@ fn infer_member_by_index_array(
 ) -> InferResult {
     let member_key = index_expr.get_index_key().ok_or(InferFailReason::None)?;
     if member_key.is_integer() {
-        return Ok(base.clone());
+        return Ok(TypeOps::Union.apply(base, &LuaType::Nil));
     } else if member_key.is_expr() {
         let expr = member_key.get_expr().ok_or(InferFailReason::None)?;
         let expr_type = infer_expr(db, cache, expr.clone())?;
         if check_type_compact(db, &LuaType::Number, &expr_type).is_ok() {
-            return Ok(base.clone());
+            return Ok(TypeOps::Union.apply(base, &LuaType::Nil));
         }
     }
 

--- a/docs/config/emmyrc_json_CN.md
+++ b/docs/config/emmyrc_json_CN.md
@@ -149,7 +149,8 @@ https://github.com/CppCXY/emmylua-analyzer-rust/blob/main/crates/emmylua_code_an
 ## strict
 
 - `requirePath`: 是否启用require严格模式, 默认为 `false`. 严格模式时, require必须从指定的根目录开始, 否则无法跳转
-- `typeCall`: 是否启用类型调用时严格模式, 默认为 `true`. 严格模式时, 类型调用必须手动写好重载, 否则返回unknown, 非严格模式时, 类型调用会返回自身
+- `typeCall`: 是否启用类型调用时严格模式, 默认为 `false`. 严格模式时, 类型调用必须手动写好重载, 否则返回unknown, 非严格模式时, 类型调用会返回自身
+- `arrayIndex`：是否启用数组索引的严格模式. 默认为 `true`. 严格模式下，索引必须遵循严格规则（如适用）
 
 ## hover
 

--- a/docs/config/emmyrc_json_EN.md
+++ b/docs/config/emmyrc_json_EN.md
@@ -64,7 +64,8 @@ It primarily follows this format:
   },
   "strict": {
     "requirePath": false,
-    "typeCall": true
+    "typeCall": false,
+    "arrayIndex": true
   },
   "hover": {
     "enable": true
@@ -135,8 +136,9 @@ This feature is mainly to make `require` work correctly. If you need to map modu
 - `enable`: Whether or not to enable CodeLens. Default is `true`.
 
 ## strict
-- `requirePath`: Whether or not to enable strict mode for require. Default is `true`.
-- `typeCall`: Whether or not to enable strict type calls. Default is `true`.
+- `requirePath`: Whether or not to enable strict mode for require. Default is `false`.
+- `typeCall`: Whether or not to enable strict type calls. Default is `false`.
+- `arrayIndex`: Whether or not to enable strict mode for array indexing. Default is `true`.
 
 ## hover
 - `enable`: Whether or not to enable hover support. Default is `true`.


### PR DESCRIPTION
Expressions like this:

```lua
---@type integer[]
local arr = {1, 2, 3}
return arr[2]
```

should be considered as type `integer|nil`, since array accesses can always *potentially* return `nil`. This commit marks those expressions as such.

Related to #248