### PR TITLE
Use `custom-annotation-usage-warning` for orphan custom doc tags

### DIFF
--- a/crates/emmylua_code_analysis/resources/schema.json
+++ b/crates/emmylua_code_analysis/resources/schema.json
@@ -293,6 +293,11 @@
           "const": "annotation-usage-error"
         },
         {
+          "description": "Custom doc tag usage warning",
+          "type": "string",
+          "const": "custom-annotation-usage-warning"
+        },
+        {
           "description": "Return type mismatch",
           "type": "string",
           "const": "return-type-mismatch"

--- a/crates/emmylua_code_analysis/src/diagnostic/lua_diagnostic_code.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/lua_diagnostic_code.rs
@@ -55,6 +55,8 @@ pub enum DiagnosticCode {
     AwaitInSync,
     /// Doc tag usage error
     AnnotationUsageError,
+    /// Custom doc tag usage warning
+    CustomAnnotationUsageWarning,
     /// Return type mismatch
     ReturnTypeMismatch,
     /// Missing return value
@@ -126,6 +128,7 @@ pub fn get_default_severity(code: DiagnosticCode) -> DiagnosticSeverity {
         DiagnosticCode::RedefinedLocal => DiagnosticSeverity::HINT,
         DiagnosticCode::DuplicateRequire => DiagnosticSeverity::HINT,
         DiagnosticCode::IterVariableReassign => DiagnosticSeverity::ERROR,
+        DiagnosticCode::CustomAnnotationUsageWarning => DiagnosticSeverity::WARNING,
         _ => DiagnosticSeverity::WARNING,
     }
 }

--- a/crates/emmylua_code_analysis/src/diagnostic/lua_diagnostic_code.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/lua_diagnostic_code.rs
@@ -139,11 +139,12 @@ pub fn is_code_default_enable(code: &DiagnosticCode, level: LuaLanguageLevel) ->
         DiagnosticCode::CodeStyleCheck => false,
         DiagnosticCode::IncompleteSignatureDoc => false,
         DiagnosticCode::MissingGlobalDoc => false,
-        DiagnosticCode::UnknownDocTag => false,
         // ... handle other variants
 
         // neovim-code-style
+        DiagnosticCode::CustomAnnotationUsageWarning => false,
         DiagnosticCode::NonLiteralExpressionsInAssert => false,
+        DiagnosticCode::UnknownDocTag => false,
 
         _ => true,
     }


### PR DESCRIPTION
See discussion in #647 for details.