### PR TITLE
build(nix): add devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,16 @@
           // {
             default = self.packages.${system}.emmylua_ls;
           };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = (with pkgs; [
+            rust-analyzer
+            clippy
+            rustfmt
+          ])
+          ++ self.packages.${system}.default.buildInputs
+          ++ self.packages.${system}.default.nativeBuildInputs;
+        };
       }
     );
 }


### PR DESCRIPTION
This adds a simple nix devShell to the flake, with the build inputs and rust tools needed to build + rust-analyzer and rustfmt.