### PR TITLE
Enhance `next` function type annotations with generics and overloads 🌟✨

### DIFF
--- a/crates/emmylua_code_analysis/resources/std/global.lua
+++ b/crates/emmylua_code_analysis/resources/std/global.lua
@@ -214,10 +214,11 @@ function module(name, ...) end
 --- The behavior of `next` is undefined if, during the traversal, you assign
 --- any value to a non-existent field in the table. You may however modify
 --- existing fields. In particular, you may set existing fields to nil.
----@overload fun(table:table):any
----@param table table
----@param index? any
----@return any
+---@generic K, V
+---@overload fun(table:table<K, V>):K?,V?
+---@param table table<K, V> | V[] | {[K]: V}
+---@param index? K
+---@return K?, V?
 function next(table, index) end
 
 ---


### PR DESCRIPTION
This pull request updates the type annotations for the `next` function in the `global.lua` file to improve type safety and provide better support for generic types.

Enhancements to type annotations:

* [`crates/emmylua_code_analysis/resources/std/global.lua`](diffhunk://#diff-d8e6f1c80026123f91eb74db8925ca9f651bee0d1ef114e95ff80279538f5c8dL217-R221): Updated the `next` function's annotations to use generics (`K, V`) for key-value pairs, allowing more precise type inference. The `table` parameter now supports `table<K, V>`, `V[]`, and `{[K]: V}` types, and the return type reflects the generic key-value pair (`K?, V?`).

![image](https://github.com/user-attachments/assets/e4f74254-f242-4670-97d1-afa62f42629f)
![image](https://github.com/user-attachments/assets/b169a076-1cce-4420-ae27-51da57bc2466)
