### PR TITLE
chore: add rust-toolchain.toml to autopick correct toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
**Issue:**

When working in different rust projects, they can use different toolchains such as stable or nightly. This can lead to issues when trying to build or run the project if the wrong toolchain is used.

**Solution:**

Add a `rust-toolchain.toml` file to the project to specify the correct toolchain. This can allow tools like `rustup` to automatically switch to the correct toolchain when entering the project directory.

https://ianwwagner.com/til/rust-toolchain-toml