### PR TITLE
Improve type inference for member access in unions and intersections

### DIFF
--- a/crates/emmylua_code_analysis/src/compilation/test/annotation_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/annotation_test.rs
@@ -38,7 +38,7 @@ mod test {
         let ty = ws.expr_ty("GG.fun");
         assert_eq!(
             format!("{:?}", ty),
-            "Signature(LuaSignatureId { file_id: FileId { id: 14 }, position: 76 })"
+            "Signature(LuaSignatureId { file_id: FileId { id: 15 }, position: 76 })"
         );
     }
 }

--- a/crates/emmylua_code_analysis/src/db_index/type/types.rs
+++ b/crates/emmylua_code_analysis/src/db_index/type/types.rs
@@ -725,6 +725,29 @@ impl From<LuaUnionType> for LuaType {
     }
 }
 
+pub fn make_union(left_type: LuaType, right_type: LuaType) -> LuaType {
+    match (left_type, right_type) {
+        (left, right) if left == right => left,
+        (LuaType::Union(left_type_union), LuaType::Union(right_type_union)) => {
+            let mut left_types = left_type_union.into_types();
+            let right_types = right_type_union.into_types();
+            left_types.extend(right_types);
+            LuaType::Union(LuaUnionType::new(left_types).into())
+        }
+        (LuaType::Union(left_type_union), right) => {
+            let mut left_types = (*left_type_union).into_types();
+            left_types.push(right);
+            LuaType::Union(LuaUnionType::new(left_types).into())
+        }
+        (left, LuaType::Union(right_type_union)) => {
+            let mut right_types = (*right_type_union).into_types();
+            right_types.push(left);
+            LuaType::Union(LuaUnionType::new(right_types).into())
+        }
+        (left, right) => LuaType::Union(LuaUnionType::new(vec![left, right]).into()),
+    }
+}
+
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct LuaIntersectionType {
     types: Vec<LuaType>,
@@ -751,6 +774,29 @@ impl LuaIntersectionType {
 impl From<LuaIntersectionType> for LuaType {
     fn from(t: LuaIntersectionType) -> Self {
         LuaType::Intersection(t.into())
+    }
+}
+
+pub fn make_intersection(left_type: LuaType, right_type: LuaType) -> LuaType {
+    match (left_type, right_type) {
+        (left, right) if left == right => left,
+        (LuaType::Intersection(left_type_union), LuaType::Intersection(right_type_union)) => {
+            let mut left_types = left_type_union.into_types();
+            let right_types = right_type_union.into_types();
+            left_types.extend(right_types);
+            LuaType::Intersection(LuaIntersectionType::new(left_types).into())
+        }
+        (LuaType::Intersection(left_type_union), right) => {
+            let mut left_types = left_type_union.into_types();
+            left_types.push(right);
+            LuaType::Intersection(LuaIntersectionType::new(left_types).into())
+        }
+        (left, LuaType::Intersection(right_type_union)) => {
+            let mut right_types = right_type_union.into_types();
+            right_types.push(left);
+            LuaType::Intersection(LuaIntersectionType::new(right_types).into())
+        }
+        (left, right) => LuaType::Intersection(LuaIntersectionType::new(vec![left, right]).into()),
     }
 }
 

--- a/crates/emmylua_code_analysis/src/diagnostic/test/undefined_field_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/undefined_field_test.rs
@@ -5,7 +5,7 @@ mod test {
     #[test]
     fn test_1() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(!ws.check_code_for(
             DiagnosticCode::UndefinedField,
             r#"
                 ---@alias std.NotNull<T> T - ?
@@ -15,7 +15,7 @@ mod test {
                 ---@return fun(tbl: any):int, std.NotNull<V>
                 function ipairs(t) end
 
-                ---@type {[integer]: string|table}
+                ---@type {[integer]: integer|table}
                 local a = {}
 
                 for i, extendsName in ipairs(a) do


### PR DESCRIPTION
I'm still not very familiar with code base, so comments are welcome.

Fix #454.

This behavior is consistent with modern type theory. In mathematics, 'type' is defined as a set of all possible values that a variable can have. Therefore, a union of types would include all possible values for left and right types. An intersection of types would only include values that can be assigned to both left and right types. Hence, we come to rules for member access:

- for union types, we can access a member if both left and right types have this member. Type of the member would be a union of corresponding members from left and right types;
- for intersection types, we can access a member if either left or right type contain it. Type of the member would be an intersection of corresponding members from left and right types.

Note for unions. If one of the types does not contain a member, we shouldn't allow accessing it:

```lua
local x --- @type integer | { meep: string }
x.meep --> Warning: accessing field on an integer value can cause an error.
```

Note for intersections. If one of the types does not contain a member, we won't be able to construct such type, therefore member access is safe:

```lua
local x --- @type integer & { meep: string }
x.meep --> No warning; however, we will not be able to assign anything to `x`.
```
