### PR TITLE
Lower type rendering level in json output

### DIFF
--- a/crates/emmylua_code_analysis/src/db_index/type/humanize_type.rs
+++ b/crates/emmylua_code_analysis/src/db_index/type/humanize_type.rs
@@ -5,8 +5,7 @@ use itertools::Itertools;
 use crate::{
     DbIndex, GenericTpl, LuaAliasCallType, LuaFunctionType, LuaGenericType, LuaInstanceType,
     LuaIntersectionType, LuaMemberKey, LuaMemberOwner, LuaObjectType, LuaSignatureId,
-    LuaStringTplType, LuaTupleType, LuaType, LuaTypeDeclId, LuaUnionType, TypeSubstitutor,
-    VariadicType,
+    LuaStringTplType, LuaTupleType, LuaType, LuaTypeDeclId, LuaUnionType, VariadicType,
 };
 
 use super::{LuaAliasCallKind, LuaMultiLineUnion};
@@ -484,22 +483,6 @@ fn humanize_generic_type(db: &DbIndex, generic: &LuaGenericType, level: RenderLe
     };
 
     let full_name = type_decl.get_full_name();
-    match level {
-        RenderLevel::Brief => {
-            if type_decl.is_alias() {
-                let params = generic
-                    .get_params()
-                    .iter()
-                    .map(|ty| ty.clone())
-                    .collect::<Vec<_>>();
-                let substitutor = TypeSubstitutor::from_type_array(params);
-                if let Some(origin) = type_decl.get_alias_origin(db, Some(&substitutor)) {
-                    return humanize_type(db, &origin, level.next_level());
-                }
-            }
-        }
-        _ => {}
-    }
 
     let generic_params = generic
         .get_params()

--- a/crates/emmylua_doc_cli/src/common.rs
+++ b/crates/emmylua_doc_cli/src/common.rs
@@ -1,12 +1,12 @@
 use emmylua_code_analysis::{humanize_type, DbIndex, LuaType, RenderLevel};
 
-pub fn render_typ(db: &DbIndex, typ: &LuaType) -> String {
+pub fn render_typ(db: &DbIndex, typ: &LuaType, level: RenderLevel) -> String {
     match typ {
         LuaType::IntegerConst(_) => "integer".to_string(),
         LuaType::FloatConst(_) => "number".to_string(),
         LuaType::StringConst(_) => "string".to_string(),
         LuaType::BooleanConst(_) => "boolean".to_string(),
-        _ => humanize_type(db, typ, RenderLevel::Documentation),
+        _ => humanize_type(db, typ, level),
     }
 }
 

--- a/crates/emmylua_doc_cli/src/markdown_generator/render.rs
+++ b/crates/emmylua_doc_cli/src/markdown_generator/render.rs
@@ -62,7 +62,11 @@ fn render_doc_function_type(
         .map(|param| {
             let name = param.0.clone();
             if let Some(ty) = &param.1 {
-                format!("{}: {}", name, render_typ(db, ty))
+                format!(
+                    "{}: {}",
+                    name,
+                    render_typ(db, ty, RenderLevel::Documentation)
+                )
             } else {
                 name.to_string()
             }
@@ -71,7 +75,7 @@ fn render_doc_function_type(
 
     let ret_type = lua_func.get_ret();
 
-    let ret_strs = render_typ(db, ret_type);
+    let ret_strs = render_typ(db, ret_type, RenderLevel::Documentation);
 
     let mut result = String::new();
     result.push_str("```lua\n");
@@ -126,7 +130,11 @@ fn render_signature_type(
         .map(|param| {
             let name = param.0.clone();
             if let Some(ty) = &param.1 {
-                format!("{}: {}", name, render_typ(db, ty))
+                format!(
+                    "{}: {}",
+                    name,
+                    render_typ(db, ty, RenderLevel::Documentation)
+                )
             } else {
                 name.to_string()
             }
@@ -160,14 +168,14 @@ fn render_signature_type(
         0 => {}
         1 => {
             result.push_str(" -> ");
-            let type_text = render_typ(db, &rets[0].type_ref);
+            let type_text = render_typ(db, &rets[0].type_ref, RenderLevel::Documentation);
             let name = rets[0].name.clone().unwrap_or("".to_string());
             result.push_str(format!("{} {}", name, type_text).as_str());
         }
         _ => {
             result.push('\n');
             for ret in rets {
-                let type_text = render_typ(db, &ret.type_ref);
+                let type_text = render_typ(db, &ret.type_ref, RenderLevel::Documentation);
                 let name = ret.name.clone().unwrap_or("".to_string());
                 result.push_str(format!(" -> {} {}\n", name, type_text).as_str());
             }


### PR DESCRIPTION
Fix #653. The new type rendering level is too excessive for JSON output. More often than not, it just repeats what's already present in JSON.