### PR TITLE
JSON format for documentation export

### DIFF
--- a/crates/emmylua_doc_cli/src/cmd_args.rs
+++ b/crates/emmylua_doc_cli/src/cmd_args.rs
@@ -1,8 +1,8 @@
+use std::str::FromStr;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 pub struct CmdArgs {
-    /// The path of the lua file
     #[structopt(
         parse(from_os_str),
         long = "input",
@@ -10,7 +10,15 @@ pub struct CmdArgs {
         help = "The path of the lua project"
     )]
     pub input: std::path::PathBuf,
-    /// The output path of the markdown file
+
+    #[structopt(
+        default_value = "Markdown",
+        long = "format",
+        short = "f",
+        help = "Format of the output, default is Markdown"
+    )]
+    pub format: Format,
+    
     #[structopt(
         parse(from_os_str),
         default_value = "./output",
@@ -33,4 +41,22 @@ pub struct CmdArgs {
         help = "The path of the mixin md file"
     )]
     pub mixin: Option<std::path::PathBuf>,
+}
+
+#[derive(Debug, Eq, PartialEq, StructOpt)]
+pub enum Format {
+    Markdown,
+    Json,
+}
+
+impl FromStr for Format {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_ref() {
+            "markdown" => Ok(Self::Markdown),
+            "json" => Ok(Self::Json),
+            _ => Err("Invalid format, must be one of markdown, json"),
+        }
+    }
 }

--- a/crates/emmylua_doc_cli/src/common.rs
+++ b/crates/emmylua_doc_cli/src/common.rs
@@ -1,0 +1,22 @@
+use emmylua_code_analysis::{humanize_type, DbIndex, LuaType, RenderLevel};
+
+pub fn render_typ(db: &DbIndex, typ: &LuaType) -> String {
+    match typ {
+        LuaType::IntegerConst(_) => "integer".to_string(),
+        LuaType::FloatConst(_) => "number".to_string(),
+        LuaType::StringConst(_) => "string".to_string(),
+        LuaType::BooleanConst(_) => "boolean".to_string(),
+        _ => humanize_type(db, typ, RenderLevel::Simple),
+    }
+}
+
+pub fn render_const(typ: &LuaType) -> Option<String> {
+    match typ {
+        LuaType::IntegerConst(i) | LuaType::DocIntegerConst(i) => Some(i.to_string()),
+        LuaType::FloatConst(f) => Some(f.to_string()),
+        LuaType::StringConst(s) | LuaType::DocStringConst(s) => {
+            Some(format!("{:?}", s.to_string()))
+        }
+        _ => None,
+    }
+}

--- a/crates/emmylua_doc_cli/src/init.rs
+++ b/crates/emmylua_doc_cli/src/init.rs
@@ -53,7 +53,7 @@ pub fn collect_files(workspaces: &Vec<PathBuf>, emmyrc: &Emmyrc) -> Vec<LuaFileI
 
     let encoding = &emmyrc.workspace.encoding;
 
-    println!(
+    eprintln!(
         "collect_files from: {:?} match_pattern: {:?} exclude: {:?}",
         workspaces, match_pattern, exclude
     );
@@ -71,10 +71,10 @@ pub fn collect_files(workspaces: &Vec<PathBuf>, emmyrc: &Emmyrc) -> Vec<LuaFileI
         }
     }
 
-    println!("load files from workspace count: {:?}", files.len());
+    eprintln!("load files from workspace count: {:?}", files.len());
 
     for file in &files {
-        println!("loaded file: {:?}", file.path);
+        eprintln!("loaded file: {:?}", file.path);
     }
     files
 }

