### PR TITLE
表的字段检查加强

### DIFF
--- a/crates/emmylua_code_analysis/src/diagnostic/checker/assign_type_mismatch.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/assign_type_mismatch.rs
@@ -239,9 +239,9 @@ fn handle_value_is_table_expr(
                     handle_value_is_table_expr(context, semantic_model, source_type.clone(), &expr);
                     // 如果continue，则字段类型为非table，但是提供了table的情况下，会检查不出来
                     // continue;
-                } else if field.is_value_field() { 
-                    continue;  
-                } 
+                } else if field.is_value_field() {
+                    continue;
+                }
 
                 let expr_type = semantic_model.infer_expr(expr).unwrap_or(LuaType::Any);
 

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/assign_type_mismatch.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/assign_type_mismatch.rs
@@ -218,9 +218,9 @@ fn handle_value_is_table_expr(
     }
 
     for field in fields {
-        if field.is_value_field() {
-            continue;
-        }
+        // if field.is_value_field() {
+        //     continue;
+        // }
 
         let field_key = field.get_field_key();
         if let Some(field_key) = field_key {
@@ -234,6 +234,11 @@ fn handle_value_is_table_expr(
 
             let expr = field.get_value_expr();
             if let Some(expr) = expr {
+                // Handle nested table expressions recursively
+                if LuaTableExpr::cast(expr.syntax().clone()).is_some() {
+                    handle_value_is_table_expr(context, semantic_model, source_type.clone(), &expr);
+                }
+
                 let expr_type = semantic_model.infer_expr(expr).unwrap_or(LuaType::Any);
 
                 let allow_nil = match table_type {

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/assign_type_mismatch.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/assign_type_mismatch.rs
@@ -237,7 +237,11 @@ fn handle_value_is_table_expr(
                 // Handle nested table expressions recursively
                 if LuaTableExpr::cast(expr.syntax().clone()).is_some() {
                     handle_value_is_table_expr(context, semantic_model, source_type.clone(), &expr);
-                }
+                    // 如果continue，则字段类型为非table，但是提供了table的情况下，会检查不出来
+                    // continue;
+                } else if field.is_value_field() { 
+                    continue;  
+                } 
 
                 let expr_type = semantic_model.infer_expr(expr).unwrap_or(LuaType::Any);
 

--- a/crates/emmylua_code_analysis/src/semantic/infer/infer_index.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/infer_index.rs
@@ -177,9 +177,7 @@ fn infer_array_member(
                 Err(InferFailReason::FieldNotFound)
             }
         }
-        LuaIndexKey::Idx(_) => {
-            Ok(expression_type)
-        }
+        LuaIndexKey::Idx(_) => Ok(expression_type),
         _ => Err(InferFailReason::FieldNotFound),
     }
 }

--- a/crates/emmylua_code_analysis/src/semantic/infer/infer_index.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/infer_index.rs
@@ -177,6 +177,9 @@ fn infer_array_member(
                 Err(InferFailReason::FieldNotFound)
             }
         }
+        LuaIndexKey::Idx(_) => {
+            Ok(expression_type)
+        }
         _ => Err(InferFailReason::FieldNotFound),
     }
 }

--- a/crates/emmylua_code_analysis/src/semantic/member/infer_raw_member.rs
+++ b/crates/emmylua_code_analysis/src/semantic/member/infer_raw_member.rs
@@ -1,8 +1,10 @@
 use crate::{
     DbIndex, InferFailReason, InferGuard, LuaMemberKey, LuaMemberOwner, LuaObjectType,
-    LuaTupleType, LuaType, LuaTypeDeclId,
+    LuaTupleType, LuaType, LuaTypeDeclId, TypeOps,
 };
-
+use std::sync::Arc;
+use smol_str::SmolStr;
+use crate::semantic::check_type_compact;
 use super::{get_buildin_type_map_type_id, RawGetMemberTypeResult};
 
 #[allow(unused)]
@@ -40,7 +42,51 @@ fn infer_raw_member_type_guard(
         }
         LuaType::Tuple(tuple) => infer_tuple_raw_member_type(tuple, member_key),
         LuaType::Object(object) => infer_object_raw_member_type(object, member_key),
+        LuaType::Array(array_type) => infer_array_member_type(db, array_type, member_key),
+        LuaType::TableGeneric(table_generic) => {
+            infer_table_generic_member_type(db, table_generic, member_key)
+        }
         // other do not support now
