### PR TITLE
Add `--version` flag to all CLIs

### DIFF
--- a/crates/emmylua_check/src/cmd_args.rs
+++ b/crates/emmylua_check/src/cmd_args.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 #[allow(unused)]
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "cli", derive(Parser))]
+#[cfg_attr(feature = "cli", command(version))]
 pub struct CmdArgs {
     /// Configuration file paths.
     /// If not provided, both ".emmyrc.json" and ".luarc.json" will be searched in the workspace

--- a/crates/emmylua_doc_cli/src/cmd_args.rs
+++ b/crates/emmylua_doc_cli/src/cmd_args.rs
@@ -2,6 +2,7 @@ use clap::{Parser, ValueEnum};
 use std::path::PathBuf;
 
 #[derive(Debug, Parser)]
+#[command(version)]
 pub struct CmdArgs {
     /// The path of the lua project
     #[arg(long, short, num_args = 1..)]

--- a/crates/emmylua_ls/src/cmd_args.rs
+++ b/crates/emmylua_ls/src/cmd_args.rs
@@ -2,6 +2,7 @@ use clap::{Parser, ValueEnum};
 
 #[allow(unused)]
 #[derive(Debug, Parser, Clone)]
+#[command(version)]
 pub struct CmdArgs {
     /// Communication method
     #[structopt(long, short, default_value = "stdio")]


### PR DESCRIPTION
This is required for identifying binary releases and ensuring reproducible CI pipelines.