### PR TITLE
feat: diagnostics for "impossible" assertions

### DIFF
--- a/crates/emmylua_code_analysis/locales/lint.yml
+++ b/crates/emmylua_code_analysis/locales/lint.yml
@@ -209,6 +209,10 @@ Cannot use `...` outside a vararg function.:
   en: 'Unnecessary assert: this expression is always truthy'
   zh_CN: '不必要的断言: 这个表达式始终为真'
   zh_HK: '不必要的斷言: 這個表達式始終為真'
+'Impossible assert: this expression is always falsy; prefer `error()`':
+  en: 'Impossible assert: this expression is always falsy; prefer `error()`'
+  zh_CN: '不可能的断言: 该表达式始终为假；建议使用 `error()`'
+  zh_HK: '不可能的斷言: 該表達式始終為假；建議使用 `error()`'
 "`...` should be the last arg.":
   en: "`...` should be the last arg."
   zh_CN: "`...`必须是最后一个参数。"

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/unnecessary_assert.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/unnecessary_assert.rs
@@ -40,6 +40,14 @@ fn check_assert_rule(
                 t!("Unnecessary assert: this expression is always truthy").to_string(),
                 None,
             );
+        } else if first_type.is_always_falsy() {
+            context.add_diagnostic(
+                DiagnosticCode::UnnecessaryAssert,
+                call_expr.get_range(),
+                t!("Impossible assert: this expression is always falsy; prefer `error()`")
+                    .to_string(),
+                None,
+            );
         }
     }
     Some(())

--- a/crates/emmylua_code_analysis/src/diagnostic/test/unnecessary_assert_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/unnecessary_assert_test.rs
@@ -32,10 +32,6 @@ mod test {
             local f
             assert(f)
 
-            assert(false)
-
-            assert(nil and 5)
-
             ---@type integer[]
             local ints = {1, 2}
             assert(ints[3])
@@ -82,6 +78,52 @@ mod test {
             ---@type [integer, integer]
             local enum = {1, 2}
             assert(enum[2])
+            "#
+        ));
+    }
+
+    #[test]
+    fn test_impossible_assert() {
+        let mut ws = VirtualWorkspace::new();
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::UnnecessaryAssert,
+            r#"
+            assert(false)
+            "#
+        ));
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::UnnecessaryAssert,
+            r#"
+            assert(nil)
+            "#
+        ));
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::UnnecessaryAssert,
+            r#"
+            assert(nil and 5)
+            "#
+        ));
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::UnnecessaryAssert,
+            r#"
+            local a = false ---@type false
+            assert(a)
+            "#
+        ));
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::UnnecessaryAssert,
+            r#"
+            ---@type integer[]
+            local a = {1,2,3}
+            local b = a[2] ---@type integer|nil
+            if not b then
+              assert(b, "No second element!")
+            end
             "#
         ));
     }


### PR DESCRIPTION
This is the reverse of unnecessary assertions; these are assertions that will always fail (and will be equivalent to just `error()`)