### PR TITLE
Fix feature conflict in `num-traits` when building `emmylua_doc_cli`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,6 +613,7 @@ dependencies = [
  "emmylua_parser",
  "include_dir",
  "lsp-types",
+ "num-traits",
  "rowan",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,4 @@ toml_edit = "0.22.23"
 itertools = "0.14.0"
 clap = { version = "4.5.39", features = ["derive", "wrap_help"] }
 ansi_term = "0.12.1"
+num-traits = { version = "0.2", features = ["std"] }

--- a/crates/emmylua_doc_cli/Cargo.toml
+++ b/crates/emmylua_doc_cli/Cargo.toml
@@ -29,3 +29,4 @@ walkdir.workspace = true
 tera.workspace = true
 include_dir.workspace = true
 clap.workspace = true
+num-traits.workspace = true


### PR DESCRIPTION
Some cargo versions fail to resolve features for `num-traits`, resulting in no-std build and compilation error:

```
Compiling num-traits v0.2.19
error[E0433]: failed to resolve: use of unresolved module or unlinked crate `std`
```

Explicitly adding `"std"` to `num-traits` features mitigates this problem.