### PR TITLE
docs: fix schema url for .emmyrc.json

### DIFF
--- a/docs/config/emmyrc_json_CN.md
+++ b/docs/config/emmyrc_json_CN.md
@@ -45,7 +45,7 @@ EmmyLua 语言服务器支持灵活的配置系统，通过配置文件可以精
 
 ```json
 {
-  "$schema": "https://github.com/CppCXY/emmylua-analyzer-rust/blob/main/crates/emmylua_code_analysis/resources/schema.json"
+  "$schema": "https://raw.githubusercontent.com/EmmyLuaLs/emmylua-analyzer-rust/refs/heads/main/crates/emmylua_code_analysis/resources/schema.json"
 }
 ```
 

--- a/docs/config/emmyrc_json_EN.md
+++ b/docs/config/emmyrc_json_EN.md
@@ -47,7 +47,7 @@ To enable intelligent completion and validation for configuration files, you can
 
 ```json
 {
-  "$schema": "https://github.com/CppCXY/emmylua-analyzer-rust/blob/main/crates/emmylua_code_analysis/resources/schema.json"
+  "$schema": "https://raw.githubusercontent.com/EmmyLuaLs/emmylua-analyzer-rust/refs/heads/main/crates/emmylua_code_analysis/resources/schema.json"
 }
 ```
 


### PR DESCRIPTION
- the autocomplete wasn't working in neovim with json-ls
- change the url to raw to make it work