+        _ => Err(InferFailReason::None),
+    }
+}
+
+fn infer_table_generic_member_type(
+    db: &DbIndex,
+    table_params: &Arc<Vec<LuaType>>,
+    member_key: &LuaMemberKey,
+) -> RawGetMemberTypeResult {
+    if table_params.len() != 2 {
+        return Err(InferFailReason::None);
+    }
+    let key_type = &table_params[0];
+    let value_type = &table_params[1];
+    let access_key_type = match member_key {
+        LuaMemberKey::Integer(i) => {LuaType::IntegerConst(*i)}
+        LuaMemberKey::Name(name) => {LuaType::StringConst(SmolStr::new(name.as_str()).into())}
+        _ => {
+            return Err(InferFailReason::None);
+        }
+    };
+    if check_type_compact(db, key_type, &access_key_type).is_ok(){
+        return Ok(value_type.clone());
+    }
+
+    Err(InferFailReason::None)
+}
+
+fn infer_array_member_type(
+    db: &DbIndex,
+    array_type: &LuaType,
+    member_key: &LuaMemberKey,
+) -> RawGetMemberTypeResult {
+    let expression_type = if db.get_emmyrc().strict.array_index {
+        TypeOps::Union.apply(db, array_type, &LuaType::Nil)
+    } else {
+        array_type.clone()
+    };
+    match member_key {
+        LuaMemberKey::Integer(_) => Ok(expression_type),
         _ => Err(InferFailReason::None),
     }
 }

--- a/crates/emmylua_code_analysis/src/semantic/member/infer_raw_member.rs
+++ b/crates/emmylua_code_analysis/src/semantic/member/infer_raw_member.rs
@@ -1,11 +1,11 @@
+use super::{get_buildin_type_map_type_id, RawGetMemberTypeResult};
+use crate::semantic::check_type_compact;
 use crate::{
     DbIndex, InferFailReason, InferGuard, LuaMemberKey, LuaMemberOwner, LuaObjectType,
     LuaTupleType, LuaType, LuaTypeDeclId, TypeOps,
 };
-use std::sync::Arc;
 use smol_str::SmolStr;
-use crate::semantic::check_type_compact;
-use super::{get_buildin_type_map_type_id, RawGetMemberTypeResult};
+use std::sync::Arc;
 
 #[allow(unused)]
 pub fn infer_raw_member_type(
@@ -62,13 +62,13 @@ fn infer_table_generic_member_type(
     let key_type = &table_params[0];
     let value_type = &table_params[1];
     let access_key_type = match member_key {
-        LuaMemberKey::Integer(i) => {LuaType::IntegerConst(*i)}
-        LuaMemberKey::Name(name) => {LuaType::StringConst(SmolStr::new(name.as_str()).into())}
+        LuaMemberKey::Integer(i) => LuaType::IntegerConst(*i),
+        LuaMemberKey::Name(name) => LuaType::StringConst(SmolStr::new(name.as_str()).into()),
         _ => {
             return Err(InferFailReason::None);
         }
     };
-    if check_type_compact(db, key_type, &access_key_type).is_ok(){
+    if check_type_compact(db, key_type, &access_key_type).is_ok() {
         return Ok(value_type.clone());
     }
 

--- a/crates/emmylua_ls/src/handlers/completion/providers/table_field_provider.rs
+++ b/crates/emmylua_ls/src/handlers/completion/providers/table_field_provider.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use emmylua_code_analysis::{LuaMemberInfo, LuaMemberKey, LuaType};
+use emmylua_code_analysis::{humanize_type, LuaMemberInfo, LuaMemberKey, LuaType, RenderLevel};
 use emmylua_parser::{LuaAst, LuaAstNode, LuaTableExpr, LuaTableField};
 use lsp_types::{CompletionItem, InsertTextFormat, InsertTextMode};
 use rowan::NodeOrToken;
@@ -136,13 +136,17 @@ fn add_field_key_completion(
     } else {
         None
     };
-
+    let description = humanize_type(builder.semantic_model.get_db(), &typ, RenderLevel::Brief);
     let completion_item = CompletionItem {
         label,
         kind: Some(lsp_types::CompletionItemKind::PROPERTY),
         data,
         deprecated,
         insert_text: Some(insert_text),
+        label_details: Some(lsp_types::CompletionItemLabelDetails {
+            description: Some(description),
+            detail: None,
+        }),
         ..Default::default()
     };
 


### PR DESCRIPTION
嵌套表时递归检查字段类型是否匹配
![image](https://github.com/user-attachments/assets/791d8884-9681-47c2-9538-033d3eabbf6f)
```
---@class T1
---@field x T2

---@class T2
---@field xx number

---@type T1
local t = {
    x = {
        xx = "", 
    }
}
```

当表类型声明为数组或者table<>时识别成员类型并提示成员的错误。当嵌套表比较大时只在最外层提示赋值错误有点难找到是哪个成员有问题