### PR TITLE
emmylua_doc_cli: support custom site_name

### DIFF
--- a/crates/emmylua_doc_cli/src/cmd_args.rs
+++ b/crates/emmylua_doc_cli/src/cmd_args.rs
@@ -19,6 +19,9 @@ pub struct CmdArgs {
     #[arg(long)]
     pub override_template: Option<PathBuf>,
 
+    #[arg(long, default_value = "Docs")]
+    pub site_name: Option<String>,
+
     /// The path of the mixin md file
     #[arg(long)]
     pub mixin: Option<PathBuf>,

--- a/crates/emmylua_doc_cli/src/main.rs
+++ b/crates/emmylua_doc_cli/src/main.rs
@@ -33,6 +33,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             &mut analysis,
             args.output,
             args.override_template,
+            args.site_name,
             args.mixin,
         ),
         Format::Json => json_generator::generate_json(&mut analysis, args.output),

--- a/crates/emmylua_doc_cli/src/markdown_generator/gen/index_gen.rs
+++ b/crates/emmylua_doc_cli/src/markdown_generator/gen/index_gen.rs
@@ -12,6 +12,9 @@ pub fn generate_index(
     mkdocs.modules.sort_by(|a, b| a.name.cmp(&b.name));
     mkdocs.globals.sort_by(|a, b| a.name.cmp(&b.name));
 
+    if !mkdocs.site_name.is_empty() {
+        context.insert("site_name", &mkdocs.site_name);
+    }
     if !mkdocs.types.is_empty() {
         context.insert("types", &mkdocs.types);
     }

--- a/crates/emmylua_doc_cli/src/markdown_generator/markdown_types.rs
+++ b/crates/emmylua_doc_cli/src/markdown_generator/markdown_types.rs
@@ -28,6 +28,7 @@ pub struct Property {
 
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct MkdocsIndex {
+    pub site_name: String,
     pub types: Vec<IndexStruct>,
     pub modules: Vec<IndexStruct>,
     pub globals: Vec<IndexStruct>,

--- a/crates/emmylua_doc_cli/src/markdown_generator/mod.rs
+++ b/crates/emmylua_doc_cli/src/markdown_generator/mod.rs
@@ -16,6 +16,7 @@ pub fn generate_markdown(
     analysis: &mut EmmyLuaAnalysis,
     output: PathBuf,
     override_template: Option<PathBuf>,
+    site_name: Option<String>,
     mixin: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let docs_dir = output.join("docs");
@@ -51,6 +52,10 @@ pub fn generate_markdown(
 
     let tl = init_tl::init_tl(override_template).ok_or("Failed to initialize TL")?;
     let mut mkdocs_index = MkdocsIndex::default();
+    if let Some(site_name) = site_name {
+        mkdocs_index.site_name = site_name;
+    }
+
     let db = analysis.compilation.get_db();
     let type_index = db.get_type_index();
     let types = type_index.get_all_types();

--- a/crates/emmylua_doc_cli/template/mkdocs_template.tl
+++ b/crates/emmylua_doc_cli/template/mkdocs_template.tl
@@ -1,4 +1,9 @@
+{% if site_name %}
+site_name: {{ site_name }}
+{% else %}
 site_name: Docs
+{% endif %}
+
 theme:
   name: material
   font:


### PR DESCRIPTION
支持自定义 site_name，这样可以和 [mkdocs-monorepo-plugin](https://backstage.github.io/mkdocs-monorepo-plugin/) 配合使用，让它可以聚合多个 emmylua_doc_cli 生成的多个 mkdocs 目录。