--- a/crates/emmylua_doc_cli/src/json_generator/export.rs
+++ b/crates/emmylua_doc_cli/src/json_generator/export.rs
@@ -1,0 +1,330 @@
+use crate::common::{render_const, render_typ};
+use crate::json_generator::json_types::*;
+use emmylua_code_analysis::{
+    DbIndex, FileId, LuaDeprecated, LuaMemberKey, LuaMemberOwner, LuaNoDiscard,
+    LuaSemanticDeclId, LuaSignature, LuaType, LuaTypeCache, LuaTypeDecl, Vfs,
+};
+use rowan::TextRange;
+
+pub fn export(db: &DbIndex) -> Index {
+    Index {
+        modules: export_modules(db),
+        types: export_types(db),
+        globals: export_globals(db),
+    }
+}
+
+fn export_modules(db: &DbIndex) -> Vec<Module> {
+    let module_index = db.get_module_index();
+    let modules = module_index.get_module_infos();
+    let vfs = db.get_vfs();
+
+    modules
+        .into_iter()
+        .filter(|module| {
+            !(module_index.is_std(&module.file_id) || module_index.is_library(&module.file_id))
+        })
+        .filter_map(|module| {
+            let members = match module.export_type.as_ref()? {
+                LuaType::Def(type_id) => {
+                    let member_owner = LuaMemberOwner::Type(type_id.clone());
+                    export_members(db, member_owner)
+                }
+                LuaType::TableConst(t) => {
+                    let member_owner = LuaMemberOwner::Element(t.clone());
+                    export_members(db, member_owner)
+                }
+                LuaType::Instance(i) => {
+                    let member_owner = LuaMemberOwner::Element(i.get_range().clone());
+                    export_members(db, member_owner)
+                }
+                _ => return None,
+            };
+
+            Some(Module {
+                name: module.full_module_name.clone(),
+                file: vfs.get_file_path(&module.file_id).cloned(),
+                members,
+            })
+        })
+        .collect()
+}
+
+fn export_types(db: &DbIndex) -> Vec<Type> {
+    let type_index = db.get_type_index();
+    let module_index = db.get_module_index();
+    let types = type_index.get_all_types();
+
+    types
+        .into_iter()
+        .filter(|type_decl| {
+            type_decl.get_locations().iter().any(|loc| {
+                !(module_index.is_std(&loc.file_id) || module_index.is_library(&loc.file_id))
+            })
+        })
+        .flat_map(|type_decl| {
+            if type_decl.is_class() {
+                Some(Type::Class(export_class(db, type_decl)))
+            } else if type_decl.is_enum() {
+                Some(Type::Enum(export_enum(db, type_decl)))
+            } else if type_decl.is_alias() {
+                Some(Type::Alias(export_alias(db, type_decl)))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn export_globals(db: &DbIndex) -> Vec<Global> {
+    let global_index = db.get_global_index();
+    let module_index = db.get_module_index();
+    let type_index = db.get_type_index();
+    let vfs = db.get_vfs();
+    let globals = global_index.get_all_global_decl_ids();
+
+    globals
+        .into_iter()
+        .filter(|global| {
+            !(module_index.is_std(&global.file_id) || module_index.is_library(&global.file_id))
+        })
+        .filter_map(|global| {
+            let decl = db.get_decl_index().get_decl(&global)?;
+            let typ = type_index.get_type_cache(&global.into())?.as_type();
+            let property = export_property(db, LuaSemanticDeclId::LuaDecl(global.clone()));
+            let loc = export_loc(vfs, decl.get_file_id(), decl.get_range());
+            match typ {
+                LuaType::TableConst(table) => {
+                    let member_owner = LuaMemberOwner::Element(table.clone());
+                    Some(Global::Table(GlobalTable {
+                        name: decl.get_name().to_string(),
+                        property,
+                        loc,
+                        members: export_members(db, member_owner),
+                    }))
+                }
+                _ => Some(Global::Field(GlobalField {
+                    name: decl.get_name().to_string(),
+                    property,
+                    loc,
+                    typ: render_typ(db, typ),
+                    literal: render_const(typ),
+                })),
+            }
+        })
+        .collect()
+}
+
+fn export_class(db: &DbIndex, type_decl: &LuaTypeDecl) -> Class {
+    let type_decl_id = type_decl.get_id();
+    let type_index = db.get_type_index();
+    let property = export_property(db, LuaSemanticDeclId::TypeDecl(type_decl.get_id().clone()));
+    let member_owner = LuaMemberOwner::Type(type_decl_id.clone());
+
+    Class {
+        name: type_decl.get_full_name().to_string(),
+        property,
+        loc: export_loc_for_type(db, type_decl),
+        bases: type_index
+            .get_super_types(&type_decl_id)
+            .unwrap_or_default()
+            .iter()
+            .map(|typ| render_typ(db, typ))
+            .collect(),
+        generics: type_index
+            .get_generic_params(&type_decl_id)
+            .map(|v| v.as_slice())
+            .unwrap_or_default()
+            .iter()
+            .map(|(name, typ)| TypeVar {
+                name: name.clone(),
+                base: typ.as_ref().map(|typ| render_typ(db, typ)),
+            })
+            .collect(),
+        members: export_members(db, member_owner),
+    }
+}
+
+fn export_alias(db: &DbIndex, type_decl: &LuaTypeDecl) -> Alias {
+    let type_decl_id = type_decl.get_id();
+    let property = export_property(db, LuaSemanticDeclId::TypeDecl(type_decl.get_id().clone()));
+    let member_owner = LuaMemberOwner::Type(type_decl_id);
+
+    Alias {
+        name: type_decl.get_full_name().to_string(),
+        property,
+        loc: export_loc_for_type(db, type_decl),
+        typ: type_decl.get_alias_ref().map(|typ| render_typ(db, typ)),
+        members: export_members(db, member_owner),
+    }
+}
+
+fn export_enum(db: &DbIndex, type_decl: &LuaTypeDecl) -> Enum {
+    let type_decl_id = type_decl.get_id();
+    let property = export_property(db, LuaSemanticDeclId::TypeDecl(type_decl.get_id().clone()));
+    let member_owner = LuaMemberOwner::Type(type_decl_id);
+
+    Enum {
+        name: type_decl.get_full_name().to_string(),
+        property,
+        loc: export_loc_for_type(db, type_decl),
+        typ: type_decl
+            .get_enum_field_type(db)
+            .map(|typ| render_typ(db, &typ)),
+        members: export_members(db, member_owner),
+    }
+}
+
+fn export_members(db: &DbIndex, member_owner: LuaMemberOwner) -> Vec<Member> {
+    let member_index = db.get_member_index();
+    let type_index = db.get_type_index();
+    let vfs = db.get_vfs();
+    let members = member_index.get_sorted_members(&member_owner);
+    if let Some(members) = members {
+        members
+            .into_iter()
+            .filter_map(|member| {
+                let typ = type_index
+                    .get_type_cache(&member.get_id().into())
+                    .unwrap_or(&LuaTypeCache::InferType(LuaType::Unknown))
+                    .as_type();
+
+                let member_key = member.get_key();
+                let name = match member_key {
+                    LuaMemberKey::Name(name) => name.to_string(),
+                    _ => return None,
+                };
+
+                let member_id = member.get_id();
+                let member_property_id = LuaSemanticDeclId::Member(member_id);
+                let property = export_property(db, member_property_id);
+
+                let loc = export_loc(vfs, member.get_file_id(), member.get_range());
+
+                match typ {
+                    LuaType::Signature(signature_id) => db
+                        .get_signature_index()
+                        .get(&signature_id)
+                        .map(|signature| {
+                            Member::Fn(export_signature(db, signature, name, property, loc))
+                        }),
+                    _ => Some(Member::Field(export_field(db, typ, name, property, loc))),
+                }
+            })
+            .collect()
+    } else {
+        Default::default()
+    }
+}
+
+fn export_signature(
+    db: &DbIndex,
+    signature: &LuaSignature,
+    name: String,
+    property: Property,
+    loc: Option<Loc>,
+) -> Fn {
+    Fn {
+        name,
+        property,
+        loc,
+        generics: signature
+            .generic_params
+            .iter()
+            .map(|(name, typ)| TypeVar {
+                name: name.clone(),
+                base: typ.as_ref().map(|typ| render_typ(db, typ)),
+            })
+            .collect(),
+        params: signature
+            .params
+            .iter()
+            .enumerate()
+            .map(|(i, name)| match signature.param_docs.get(&i) {
+                Some(param_info) => FnParam {
+                    name: Some(name.clone()),
+                    typ: Some(render_typ(db, &param_info.type_ref)),
+                    desc: param_info.description.clone(),
+                },
+                None => FnParam {
+                    name: Some(name.clone()),
+                    ..Default::default()
+                },
+            })
+            .collect(),
+        returns: signature
+            .return_docs
+            .iter()
+            .map(|ret| FnParam {
+                name: ret.name.clone(),
+                typ: Some(render_typ(db, &ret.type_ref)),
+                desc: ret.description.clone(),
+            })
+            .collect(),
+        overloads: signature
+            .overloads
+            .iter()
+            .map(|overload| render_typ(db, &LuaType::DocFunction(overload.clone())))
+            .collect(),
+        is_async: signature.is_async,
+        is_meth: signature.is_colon_define,
+        is_nodiscard: signature.nodiscard.is_some(),
+        nodiscard_message: match &signature.nodiscard {
+            Some(LuaNoDiscard::NoDiscardWithMessage(msg)) => Some(msg.to_string()),
+            _ => None,
+        },
+    }
+}
+
+fn export_field(
+    db: &DbIndex,
+    typ: &LuaType,
+    name: String,
+    property: Property,
+    loc: Option<Loc>,
+) -> Field {
+    Field {
+        name,
+        property,
+        loc,
+        typ: render_typ(db, typ),
+        literal: render_const(typ),
+    }
+}
+
+fn export_property(db: &DbIndex, semantic_decl: LuaSemanticDeclId) -> Property {
+    match db.get_property_index().get_property(&semantic_decl) {
+        Some(property) => Property {
+            description: property.description.as_ref().map(|s| s.to_string()),
+            visibility: property
+                .visibility
+                .as_ref()
+                .and_then(|s| s.to_str())
+                .map(|s| s.to_string()),
+            see: property.see_content.as_ref().map(|s| s.to_string()),
+            deprecated: property.deprecated.is_some(),
+            deprecation_reason: property.deprecated.as_ref().and_then(|s| match s {
+                LuaDeprecated::Deprecated => None,
+                LuaDeprecated::DeprecatedWithMessage(msg) => Some(msg.to_string()),
+            }),
+            other: property.other_content.as_ref().map(|s| s.to_string()),
+        },
+        None => Default::default(),
+    }
+}
+
+fn export_loc_for_type(db: &DbIndex, type_decl: &LuaTypeDecl) -> Vec<Loc> {
+    let vfs = db.get_vfs();
+    type_decl
+        .get_locations()
+        .iter()
+        .filter_map(|loc| export_loc(vfs, loc.file_id, loc.range))
+        .collect()
+}
+
+fn export_loc(vfs: &Vfs, file_id: FileId, range: TextRange) -> Option<Loc> {
+    vfs.get_document(&file_id).map(|document| Loc {
+        file: document.get_file_path().clone(),
+        line: document.get_line(range.start()).unwrap_or_default() + 1,
+    })
+}

--- a/crates/emmylua_doc_cli/src/json_generator/json_types.rs
+++ b/crates/emmylua_doc_cli/src/json_generator/json_types.rs
@@ -1,0 +1,143 @@
+use std::path::PathBuf;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct Index {
+    pub modules: Vec<Module>,
+    pub types: Vec<Type>,
+    pub globals: Vec<Global>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all="snake_case")]
+pub enum Global {
+    Table(GlobalTable),
+    Field(GlobalField),
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct GlobalTable {
+    pub name: String,
+    #[serde(flatten)]
+    pub property: Property,
+    pub loc: Option<Loc>,
+    pub members: Vec<Member>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct GlobalField {
+    pub name: String,
+    #[serde(flatten)]
+    pub property: Property,
+    pub loc: Option<Loc>,
+    pub typ: String,
+    pub literal: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct Module {
+    pub name: String,
+    pub file: Option<PathBuf>,
+    pub members: Vec<Member>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all="snake_case")]
+pub enum Type {
+    Class(Class),
+    Enum(Enum),
+    Alias(Alias),
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct Class {
+    pub name: String,
+    #[serde(flatten)]
+    pub property: Property,
+    pub loc: Vec<Loc>,
+    pub bases: Vec<String>,
+    pub generics: Vec<TypeVar>,
+    pub members: Vec<Member>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct Enum {
+    pub name: String,
+    #[serde(flatten)]
+    pub property: Property,
+    pub loc: Vec<Loc>,
+    pub typ: Option<String>,
+    pub members: Vec<Member>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct Alias {
+    pub name: String,
+    #[serde(flatten)]
+    pub property: Property,
+    pub loc: Vec<Loc>,
+    pub typ: Option<String>,
+    pub members: Vec<Member>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all="snake_case")]
+pub enum Member {
+    Fn(Fn),
+    Field(Field),
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct Fn {
+    pub name: String,
+    #[serde(flatten)]
+    pub property: Property,
+    pub loc: Option<Loc>,
+    pub generics: Vec<TypeVar>,
+    pub params: Vec<FnParam>,
+    pub returns: Vec<FnParam>,
+    pub overloads: Vec<String>,
+    pub is_async: bool,
+    pub is_meth: bool,
+    pub is_nodiscard: bool,
+    pub nodiscard_message: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct FnParam {
+    pub name: Option<String>,
+    pub typ: Option<String>,
+    pub desc: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct Field {
+    pub name: String,
+    #[serde(flatten)]
+    pub property: Property,
+    pub loc: Option<Loc>,
+    pub typ: String,
+    pub literal: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct Property {
+    pub description: Option<String>,
+    pub visibility: Option<String>,
+    pub see: Option<String>,
+    pub deprecated: bool,
+    pub deprecation_reason: Option<String>,
+    pub other: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct TypeVar {
+    pub name: String,
+    pub base: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct Loc {
+    pub file: PathBuf,
+    pub line: usize,
+}

--- a/crates/emmylua_doc_cli/src/json_generator/mod.rs
+++ b/crates/emmylua_doc_cli/src/json_generator/mod.rs
@@ -1,0 +1,31 @@
+use emmylua_code_analysis::EmmyLuaAnalysis;
+use std::path::PathBuf;
+
+mod export;
+mod json_types;
+
+pub fn generate_json(
+    analysis: &mut EmmyLuaAnalysis,
+    output: PathBuf,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let db = analysis.compilation.get_db();
+
+    let json_path = if output.ends_with(".json") {
+        output
+    } else {
+        if !output.exists() {
+            eprintln!("Creating output directory: {:?}", output);
+            std::fs::create_dir_all(&output)?;
+        }
+
+        output.join("doc.json")
+    };
+
+    let data = export::export(db);
+
+    eprintln!("Writing JSON output to {:?}", json_path);
+
+    std::fs::write(&json_path, serde_json::to_string_pretty(&data)?)?;
+
+    Ok(())
+}

--- a/crates/emmylua_doc_cli/src/markdown_generator/gen/global_gen.rs
+++ b/crates/emmylua_doc_cli/src/markdown_generator/gen/global_gen.rs
@@ -61,7 +61,7 @@ pub fn generate_global_markdown(
     });
 
     let outpath = output.join(file_name);
-    println!("output global file: {}", outpath.display());
+    eprintln!("output global file: {}", outpath.display());
     match std::fs::write(outpath, render_text) {
         Ok(_) => {}
         Err(e) => {

--- a/crates/emmylua_doc_cli/src/markdown_generator/gen/mod_gen.rs
+++ b/crates/emmylua_doc_cli/src/markdown_generator/gen/mod_gen.rs
@@ -67,7 +67,7 @@ pub fn generate_module_markdown(
     });
 
     let outpath = output.join(file_name);
-    println!("output module file: {}", outpath.display());
+    eprintln!("output module file: {}", outpath.display());
     match std::fs::write(outpath, render_text) {
         Ok(_) => {}
         Err(e) => {

--- a/crates/emmylua_doc_cli/src/markdown_generator/gen/typ_gen.rs
+++ b/crates/emmylua_doc_cli/src/markdown_generator/gen/typ_gen.rs
@@ -163,7 +163,7 @@ fn generate_class_type_markdown(
     });
 
     let outpath = output.join(file_type_name);
-    println!("output class file: {}", outpath.display());
+    eprintln!("output class file: {}", outpath.display());
     match std::fs::write(outpath, render_text) {
         Ok(_) => {}
         Err(e) => {
@@ -249,7 +249,7 @@ fn generate_enum_type_markdown(
     });
 
     let outpath = output.join(file_type_name);
-    println!("output enum file: {}", outpath.display());
+    eprintln!("output enum file: {}", outpath.display());
     match std::fs::write(outpath, render_text) {
         Ok(_) => {}
         Err(e) => {
@@ -305,7 +305,7 @@ fn generate_alias_type_markdown(
     });
 
     let outpath = output.join(file_type_name);
-    println!("output alias file: {}", outpath.display());
+    eprintln!("output alias file: {}", outpath.display());
     match std::fs::write(outpath, render_text) {
         Ok(_) => {}
         Err(e) => {

--- a/crates/emmylua_doc_cli/src/markdown_generator/mod.rs
+++ b/crates/emmylua_doc_cli/src/markdown_generator/mod.rs
@@ -12,46 +12,44 @@ use gen::{
 };
 use markdown_types::MkdocsIndex;
 
-#[allow(unused)]
 pub fn generate_markdown(
     analysis: &mut EmmyLuaAnalysis,
-    input: PathBuf,
     output: PathBuf,
     override_template: Option<PathBuf>,
     mixin: Option<PathBuf>,
-) -> Option<()> {
+) -> Result<(), Box<dyn std::error::Error>> {
     let docs_dir = output.join("docs");
     let types_out = docs_dir.join("types");
     if !types_out.exists() {
-        println!("Creating types directory: {:?}", types_out);
-        std::fs::create_dir_all(&types_out).ok()?;
+        eprintln!("Creating types directory: {:?}", types_out);
+        std::fs::create_dir_all(&types_out)?;
     } else {
-        println!("Clearing types directory: {:?}", types_out);
-        std::fs::remove_dir_all(&types_out).ok()?;
-        std::fs::create_dir_all(&types_out).ok()?;
+        eprintln!("Clearing types directory: {:?}", types_out);
+        std::fs::remove_dir_all(&types_out)?;
+        std::fs::create_dir_all(&types_out)?;
     }
 
     let module_out = docs_dir.join("modules");
     if !module_out.exists() {
-        println!("Creating modules directory: {:?}", module_out);
-        std::fs::create_dir_all(&module_out).ok()?;
+        eprintln!("Creating modules directory: {:?}", module_out);
+        std::fs::create_dir_all(&module_out)?;
     } else {
-        println!("Clearing modules directory: {:?}", module_out);
-        std::fs::remove_dir_all(&module_out).ok()?;
-        std::fs::create_dir_all(&module_out).ok()?;
+        eprintln!("Clearing modules directory: {:?}", module_out);
+        std::fs::remove_dir_all(&module_out)?;
+        std::fs::create_dir_all(&module_out)?;
     }
 
     let global_out = docs_dir.join("globals");
     if !global_out.exists() {
-        println!("Creating globals directory: {:?}", global_out);
-        std::fs::create_dir_all(&global_out).ok()?;
+        eprintln!("Creating globals directory: {:?}", global_out);
+        std::fs::create_dir_all(&global_out)?;
     } else {
-        println!("Clearing globals directory: {:?}", global_out);
-        std::fs::remove_dir_all(&global_out).ok()?;
-        std::fs::create_dir_all(&global_out).ok()?;
+        eprintln!("Clearing globals directory: {:?}", global_out);
+        std::fs::remove_dir_all(&global_out)?;
+        std::fs::create_dir_all(&global_out)?;
     }
 
-    let tl = init_tl::init_tl(override_template)?;
+    let tl = init_tl::init_tl(override_template).ok_or("Failed to initialize TL")?;
     let mut mkdocs_index = MkdocsIndex::default();
     let db = analysis.compilation.get_db();
     let type_index = db.get_type_index();
@@ -78,7 +76,7 @@ pub fn generate_markdown(
         mixin_copy::mixin_copy(&output, mixin);
     }
 
-    Some(())
+    Ok(())
 }
 
 fn escape_type_name(name: &str) -> String {

--- a/crates/emmylua_doc_cli/src/markdown_generator/render.rs
+++ b/crates/emmylua_doc_cli/src/markdown_generator/render.rs
@@ -1,3 +1,4 @@
+use crate::common::render_typ;
 use emmylua_code_analysis::{
     humanize_type, DbIndex, LuaFunctionType, LuaSignatureId, LuaType, RenderLevel,
 };
@@ -203,14 +204,4 @@ fn render_signature_type(
     result.push('\n');
 
     Some(result)
-}
-
-fn render_typ(db: &DbIndex, typ: &LuaType) -> String {
-    match typ {
-        LuaType::IntegerConst(_) => "integer".to_string(),
-        LuaType::FloatConst(_) => "number".to_string(),
-        LuaType::StringConst(_) => "string".to_string(),
-        LuaType::BooleanConst(_) => "boolean".to_string(),
-        _ => humanize_type(db, typ, RenderLevel::Simple),
-    }
 }

--- a/crates/emmylua_parser/src/kind/lua_visibility_kind.rs
+++ b/crates/emmylua_parser/src/kind/lua_visibility_kind.rs
@@ -20,4 +20,16 @@ impl VisibilityKind {
             _ => VisibilityKind::None,
         }
     }
+
+    #[allow(unused)]
+    pub fn to_str(&self) -> Option<&'static str> {
+        match self {
+            VisibilityKind::None => None,
+            VisibilityKind::Public => Some("public"),
+            VisibilityKind::Protected => Some("protected"),
+            VisibilityKind::Private => Some("private"),
+            VisibilityKind::Internal => Some("internal"),
+            VisibilityKind::Package => Some("package"),
+        }
+    }
 }


### PR DESCRIPTION
Partial solution for #435.

The only thing that's missing from export is descriptions for modules. They are not stored in the database as of now. I could add them, but I'm not sure where to store them. I guess `VFS` or `LuaModuleIndex`? @CppCXY any ideas?
