### PR TITLE
refactor: use `matches!` macro as suggested by clippy

### DIFF
--- a/crates/emmylua_code_analysis/src/compilation/analyzer/decl/mod.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/decl/mod.rs
@@ -122,19 +122,19 @@ fn walk_node_leave(analyzer: &mut DeclAnalyzer, node: LuaAst) {
 }
 
 fn is_scope_owner(node: &LuaAst) -> bool {
-    match node.syntax().kind().into() {
+    matches!(
+        node.syntax().kind().into(),
         LuaSyntaxKind::Chunk
-        | LuaSyntaxKind::Block
-        | LuaSyntaxKind::ClosureExpr
-        | LuaSyntaxKind::RepeatStat
-        | LuaSyntaxKind::ForRangeStat
-        | LuaSyntaxKind::ForStat
-        | LuaSyntaxKind::LocalStat
-        | LuaSyntaxKind::FuncStat
-        | LuaSyntaxKind::LocalFuncStat
-        | LuaSyntaxKind::AssignStat => true,
-        _ => false,
-    }
+            | LuaSyntaxKind::Block
+            | LuaSyntaxKind::ClosureExpr
+            | LuaSyntaxKind::RepeatStat
+            | LuaSyntaxKind::ForRangeStat
+            | LuaSyntaxKind::ForStat
+            | LuaSyntaxKind::LocalStat
+            | LuaSyntaxKind::FuncStat
+            | LuaSyntaxKind::LocalFuncStat
+            | LuaSyntaxKind::AssignStat
+    )
 }
 
 #[derive(Debug)]

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/flow/bind_analyze/exprs/bind_binary_expr.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/flow/bind_analyze/exprs/bind_binary_expr.rs
@@ -72,10 +72,10 @@ pub fn is_binary_logical(expr: &LuaExpr) -> bool {
                 return false;
             };
 
-            return match op_token.get_op() {
-                BinaryOperator::OpAnd | BinaryOperator::OpOr => true,
-                _ => false,
-            };
+            return matches!(
+                op_token.get_op(),
+                BinaryOperator::OpAnd | BinaryOperator::OpOr
+            );
         }
         LuaExpr::ParenExpr(paren_expr) => {
             if let Some(inner_expr) = paren_expr.get_expr() {

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/flow/bind_analyze/stats.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/flow/bind_analyze/stats.rs
@@ -68,10 +68,7 @@ fn check_value_expr_is_check_expr(value_expr: LuaExpr) -> bool {
                 return false;
             };
 
-            match op.get_op() {
-                BinaryOperator::OpEq | BinaryOperator::OpNe => true,
-                _ => false,
-            }
+            matches!(op.get_op(), BinaryOperator::OpEq | BinaryOperator::OpNe)
         }
         LuaExpr::CallExpr(_) => true,
         _ => false, // Other expressions can be checked

--- a/crates/emmylua_parser/src/syntax/node/lua/expr.rs
+++ b/crates/emmylua_parser/src/syntax/node/lua/expr.rs
@@ -43,25 +43,25 @@ impl LuaAstNode for LuaExpr {
     where
         Self: Sized,
     {
-        match kind {
+        matches!(
+            kind,
             LuaSyntaxKind::CallExpr
-            | LuaSyntaxKind::AssertCallExpr
-            | LuaSyntaxKind::ErrorCallExpr
-            | LuaSyntaxKind::RequireCallExpr
-            | LuaSyntaxKind::TypeCallExpr
-            | LuaSyntaxKind::SetmetatableCallExpr => true,
-            LuaSyntaxKind::TableArrayExpr
-            | LuaSyntaxKind::TableObjectExpr
-            | LuaSyntaxKind::TableEmptyExpr => true,
-            LuaSyntaxKind::LiteralExpr => true,
-            LuaSyntaxKind::BinaryExpr => true,
-            LuaSyntaxKind::UnaryExpr => true,
-            LuaSyntaxKind::ClosureExpr => true,
-            LuaSyntaxKind::ParenExpr => true,
-            LuaSyntaxKind::NameExpr => true,
-            LuaSyntaxKind::IndexExpr => true,
-            _ => false,
-        }
+                | LuaSyntaxKind::AssertCallExpr
+                | LuaSyntaxKind::ErrorCallExpr
+                | LuaSyntaxKind::RequireCallExpr
+                | LuaSyntaxKind::TypeCallExpr
+                | LuaSyntaxKind::SetmetatableCallExpr
+                | LuaSyntaxKind::TableArrayExpr
+                | LuaSyntaxKind::TableObjectExpr
+                | LuaSyntaxKind::TableEmptyExpr
+                | LuaSyntaxKind::LiteralExpr
+                | LuaSyntaxKind::BinaryExpr
+                | LuaSyntaxKind::UnaryExpr
+                | LuaSyntaxKind::ClosureExpr
+                | LuaSyntaxKind::ParenExpr
+                | LuaSyntaxKind::NameExpr
+                | LuaSyntaxKind::IndexExpr
+        )
     }
 
     fn cast(syntax: LuaSyntaxNode) -> Option<Self>
@@ -110,11 +110,7 @@ impl LuaAstNode for LuaVarExpr {
     where
         Self: Sized,
     {
-        match kind {
-            LuaSyntaxKind::NameExpr => true,
-            LuaSyntaxKind::IndexExpr => true,
-            _ => false,
-        }
+        matches!(kind, LuaSyntaxKind::NameExpr | LuaSyntaxKind::IndexExpr)
     }
 
     fn cast(syntax: LuaSyntaxNode) -> Option<Self>
@@ -167,13 +163,13 @@ impl LuaAstNode for LuaSingleArgExpr {
     where
         Self: Sized,
     {
-        match kind {
+        matches!(
+            kind,
             LuaSyntaxKind::TableArrayExpr
-            | LuaSyntaxKind::TableObjectExpr
-            | LuaSyntaxKind::TableEmptyExpr => true,
-            LuaSyntaxKind::LiteralExpr => true,
-            _ => false,
-        }
+                | LuaSyntaxKind::TableObjectExpr
+                | LuaSyntaxKind::TableEmptyExpr
+                | LuaSyntaxKind::LiteralExpr
+        )
     }
 
     fn cast(syntax: LuaSyntaxNode) -> Option<Self>


### PR DESCRIPTION
I started reading the codebase and noticed `cargo clippy` suggests some refactorings that can be done. If these seem like a good idea, they can be included (most are basically autofixes)

<img width="972" height="363" alt="image" src="https://github.com/user-attachments/assets/d08bf0d7-4e3a-4375-a4ea-d03d6d6e5bfe" />

---

Running `cargo clippy` suggested using the `matches!` macro in various places. There are many other fixes, but this commit focuses on just using the `matches!` macro.

```rs
92  warning: match expression looks like `matches!` macro
   --> crates/emmylua_parser/src/grammar/lua/stat.rs:33:5
    |
 33 | /     match p.current_token() {
 34 | |         LuaTokenKind::TkElse
 35 | |         | LuaTokenKind::TkElseIf
 36 | |         | LuaTokenKind::TkEnd
 ...  |
 39 | |         _ => false,
 40 | |     }
    | |_____^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_like_matches_macro
    = note: `#[warn(clippy::match_like_matches_macro)]` on by default
 help: try
    |
 33 ~     matches!(p.current_token(), LuaTokenKind::TkElse
 34 +         | LuaTokenKind::TkElseIf
 35 +         | LuaTokenKind::TkEnd
 36 +         | LuaTokenKind::TkEof
 37 +         | LuaTokenKind::TkUntil)
    |
```