### PR TITLE
Support for rawget annotations

### DIFF
--- a/crates/emmylua_code_analysis/resources/std/builtin.lua
+++ b/crates/emmylua_code_analysis/resources/std/builtin.lua
@@ -118,6 +118,9 @@
 --- built-in type for Unpack function
 ---@alias std.Unpack<T, Start, End> unknown
 
+--- built-in type for Get function, returns the value type for a key in a table
+---@alias std.Get<T, K> unknown
+
 --- compact luals
 
 ---@alias type std.type

--- a/crates/emmylua_code_analysis/resources/std/global.lua
+++ b/crates/emmylua_code_analysis/resources/std/global.lua
@@ -267,9 +267,10 @@ function rawequal(v1, v2) end
 ---
 --- Gets the real value of `table[index]`, the `__index` metamethod. `table`
 --- must be a table; `index` may be any value.
----@param table table
----@param index any
----@return any
+---@generic T, K
+---@param table T
+---@param index K
+---@return std.Get<T, K>
 function rawget(table, index) end
 
 --- Returns the length of the object `v`, which must be a table or a string, without

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/doc/infer_type.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/doc/infer_type.rs
@@ -269,7 +269,16 @@ fn infer_special_generic_type(
                 LuaAliasCallType::new(LuaAliasCallKind::Select, params).into(),
             ));
         }
-        "std.Unpack" => {}
+        "std.Get" => {
+            let mut params = Vec::new();
+            for param in generic_type.get_generic_types()?.get_types() {
+                let param_type = infer_type(analyzer, param);
+                params.push(param_type);
+            }
+            return Some(LuaType::Call(
+                LuaAliasCallType::new(LuaAliasCallKind::Get, params).into(),
+            ));
+        }
         "TypeGuard" => {
             let first_doc_param_type = generic_type.get_generic_types()?.get_types().next()?;
             let first_param = infer_type(analyzer, first_doc_param_type);

--- a/crates/emmylua_code_analysis/src/db_index/type/types.rs
+++ b/crates/emmylua_code_analysis/src/db_index/type/types.rs
@@ -773,6 +773,7 @@ pub enum LuaAliasCallKind {
     Sub,
     Select,
     Unpack,
+    Get,
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]

--- a/crates/emmylua_code_analysis/src/semantic/generic/instantiate_type_generic.rs
+++ b/crates/emmylua_code_analysis/src/semantic/generic/instantiate_type_generic.rs
@@ -300,7 +300,6 @@ fn instantiate_signature(
     return LuaType::Signature(signature_id.clone());
 }
 
-#[derive(Debug, Clone)]
 enum ExtractKeyName {
     String(String),
     Integer(i64),


### PR DESCRIPTION
This pull request introduces a new built-in type `std.Get` for Lua, enhances the handling of the `rawget` function, and adds related functionality for type inference and testing. The most important changes include defining the `std.Get` type, updating `rawget` to use generics, implementing a new type inference mechanism for `std.Get`, and adding comprehensive tests to validate the improvements.

### Enhancements to Lua type system:

* Added a new built-in type alias `std.Get<T, K>` to represent the value type for a key in a table. (`crates/emmylua_code_analysis/resources/std/builtin.lua`, [crates/emmylua_code_analysis/resources/std/builtin.luaR121-R123](diffhunk://#diff-0d4c64248f3651f4116767f05613d125605eb64c654a2706439b51f48bb9d158R121-R123))
* Updated the `rawget` function to use generics, allowing it to return a type-safe result based on the `std.Get` type. (`crates/emmylua_code_analysis/resources/std/global.lua`, [crates/emmylua_code_analysis/resources/std/global.luaL271-R274](diffhunk://#diff-d8e6f1c80026123f91eb74db8925ca9f651bee0d1ef114e95ff80279538f5c8dL271-R274))

### Improvements to type inference:

* Added support for inferring `std.Get` in the `infer_special_generic_type` function, enabling the resolution of types for `rawget` calls. (`crates/emmylua_code_analysis/src/compilation/analyzer/doc/infer_type.rs`, [crates/emmylua_code_analysis/src/compilation/analyzer/doc/infer_type.rsR282-R291](diffhunk://#diff-793a868dcb6433e8f8675f19a4b25d59bb293f91eaea0badc0af266fd2d7ea8aR282-R291))
* Introduced a new `LuaAliasCallKind::Get` variant to handle `std.Get` operations and implemented the `instantiate_rawget_call` function for precise type inference. (`crates/emmylua_code_analysis/src/db_index/type/types.rs`, [[1]](diffhunk://#diff-abc8cd5d6337cb22d4e6e32cf6e5f90f4b79cd184fb00da03b555af691393e88R776); `crates/emmylua_code_analysis/src/semantic/generic/instantiate_type_generic.rs`, [[2]](diffhunk://#diff-3c0b1af1c2ba93136a8900610d3f42efbc7b9606b7fa1e748cc09eb6c53a7d7fR383-R385) [[3]](diffhunk://#diff-3c0b1af1c2ba93136a8900610d3f42efbc7b9606b7fa1e748cc09eb6c53a7d7fR589-R651)

### Testing and validation:

* Added two new test cases (`test_better_rawget` and `test_better_rawget2`) to validate the behavior of `rawget` with various table structures and key types, ensuring accurate type inference. (`crates/emmylua_code_analysis/src/compilation/test/flow.rs`, [crates/emmylua_code_analysis/src/compilation/test/flow.rsR763-R843](diffhunk://#diff-c35e9f0bf437f378811ecf800c2afa3dcb21e8bcf9114464edb20326e2772b4fR763-R843))

### Captures
![image](https://github.com/user-attachments/assets/c16c858a-4028-43d6-8389-20ca4877d197)
![image](https://github.com/user-attachments/assets/58689692-bdcb-4ccb-9829-ddbe1de7132a)
![image](https://github.com/user-attachments/assets/64d0b6a3-4387-4baa-beed-b641946a1c1a)
![image](https://github.com/user-attachments/assets/a875a15a-3705-4f8f-a180-40891c43dc5a)

ETC...


## Notes..
There are still things that I found impossible to achieve, such as boolean-type keys or more complex objects, but I think most use cases for table keys are integers and strings, so this covers a large part.