### PR TITLE
std: allow setmetable to take `nil`

### DIFF
--- a/crates/emmylua_code_analysis/resources/std/global.lua
+++ b/crates/emmylua_code_analysis/resources/std/global.lua
@@ -375,7 +375,7 @@ function select(index, ...) end
 ---
 --- This function returns `table`.
 ---@param table table
----@param metatable std.metatable|table
+---@param metatable std.metatable|table|nil
 ---@return table
 function setmetatable(table, metatable) end
 


### PR DESCRIPTION
Note Lua allows:

```lua
setmetable({}, nil)
```

but does not allow:

```lua
setmetable({})
```
