### PR TITLE
feature: add goto_str_tpl_ref_definition

### DIFF
--- a/crates/emmylua_ls/src/handlers/definition/goto_def_definition.rs
+++ b/crates/emmylua_ls/src/handlers/definition/goto_def_definition.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
-use emmylua_code_analysis::{LuaSemanticDeclId, SemanticModel};
+use emmylua_code_analysis::{LuaSemanticDeclId, LuaType, LuaTypeDeclId, SemanticModel};
+use emmylua_parser::{LuaAstNode, LuaAstToken, LuaCallExpr, LuaExpr, LuaStringToken};
 use lsp_types::{GotoDefinitionResponse, Location, Position, Range, Uri};
 
 pub fn goto_def_definition(
@@ -80,6 +81,63 @@ fn goto_source_location(source: &str) -> Option<Location> {
                 range,
             });
         }
+    }
+
+    None
+}
+
+pub fn goto_str_tpl_ref_definition(
+    semantic_model: &SemanticModel,
+    string_token: LuaStringToken,
+) -> Option<GotoDefinitionResponse> {
+    let name = string_token.get_value();
+    let call_expr = string_token.ancestors::<LuaCallExpr>().next()?;
+    let arg_exprs = call_expr.get_args_list()?.get_args().collect::<Vec<_>>();
+    let string_token_idx = arg_exprs.iter().position(|arg| {
+        if let LuaExpr::LiteralExpr(literal_expr) = arg {
+            if literal_expr
+                .syntax()
+                .text_range()
+                .contains(string_token.get_range().start())
+            {
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+    })?;
+    let func = semantic_model.infer_call_expr_func(call_expr.clone(), None)?;
+    let params = func.get_params();
+
+    let target_param = match (func.is_colon_define(), call_expr.is_colon_call()) {
+        (false, true) => params.get(string_token_idx + 1),
+        (true, false) => {
+            if string_token_idx > 0 {
+                params.get(string_token_idx - 1)
+            } else {
+                None
+            }
+        }
+        _ => params.get(string_token_idx),
+    }?;
+    if let Some(LuaType::StrTplRef(str_tpl)) = target_param.1.clone() {
+        let prefix = str_tpl.get_prefix();
+        let suffix = str_tpl.get_suffix();
+        let type_decl_id = LuaTypeDeclId::new(format!("{}{}{}", prefix, name, suffix).as_str());
+        let type_decl = semantic_model
+            .get_db()
+            .get_type_index()
+            .get_type_decl(&type_decl_id)?;
+        let mut locations = Vec::new();
+        for lua_location in type_decl.get_locations() {
+            let document = semantic_model.get_document_by_file_id(lua_location.file_id)?;
+            let location = document.to_lsp_location(lua_location.range)?;
+            locations.push(location);
+        }
+
+        return Some(GotoDefinitionResponse::Array(locations));
     }
 
     None

--- a/crates/emmylua_ls/src/handlers/definition/test/definition_test.rs
+++ b/crates/emmylua_ls/src/handlers/definition/test/definition_test.rs
@@ -1,0 +1,23 @@
+#[cfg(test)]
+mod tests {
+    use crate::handlers::test_lib::ProviderVirtualWorkspace;
+
+    #[test]
+    fn test_basic_definition() {
+        let mut ws = ProviderVirtualWorkspace::new();
+        ws.check_definition(
+            r#"
+                ---@generic T: string
+                ---@param name `T`
+                ---@return T
+                local function new(name)
+                    return name
+                end
+
+                ---@class Ability
+
+                local a = new("<??>Ability")
+            "#,
+        );
+    }
+}

--- a/crates/emmylua_ls/src/handlers/definition/test/mod.rs
+++ b/crates/emmylua_ls/src/handlers/definition/test/mod.rs
@@ -1,0 +1,1 @@
+mod definition_test;

--- a/crates/emmylua_ls/src/handlers/test_lib/mod.rs
+++ b/crates/emmylua_ls/src/handlers/test_lib/mod.rs
@@ -217,6 +217,7 @@ impl ProviderVirtualWorkspace {
         };
         let file_id = self.def(&content);
         let result = implementation(&self.analysis, file_id, position);
+        dbg!(&result);
         let Some(result) = result else {
             return false;
         };
@@ -225,5 +226,23 @@ impl ProviderVirtualWorkspace {
         };
         dbg!(&implementations.len());
         true
+    }
+
+    pub fn check_definition(&mut self, block_str: &str) -> bool {
+        let content = Self::handle_file_content(block_str);
+        let Some((content, position)) = content else {
+            return false;
+        };
+        let file_id = self.def(&content);
+        let result = super::definition::definition(&self.analysis, file_id, position);
+        dbg!(&result);
+        let Some(result) = result else {
+            return false;
+        };
+        match result {
+            GotoDefinitionResponse::Scalar(_) => true,
+            GotoDefinitionResponse::Array(_) => true,
+            GotoDefinitionResponse::Link(_) => true,
+        }
     }
 }


### PR DESCRIPTION
当函数调用参数为string且目标为字符串泛型模板时, 允许跳转到实际定义
