### PR TITLE
Support highlighting Markdown/RST in comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,6 +642,7 @@ dependencies = [
  "dirs",
  "emmylua_code_analysis",
  "emmylua_parser",
+ "emmylua_parser_desc",
  "fern",
  "glob",
  "googletest",
@@ -669,6 +670,15 @@ dependencies = [
  "rowan",
  "rust-i18n",
  "serde",
+]
+
+[[package]]
+name = "emmylua_parser_desc"
+version = "0.12.0"
+dependencies = [
+ "emmylua_parser",
+ "rowan",
+ "unicode-general-category",
 ]
 
 [[package]]
@@ -2393,6 +2403,12 @@ checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
 dependencies = [
  "unic-common",
 ]
+
+[[package]]
+name = "unicode-general-category"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24adfe8311434967077a6adff125729161e6e4934d76f6b7c55318ac5c9246d3"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
 # local
 emmylua_code_analysis = { path = "crates/emmylua_code_analysis", version = "0.10.0" }
 emmylua_parser = { path = "crates/emmylua_parser", version = "0.12.0" }
+emmylua_parser_desc = { path = "crates/emmylua_parser_desc", version = "0.12.0" }
 emmylua_diagnostic_macro = { path = "crates/emmylua_diagnostic_macro", version = "0.5.0" }
 
 # external
@@ -51,3 +52,4 @@ ansi_term = "0.12.1"
 num-traits = { version = "0.2", features = ["std"] }
 mimalloc = "0.1.47"
 googletest = "0.14.2"
+unicode-general-category = "1.0.0"

--- a/README.md
+++ b/README.md
@@ -79,13 +79,14 @@
 
 Our project is meticulously organized into specialized crates, each serving a critical role in the Lua analysis ecosystem:
 
-| Crate | Badge | Description |
-| ----- | ----- | ----------- |
-| [🔍 **emmylua_parser**](./crates/emmylua_parser) | [![emmylua_parser](https://img.shields.io/crates/v/emmylua_parser.svg?style=flat-square)](https://crates.io/crates/emmylua_parser) | The foundational Rust-based Lua parser engineered for maximum efficiency and accuracy. Powers all downstream analysis tools. |
+| Crate                                                          | Badge                                                                                                                                                   | Description |
+|----------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------| ----------- |
+| [🔍 **emmylua_parser**](./crates/emmylua_parser)               | [![emmylua_parser](https://img.shields.io/crates/v/emmylua_parser.svg?style=flat-square)](https://crates.io/crates/emmylua_parser)                      | The foundational Rust-based Lua parser engineered for maximum efficiency and accuracy. Powers all downstream analysis tools. |
+| [📑 **emmylua_parser_desc**](./crates/emmylua_parser_desc)     | [![emmylua_parser_desc](https://img.shields.io/crates/v/emmylua_parser_desc.svg?style=flat-square)](https://crates.io/crates/emmylua_parser_desc)       | Extension for EmmyLua-Parser that handles Markdown/RST highlighting in comments. |
 | [🧠 **emmylua_code_analysis**](./crates/emmylua_code_analysis) | [![emmylua_code_analysis](https://img.shields.io/crates/v/emmylua_code_analysis.svg?style=flat-square)](https://crates.io/crates/emmylua_code_analysis) | Advanced semantic analysis engine providing deep code understanding, type inference, and cross-reference resolution. |
-| [🖥️ **emmylua_ls**](./crates/emmylua_ls) | [![emmylua_ls](https://img.shields.io/crates/v/emmylua_ls.svg?style=flat-square)](https://crates.io/crates/emmylua_ls) | The complete Language Server Protocol implementation offering rich IDE features across all major editors. |
-| [📚 **emmylua_doc_cli**](./crates/emmylua_doc_cli/) | [![emmylua_doc_cli](https://img.shields.io/crates/v/emmylua_doc_cli.svg?style=flat-square)](https://crates.io/crates/emmylua_doc_cli) | Professional documentation generator creating beautiful, searchable API docs from your Lua code and annotations. |
-| [✅ **emmylua_check**](./crates/emmylua_check) | [![emmylua_check](https://img.shields.io/crates/v/emmylua_check.svg?style=flat-square)](https://crates.io/crates/emmylua_check) | Comprehensive static analysis tool for code quality assurance, catching bugs before they reach production. |
+| [🖥️ **emmylua_ls**](./crates/emmylua_ls)                       | [![emmylua_ls](https://img.shields.io/crates/v/emmylua_ls.svg?style=flat-square)](https://crates.io/crates/emmylua_ls)                                  | The complete Language Server Protocol implementation offering rich IDE features across all major editors. |
+| [📚 **emmylua_doc_cli**](./crates/emmylua_doc_cli/)            | [![emmylua_doc_cli](https://img.shields.io/crates/v/emmylua_doc_cli.svg?style=flat-square)](https://crates.io/crates/emmylua_doc_cli)                   | Professional documentation generator creating beautiful, searchable API docs from your Lua code and annotations. |
+| [✅ **emmylua_check**](./crates/emmylua_check)                 | [![emmylua_check](https://img.shields.io/crates/v/emmylua_check.svg?style=flat-square)](https://crates.io/crates/emmylua_check)                         | Comprehensive static analysis tool for code quality assurance, catching bugs before they reach production. |
 
 
 ---

--- a/crates/emmylua_code_analysis/resources/schema.json
+++ b/crates/emmylua_code_analysis/resources/schema.json
@@ -50,7 +50,8 @@
       "$ref": "#/$defs/EmmyrcDoc",
       "default": {
         "knownTags": [],
-        "privateName": []
+        "privateName": [],
+        "syntax": "none"
       }
     },
     "documentColor": {
@@ -123,7 +124,8 @@
     "semanticTokens": {
       "$ref": "#/$defs/EmmyrcSemanticToken",
       "default": {
-        "enable": true
+        "enable": true,
+        "renderDocumentationMarkup": false
       }
     },
     "signature": {
@@ -442,6 +444,15 @@
         }
       ]
     },
+    "DocSyntax": {
+      "type": "string",
+      "enum": [
+        "none",
+        "md",
+        "myst",
+        "rst"
+      ]
+    },
     "EmmyrcCodeAction": {
       "type": "object",
       "properties": {
@@ -611,6 +622,25 @@
           "items": {
             "type": "string"
           }
+        },
+        "rstDefaultRole": {
+          "description": "When `syntax` is `Myst` or `Rst`, specifies default role used\nwith RST processor.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "rstPrimaryDomain": {
+          "description": "When `syntax` is `Myst` or `Rst`, specifies primary domain used\nwith RST processor.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "syntax": {
+          "description": "Syntax for highlighting documentation.",
+          "$ref": "#/$defs/DocSyntax",
+          "default": "none"
         }
       }
     },
@@ -933,6 +963,12 @@
           "description": "Enable semantic tokens.",
           "type": "boolean",
           "default": true,
+          "x-vscode-setting": true
+        },
+        "renderDocumentationMarkup": {
+          "description": "Render Markdown/RST in documentation. Set `doc.syntax` for this option to have effect.",
+          "type": "boolean",
+          "default": false,
           "x-vscode-setting": true
         }
       }

--- a/crates/emmylua_code_analysis/src/config/configs/doc.rs
+++ b/crates/emmylua_code_analysis/src/config/configs/doc.rs
@@ -4,13 +4,27 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct EmmyrcDoc {
-    #[serde(default)]
     /// Treat specific field names as private, e.g. `m_*` means `XXX.m_id` and `XXX.m_type` are private, witch can only be accessed in the class where the definition is located.
+    #[serde(default)]
     pub private_name: Vec<String>,
 
     /// List of known documentation tags.
     #[serde(default)]
     pub known_tags: Vec<String>,
+
+    /// Syntax for highlighting documentation.
+    #[serde(default)]
+    pub syntax: DocSyntax,
+
+    /// When `syntax` is `Myst` or `Rst`, specifies primary domain used
+    /// with RST processor.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rst_primary_domain: Option<String>,
+
+    /// When `syntax` is `Myst` or `Rst`, specifies default role used
+    /// with RST processor.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rst_default_role: Option<String>,
 }
 
 impl Default for EmmyrcDoc {
@@ -18,6 +32,24 @@ impl Default for EmmyrcDoc {
         Self {
             private_name: Default::default(),
             known_tags: Default::default(),
+            syntax: Default::default(),
+            rst_primary_domain: None,
+            rst_default_role: None,
         }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub enum DocSyntax {
+    None,
+    Md,
+    Myst,
+    Rst,
+}
+
+impl Default for DocSyntax {
+    fn default() -> Self {
+        DocSyntax::None
     }
 }

--- a/crates/emmylua_code_analysis/src/config/configs/mod.rs
+++ b/crates/emmylua_code_analysis/src/config/configs/mod.rs
@@ -20,7 +20,7 @@ pub use code_action::EmmyrcCodeAction;
 pub use codelen::EmmyrcCodeLens;
 pub use completion::{EmmyrcCompletion, EmmyrcFilenameConvention};
 pub use diagnostics::EmmyrcDiagnostic;
-pub use doc::EmmyrcDoc;
+pub use doc::{DocSyntax, EmmyrcDoc};
 pub use document_color::EmmyrcDocumentColor;
 pub use hover::EmmyrcHover;
 pub use inlayhint::EmmyrcInlayHint;

--- a/crates/emmylua_code_analysis/src/config/configs/semantictoken.rs
+++ b/crates/emmylua_code_analysis/src/config/configs/semantictoken.rs
@@ -8,12 +8,18 @@ pub struct EmmyrcSemanticToken {
     #[serde(default = "default_true")]
     #[schemars(extend("x-vscode-setting" = true))]
     pub enable: bool,
+
+    /// Render Markdown/RST in documentation. Set `doc.syntax` for this option to have effect.
+    #[serde(default)]
+    #[schemars(extend("x-vscode-setting" = true))]
+    pub render_documentation_markup: bool,
 }
 
 impl Default for EmmyrcSemanticToken {
     fn default() -> Self {
         Self {
             enable: default_true(),
+            render_documentation_markup: false,
         }
     }
 }

--- a/crates/emmylua_code_analysis/src/config/mod.rs
+++ b/crates/emmylua_code_analysis/src/config/mod.rs
@@ -9,13 +9,13 @@ use std::{
 
 pub use crate::config::configs::{EmmyrcExternalTool, EmmyrcReformat};
 pub use config_loader::{load_configs, load_configs_raw};
+pub use configs::{DocSyntax, EmmyrcFilenameConvention, EmmyrcLuaVersion};
 use configs::{
     EmmyrcCodeAction, EmmyrcCodeLens, EmmyrcCompletion, EmmyrcDiagnostic, EmmyrcDoc,
     EmmyrcDocumentColor, EmmyrcHover, EmmyrcInlayHint, EmmyrcInlineValues, EmmyrcReference,
     EmmyrcResource, EmmyrcRuntime, EmmyrcSemanticToken, EmmyrcSignature, EmmyrcStrict,
     EmmyrcWorkspace,
 };
-pub use configs::{EmmyrcFilenameConvention, EmmyrcLuaVersion};
 use emmylua_parser::{LuaLanguageLevel, LuaNonStdSymbolSet, ParserConfig, SpecialFunction};
 use regex::Regex;
 use rowan::NodeCache;

--- a/crates/emmylua_code_analysis/src/semantic/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/mod.rs
@@ -40,7 +40,7 @@ pub use visibility::check_export_visibility;
 use visibility::check_visibility;
 
 use crate::semantic::member::find_members_with_key;
-use crate::{Emmyrc, LuaDocument, LuaSemanticDeclId, db_index::LuaTypeDeclId};
+use crate::{Emmyrc, LuaDocument, LuaSemanticDeclId, ModuleInfo, db_index::LuaTypeDeclId};
 use crate::{
     FileId,
     db_index::{DbIndex, LuaType},
@@ -85,6 +85,10 @@ impl<'a> SemanticModel<'a> {
 
     pub fn get_document(&self) -> LuaDocument {
         self.db.get_vfs().get_document(&self.file_id).unwrap()
+    }
+
+    pub fn get_module(&self) -> Option<&ModuleInfo> {
+        self.db.get_module_index().get_module(self.file_id)
     }
 
     pub fn get_document_by_file_id(&self, file_id: FileId) -> Option<LuaDocument> {
@@ -254,6 +258,10 @@ impl<'a> SemanticModel<'a> {
 
     pub fn get_emmyrc(&self) -> &Emmyrc {
         &self.emmyrc
+    }
+
+    pub fn get_emmyrc_arc(&self) -> Arc<Emmyrc> {
+        self.emmyrc.clone()
     }
 
     pub fn get_root(&self) -> &LuaChunk {

--- a/crates/emmylua_ls/Cargo.toml
+++ b/crates/emmylua_ls/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["development-tools"]
 # local
 emmylua_code_analysis.workspace = true
 emmylua_parser.workspace = true
+emmylua_parser_desc.workspace = true
 
 # external
 lsp-server.workspace = true

--- a/crates/emmylua_ls/src/handlers/completion/completion_builder.rs
+++ b/crates/emmylua_ls/src/handlers/completion/completion_builder.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use emmylua_code_analysis::SemanticModel;
 use emmylua_parser::LuaSyntaxToken;
 use lsp_types::{CompletionItem, CompletionTriggerKind};
+use rowan::TextSize;
 use tokio_util::sync::CancellationToken;
 
 pub struct CompletionBuilder<'a> {
@@ -15,6 +16,7 @@ pub struct CompletionBuilder<'a> {
     pub trigger_kind: CompletionTriggerKind,
     /// 是否为空格字符触发的补全(非主动触发)
     pub is_space_trigger_character: bool,
+    pub position_offset: TextSize,
 }
 
 impl<'a> CompletionBuilder<'a> {
@@ -23,6 +25,7 @@ impl<'a> CompletionBuilder<'a> {
         semantic_model: SemanticModel<'a>,
         cancel_token: CancellationToken,
         trigger_kind: CompletionTriggerKind,
+        position_offset: TextSize,
     ) -> Self {
         let is_space_trigger_character = if trigger_kind == CompletionTriggerKind::TRIGGER_CHARACTER
         {
@@ -40,6 +43,7 @@ impl<'a> CompletionBuilder<'a> {
             stopped: false,
             trigger_kind,
             is_space_trigger_character,
+            position_offset,
         }
     }
 

--- a/crates/emmylua_ls/src/handlers/completion/mod.rs
+++ b/crates/emmylua_ls/src/handlers/completion/mod.rs
@@ -80,9 +80,14 @@ pub fn completion(
         }
     };
 
-    let mut builder = CompletionBuilder::new(token, semantic_model, cancel_token, trigger_kind);
-    let emmyrc = analysis.get_emmyrc();
-    add_completions(&mut builder, &emmyrc);
+    let mut builder = CompletionBuilder::new(
+        token,
+        semantic_model,
+        cancel_token,
+        trigger_kind,
+        position_offset,
+    );
+    add_completions(&mut builder);
     Some(CompletionResponse::Array(builder.get_completion_items()))
 }
 

--- a/crates/emmylua_ls/src/handlers/completion/providers/desc_provider.rs
+++ b/crates/emmylua_ls/src/handlers/completion/providers/desc_provider.rs
@@ -1,0 +1,165 @@
+use crate::handlers::completion::add_completions::CompletionTriggerStatus;
+use crate::handlers::completion::completion_builder::CompletionBuilder;
+use crate::handlers::completion::providers::doc_type_provider::complete_types_by_prefix;
+use crate::handlers::completion::providers::env_provider::add_global_env;
+use crate::handlers::completion::providers::member_provider::add_completions_for_members;
+use crate::handlers::completion::providers::module_path_provider::add_modules;
+use crate::util::{find_comment_scope, find_ref_at, resolve_ref};
+use emmylua_code_analysis::{LuaType, WorkspaceId};
+use emmylua_parser::{LuaAstNode, LuaDocDescription};
+use emmylua_parser_desc::LuaDescRefPathItem;
+use rowan::TextRange;
+use std::collections::HashSet;
+
+pub fn add_completions(builder: &mut CompletionBuilder) -> Option<()> {
+    if builder.is_cancelled() {
+        return None;
+    }
+
+    let semantic_model = &builder.semantic_model;
+    let document = semantic_model.get_document();
+    let description = LuaDocDescription::cast(builder.trigger_token.parent()?)?;
+
+    // Quickly scan the line before actually parsing comment.
+    let line = document.get_line(builder.position_offset)?;
+    let line_range = document.get_line_range(line)?;
+    let line_text =
+        &document.get_text()[line_range.intersect(TextRange::up_to(builder.position_offset))?];
+
+    if !line_text.contains('`') {
+        return None;
+    }
+
+    let path = find_ref_at(
+        semantic_model
+            .get_module()
+            .map(|m| m.workspace_id)
+            .unwrap_or(WorkspaceId::MAIN),
+        semantic_model.get_emmyrc(),
+        document.get_text(),
+        description.clone(),
+        builder.position_offset,
+    )?;
+
+    if path.is_empty() {
+        add_global_completions(builder);
+    } else {
+        add_by_prefix(builder, &path);
+    }
+
+    builder.stop_here();
+
+    Some(())
+}
+
+fn add_global_completions(builder: &mut CompletionBuilder) -> Option<()> {
+    let mut seen_types = HashSet::new();
+
+    // Children in scope.
+    if let Some(scope) = find_comment_scope(
+        builder.semantic_model.get_db(),
+        builder.semantic_model.get_file_id(),
+        &builder.trigger_token,
+    ) {
+        if let Some(member_info_map) = builder
+            .semantic_model
+            .get_member_info_map(&LuaType::Ref(scope))
+        {
+            seen_types.extend(member_info_map.iter().flat_map(|(_, members)| {
+                members.iter().filter_map(|member| match &member.typ {
+                    LuaType::Def(type_id) => Some(type_id.clone()),
+                    _ => None,
+                })
+            }));
+            add_completions_for_members(builder, &member_info_map, CompletionTriggerStatus::Dot);
+        }
+    }
+
+    // Types in namespaces.
+    complete_types_by_prefix(builder, "", Some(&seen_types));
+
+    // Types in current module.
+    if let Some(module) = builder.semantic_model.get_module() {
+        if let Some(member_info_map) = builder
+            .semantic_model
+            .get_member_info_map(module.export_type.as_ref().unwrap_or(&LuaType::Nil))
+        {
+            seen_types.extend(member_info_map.iter().flat_map(|(_, members)| {
+                members.iter().filter_map(|member| match &member.typ {
+                    LuaType::Def(type_id) => Some(type_id.clone()),
+                    _ => None,
+                })
+            }));
+            add_completions_for_members(builder, &member_info_map, CompletionTriggerStatus::Dot);
+        }
+    }
+
+    // Globals.
+    add_global_env(builder, &mut HashSet::new(), "");
+
+    // Modules.
+    add_modules(builder, "", None);
+
+    Some(())
+}
+
+fn add_by_prefix(
+    builder: &mut CompletionBuilder,
+    mut path: &[(LuaDescRefPathItem, TextRange)],
+) -> Option<()> {
+    let mut seen_types = HashSet::new();
+
+    while let Some(last) = path.last() {
+        if TextRange::up_to(last.1.end()).contains_inclusive(builder.position_offset) {
+            path = &path[..path.len() - 1];
+        } else {
+            break;
+        }
+    }
+
+    if path.is_empty() {
+        add_global_completions(builder);
+        return Some(());
+    }
+
+    // 1. Type members.
+    let parent_semantic_infos = resolve_ref(
+        builder.semantic_model.get_db(),
+        builder.semantic_model.get_file_id(),
+        path,
+        &builder.trigger_token,
+    );
+    for semantic_info in parent_semantic_infos {
+        if let Some(member_info_map) = builder
+            .semantic_model
+            .get_member_info_map(&semantic_info.typ)
+        {
+            seen_types.extend(member_info_map.iter().flat_map(|(_, members)| {
+                members.iter().filter_map(|member| match &member.typ {
+                    LuaType::Def(type_id) => Some(type_id.clone()),
+                    _ => None,
+                })
+            }));
+            add_completions_for_members(builder, &member_info_map, CompletionTriggerStatus::Dot);
+        }
+    }
+
+    // 2. Sub-modules and namespaces.
+    's: {
+        let Some(name_parts) = path
+            .iter()
+            .map(|(item, _)| item.get_name())
+            .collect::<Option<Vec<_>>>()
+        else {
+            break 's;
+        };
+        let prefix = name_parts.join(".") + ".";
+
+        // Modules.
+        add_modules(builder, &prefix, None);
+        dbg!(&seen_types);
+        complete_types_by_prefix(builder, &prefix, Some(&seen_types));
+    }
+
+    None
+}

--- a/crates/emmylua_ls/src/handlers/completion/providers/desc_provider.rs
+++ b/crates/emmylua_ls/src/handlers/completion/providers/desc_provider.rs
@@ -157,7 +157,6 @@ fn add_by_prefix(
 
         // Modules.
         add_modules(builder, &prefix, None);
-        dbg!(&seen_types);
         complete_types_by_prefix(builder, &prefix, Some(&seen_types));
     }
 

--- a/crates/emmylua_ls/src/handlers/completion/providers/doc_tag_provider.rs
+++ b/crates/emmylua_ls/src/handlers/completion/providers/doc_tag_provider.rs
@@ -1,10 +1,9 @@
 use crate::handlers::completion::{completion_builder::CompletionBuilder, data::DOC_TAGS};
 use crate::meta_text::meta_doc_tag;
-use emmylua_code_analysis::Emmyrc;
 use emmylua_parser::LuaTokenKind;
 use lsp_types::{CompletionItem, MarkupContent};
 
-pub fn add_completion(builder: &mut CompletionBuilder, emmyrc: &Emmyrc) -> Option<()> {
+pub fn add_completion(builder: &mut CompletionBuilder) -> Option<()> {
     if builder.is_cancelled() {
         return None;
     }
@@ -17,6 +16,7 @@ pub fn add_completion(builder: &mut CompletionBuilder, emmyrc: &Emmyrc) -> Optio
         return None;
     }
 
+    let emmyrc = builder.semantic_model.get_emmyrc_arc();
     let known_other_tags = emmyrc.doc.known_tags.iter().map(|tag| tag.as_str());
 
     for (sorted_index, tag) in DOC_TAGS.iter().copied().chain(known_other_tags).enumerate() {

--- a/crates/emmylua_ls/src/handlers/completion/providers/env_provider.rs
+++ b/crates/emmylua_ls/src/handlers/completion/providers/env_provider.rs
@@ -32,7 +32,7 @@ pub fn add_completion(builder: &mut CompletionBuilder) -> Option<()> {
 
     let mut duplicated_name = HashSet::new();
     add_local_env(builder, &mut duplicated_name, &parent_node);
-    add_global_env(builder, &mut duplicated_name);
+    add_global_env(builder, &mut duplicated_name, &builder.get_trigger_text());
     add_self(builder, &mut duplicated_name, &parent_node);
     builder.env_duplicate_name.extend(duplicated_name);
 
@@ -183,11 +183,11 @@ fn add_local_env(
     Some(())
 }
 
-fn add_global_env(
+pub fn add_global_env(
     builder: &mut CompletionBuilder,
     duplicated_name: &mut HashSet<String>,
+    trigger_text: &str,
 ) -> Option<()> {
-    let trigger_text = builder.get_trigger_text();
     let global_env = builder
         .semantic_model
         .get_db()

--- a/crates/emmylua_ls/src/handlers/completion/providers/member_provider.rs
+++ b/crates/emmylua_ls/src/handlers/completion/providers/member_provider.rs
@@ -1,8 +1,9 @@
 use emmylua_code_analysis::{
-    DbIndex, LuaMemberInfo, LuaSemanticDeclId, LuaType, LuaTypeDeclId, SemanticModel,
+    DbIndex, LuaMemberInfo, LuaMemberKey, LuaSemanticDeclId, LuaType, LuaTypeDeclId, SemanticModel,
     enum_variable_is_param,
 };
 use emmylua_parser::{LuaAstNode, LuaAstToken, LuaIndexExpr, LuaStringToken};
+use std::collections::HashMap;
 
 use crate::handlers::completion::{
     add_completions::{CompletionTriggerStatus, add_member_completion},
@@ -41,8 +42,17 @@ pub fn add_completion(builder: &mut CompletionBuilder) -> Option<()> {
     }
 
     let member_info_map = builder.semantic_model.get_member_info_map(&prefix_type)?;
+
+    add_completions_for_members(builder, &member_info_map, completion_status)
+}
+
+pub fn add_completions_for_members(
+    builder: &mut CompletionBuilder,
+    members: &HashMap<LuaMemberKey, Vec<LuaMemberInfo>>,
+    completion_status: CompletionTriggerStatus,
+) -> Option<()> {
     // 排序
-    let mut sorted_entries: Vec<_> = member_info_map.iter().collect();
+    let mut sorted_entries: Vec<_> = members.iter().collect();
     sorted_entries.sort_unstable_by(|(name1, _), (name2, _)| name1.cmp(name2));
 
     for (_, member_infos) in sorted_entries {

--- a/crates/emmylua_ls/src/handlers/completion/providers/mod.rs
+++ b/crates/emmylua_ls/src/handlers/completion/providers/mod.rs
@@ -1,4 +1,5 @@
 mod auto_require_provider;
+mod desc_provider;
 mod doc_name_token_provider;
 mod doc_tag_provider;
 mod doc_type_provider;
@@ -13,13 +14,12 @@ mod postfix_provider;
 mod table_field_provider;
 
 use super::completion_builder::CompletionBuilder;
-use emmylua_code_analysis::Emmyrc;
 use emmylua_parser::LuaAstToken;
 use emmylua_parser::LuaStringToken;
 pub use function_provider::get_function_remove_nil;
 use rowan::TextRange;
 
-pub fn add_completions(builder: &mut CompletionBuilder, emmyrc: &Emmyrc) -> Option<()> {
+pub fn add_completions(builder: &mut CompletionBuilder) -> Option<()> {
     postfix_provider::add_completion(builder);
     // `function_provider`优先级必须高于`env_provider`
     function_provider::add_completion(builder);
@@ -33,9 +33,10 @@ pub fn add_completions(builder: &mut CompletionBuilder, emmyrc: &Emmyrc) -> Opti
     module_path_provider::add_completion(builder);
     file_path_provider::add_completion(builder);
     auto_require_provider::add_completion(builder);
-    doc_tag_provider::add_completion(builder, emmyrc);
+    doc_tag_provider::add_completion(builder);
     doc_type_provider::add_completion(builder);
     doc_name_token_provider::add_completion(builder);
+    desc_provider::add_completions(builder);
 
     for (index, item) in builder.get_completion_items_mut().iter_mut().enumerate() {
         if item.sort_text.is_none() {

--- a/crates/emmylua_ls/src/handlers/definition/goto_path.rs
+++ b/crates/emmylua_ls/src/handlers/definition/goto_path.rs
@@ -1,0 +1,44 @@
+use crate::handlers::definition::goto_def_definition;
+use crate::util::resolve_ref;
+use emmylua_code_analysis::{LuaCompilation, SemanticModel};
+use emmylua_parser::LuaSyntaxToken;
+use emmylua_parser_desc::LuaDescRefPathItem;
+use lsp_types::GotoDefinitionResponse;
+use rowan::TextRange;
+
+pub fn goto_path(
+    semantic_model: &SemanticModel,
+    compilation: &LuaCompilation,
+    path: &[(LuaDescRefPathItem, TextRange)],
+    trigger_token: &LuaSyntaxToken,
+) -> Option<GotoDefinitionResponse> {
+    let semantic_infos = resolve_ref(
+        semantic_model.get_db(),
+        semantic_model.get_file_id(),
+        path,
+        trigger_token,
+    );
+
+    let locations = semantic_infos
+        .into_iter()
+        .filter_map(|semantic_info| {
+            goto_def_definition(
+                &semantic_model,
+                compilation,
+                semantic_info.semantic_decl?,
+                trigger_token,
+            )
+        })
+        .flat_map(|response| match response {
+            GotoDefinitionResponse::Scalar(location) => vec![location],
+            GotoDefinitionResponse::Array(locations) => locations,
+            GotoDefinitionResponse::Link(_) => Vec::new(),
+        })
+        .collect::<Vec<_>>();
+
+    if locations.is_empty() {
+        None
+    } else {
+        Some(GotoDefinitionResponse::Array(locations))
+    }
+}

--- a/crates/emmylua_ls/src/handlers/document_selection_range/mod.rs
+++ b/crates/emmylua_ls/src/handlers/document_selection_range/mod.rs
@@ -1,14 +1,14 @@
-use emmylua_parser::LuaAstNode;
+use super::RegisterCapabilities;
+use crate::context::ServerContextSnapshot;
+use crate::util::parse_desc;
+use emmylua_code_analysis::{SemanticModel, WorkspaceId};
+use emmylua_parser::{LuaAstNode, LuaDocDescription};
 use lsp_types::{
     ClientCapabilities, SelectionRange, SelectionRangeParams, SelectionRangeProviderCapability,
     ServerCapabilities,
 };
-use rowan::TokenAtOffset;
+use rowan::{TextRange, TextSize, TokenAtOffset};
 use tokio_util::sync::CancellationToken;
-
-use crate::context::ServerContextSnapshot;
-
-use super::RegisterCapabilities;
 
 pub async fn on_document_selection_range_handle(
     context: ServerContextSnapshot,
@@ -35,8 +35,17 @@ pub async fn on_document_selection_range_handle(
         };
 
         let mut ranges = Vec::new();
-        let range = token.text_range();
-        ranges.push(range);
+
+        let description = token
+            .parent()
+            .and_then(|parent| LuaDocDescription::cast(parent));
+        if let Some(description) = description {
+            add_detail_ranges(&semantic_model, description, offset, &mut ranges);
+        } else {
+            let range = token.text_range();
+            ranges.push(range);
+        }
+
         for ancestor in token.parent_ancestors() {
             let range = ancestor.text_range();
             ranges.push(range);
@@ -57,6 +66,36 @@ pub async fn on_document_selection_range_handle(
     }
 
     Some(result)
+}
+
+fn add_detail_ranges(
+    semantic_model: &SemanticModel,
+    description: LuaDocDescription,
+    offset: TextSize,
+    result: &mut Vec<TextRange>,
+) {
+    let document = semantic_model.get_document();
+    let text = document.get_text();
+
+    let mut items = parse_desc(
+        semantic_model
+            .get_module()
+            .map(|m| m.workspace_id)
+            .unwrap_or(WorkspaceId::MAIN),
+        semantic_model.get_emmyrc(),
+        text,
+        description,
+        None,
+    );
+
+    items.sort_by_key(|item| item.range.len());
+
+    result.extend(
+        items
+            .into_iter()
+            .map(|item| item.range)
+            .filter(|range| range.contains(offset)),
+    );
 }
 
 pub struct DocumentSelectionRangeCapabilities;

--- a/crates/emmylua_ls/src/handlers/emmy_annotator/emmy_annotator_request.rs
+++ b/crates/emmylua_ls/src/handlers/emmy_annotator/emmy_annotator_request.rs
@@ -30,6 +30,8 @@ pub enum EmmyAnnotatorType {
     ReadOnlyLocal = 2,
     MutLocal = 3,
     MutParam = 4,
+    DocEm = 5,
+    DocStrong = 6,
 }
 
 impl From<EmmyAnnotatorType> for u8 {
@@ -46,6 +48,8 @@ impl From<u8> for EmmyAnnotatorType {
             2 => EmmyAnnotatorType::ReadOnlyLocal,
             3 => EmmyAnnotatorType::MutLocal,
             4 => EmmyAnnotatorType::MutParam,
+            5 => EmmyAnnotatorType::DocEm,
+            6 => EmmyAnnotatorType::DocStrong,
             _ => EmmyAnnotatorType::ReadOnlyLocal,
         }
     }

--- a/crates/emmylua_ls/src/handlers/hover/build_hover.rs
+++ b/crates/emmylua_ls/src/handlers/hover/build_hover.rs
@@ -1,13 +1,13 @@
 use std::collections::HashSet;
 
+use emmylua_code_analysis::humanize_type;
 use emmylua_code_analysis::{
     DbIndex, LuaCompilation, LuaDeclId, LuaDocument, LuaMemberId, LuaMemberKey, LuaSemanticDeclId,
     LuaSignatureId, LuaType, LuaTypeDeclId, RenderLevel, SemanticInfo, SemanticModel,
 };
 use emmylua_parser::{LuaAssignStat, LuaAstNode, LuaExpr, LuaSyntaxToken};
 use lsp_types::{Hover, HoverContents, MarkedString, MarkupContent};
-
-use emmylua_code_analysis::humanize_type;
+use rowan::TextRange;
 
 use crate::handlers::hover::{
     find_origin::replace_semantic_type,
@@ -28,6 +28,7 @@ pub fn build_semantic_info_hover(
     document: &LuaDocument,
     token: LuaSyntaxToken,
     semantic_info: SemanticInfo,
+    range: TextRange,
 ) -> Option<Hover> {
     let typ = semantic_info.clone().typ;
     if semantic_info.semantic_decl.is_none() {
@@ -43,7 +44,7 @@ pub fn build_semantic_info_hover(
         Some(token.clone()),
     );
     if let Some(hover_builder) = hover_builder {
-        hover_builder.build_hover_result(document.to_lsp_range(token.text_range()))
+        hover_builder.build_hover_result(document.to_lsp_range(range))
     } else {
         None
     }

--- a/crates/emmylua_ls/src/handlers/test/semantic_token_test.rs
+++ b/crates/emmylua_ls/src/handlers/test/semantic_token_test.rs
@@ -25,17 +25,24 @@ mod tests {
             vec![
                 VirtualSemanticToken {
                     line: 1,
+                    start: 16,
+                    length: 3,
+                    token_type: SemanticTokenType::COMMENT,
+                    token_modifier: HashSet::new(),
+                },
+                VirtualSemanticToken {
+                    line: 1,
                     start: 19,
                     length: 1,
                     token_type: SemanticTokenType::KEYWORD,
-                    token_modifier: HashSet::from([SemanticTokenModifier::DOCUMENTATION,]),
+                    token_modifier: HashSet::from([SemanticTokenModifier::DOCUMENTATION]),
                 },
                 VirtualSemanticToken {
                     line: 1,
                     start: 20,
                     length: 4,
                     token_type: SemanticTokenType::KEYWORD,
-                    token_modifier: HashSet::from([SemanticTokenModifier::DOCUMENTATION,]),
+                    token_modifier: HashSet::from([SemanticTokenModifier::DOCUMENTATION]),
                 },
                 VirtualSemanticToken {
                     line: 1,
@@ -81,17 +88,24 @@ mod tests {
                 },
                 VirtualSemanticToken {
                     line: 4,
+                    start: 36,
+                    length: 4,
+                    token_type: SemanticTokenType::COMMENT,
+                    token_modifier: HashSet::new(),
+                },
+                VirtualSemanticToken {
+                    line: 4,
                     start: 40,
                     length: 1,
                     token_type: SemanticTokenType::KEYWORD,
-                    token_modifier: HashSet::from([SemanticTokenModifier::DOCUMENTATION,]),
+                    token_modifier: HashSet::from([SemanticTokenModifier::DOCUMENTATION]),
                 },
                 VirtualSemanticToken {
                     line: 4,
                     start: 41,
                     length: 4,
                     token_type: SemanticTokenType::KEYWORD,
-                    token_modifier: HashSet::from([SemanticTokenModifier::DOCUMENTATION,]),
+                    token_modifier: HashSet::from([SemanticTokenModifier::DOCUMENTATION]),
                 },
                 VirtualSemanticToken {
                     line: 4,
@@ -105,7 +119,7 @@ mod tests {
                     start: 47,
                     length: 1,
                     token_type: SemanticTokenType::OPERATOR,
-                    token_modifier: HashSet::new(),
+                    token_modifier: HashSet::from([SemanticTokenModifier::DOCUMENTATION]),
                 },
                 VirtualSemanticToken {
                     line: 4,

--- a/crates/emmylua_ls/src/handlers/test_lib/mod.rs
+++ b/crates/emmylua_ls/src/handlers/test_lib/mod.rs
@@ -2,10 +2,11 @@ use emmylua_code_analysis::{EmmyLuaAnalysis, Emmyrc, FileId, VirtualUrlGenerator
 use googletest::prelude::*;
 use itertools::Itertools;
 use lsp_types::{
-    CodeActionOrCommand, CompletionItem, CompletionItemKind, CompletionResponse,
-    CompletionTriggerKind, GotoDefinitionResponse, Hover, HoverContents, InlayHintLabel, Location,
-    MarkupContent, Position, SemanticTokenModifier, SemanticTokenType, SemanticTokensResult,
-    SignatureHelpContext, SignatureHelpTriggerKind, SignatureInformation, TextEdit,
+    ClientCapabilities, CodeActionOrCommand, CompletionItem, CompletionItemKind,
+    CompletionResponse, CompletionTriggerKind, GotoDefinitionResponse, Hover, HoverContents,
+    InlayHintLabel, Location, MarkupContent, Position, SemanticTokenModifier, SemanticTokenType,
+    SemanticTokensResult, SignatureHelpContext, SignatureHelpTriggerKind, SignatureInformation,
+    TextEdit,
 };
 use std::collections::HashSet;
 use std::{ops::Deref, sync::Arc};
@@ -489,9 +490,14 @@ impl ProviderVirtualWorkspace {
         expected: Vec<VirtualSemanticToken>,
     ) -> Result<()> {
         let file_id = self.def(block_str);
-        let result = semantic_token(&self.analysis, file_id, ClientId::VSCode)
-            .ok_or("failed to get semantic tokens")
-            .or_fail()?;
+        let result = semantic_token(
+            &self.analysis,
+            file_id,
+            &ClientCapabilities::default(),
+            ClientId::VSCode,
+        )
+        .ok_or("failed to get semantic tokens")
+        .or_fail()?;
         let SemanticTokensResult::Tokens(result) = result else {
             return fail!("expected SemanticTokensResult::Tokens, got {result:?}");
         };

--- a/crates/emmylua_ls/src/handlers/test_lib/mod.rs
+++ b/crates/emmylua_ls/src/handlers/test_lib/mod.rs
@@ -214,7 +214,7 @@ impl ProviderVirtualWorkspace {
     pub fn check_completion_with_kind(
         &mut self,
         block_str: &str,
-        expected: Vec<VirtualCompletionItem>,
+        mut expected: Vec<VirtualCompletionItem>,
         trigger_kind: CompletionTriggerKind,
     ) -> Result<()> {
         let (content, position) = Self::handle_file_content(block_str)?;
@@ -229,10 +229,13 @@ impl ProviderVirtualWorkspace {
         .ok_or("failed to get completion")
         .or_fail()?;
         // 对比
-        let items = match result {
+        let mut items = match result {
             CompletionResponse::Array(items) => items,
             CompletionResponse::List(list) => list.items,
         };
+
+        items.sort_by_key(|item| item.label.clone());
+        expected.sort_by_key(|item| item.label.clone());
 
         fn get_item_detail(i: &CompletionItem) -> Option<&String> {
             i.label_details.as_ref().and_then(|d| d.detail.as_ref())

--- a/crates/emmylua_ls/src/util/desc.rs
+++ b/crates/emmylua_ls/src/util/desc.rs
@@ -1,0 +1,283 @@
+use emmylua_code_analysis::{
+    DbIndex, DocSyntax, Emmyrc, FileId, LuaMemberId, LuaMemberKey, LuaType, LuaTypeDeclId,
+    SemanticInfo, WorkspaceId, get_member_map,
+};
+use emmylua_parser::{
+    LuaAst, LuaAstNode, LuaComment, LuaDocDescription, LuaDocTag, LuaLocalName, LuaSyntaxToken,
+    LuaVarExpr,
+};
+use emmylua_parser_desc::{
+    DescItem, DescItemKind, DescParserType, LuaDescRefPathItem, parse_ref_target,
+};
+use itertools::Itertools;
+use rowan::{TextRange, TextSize};
+use std::collections::HashSet;
+
+pub fn parse_desc(
+    workspace_id: WorkspaceId,
+    emmyrc: &Emmyrc,
+    text: &str,
+    desc: LuaDocDescription,
+    offset: Option<usize>,
+) -> Vec<DescItem> {
+    let parser_kind = if workspace_id == WorkspaceId::STD {
+        DescParserType::Md
+    } else {
+        match emmyrc.doc.syntax {
+            DocSyntax::None => DescParserType::None,
+            DocSyntax::Md => DescParserType::Md,
+            DocSyntax::Myst => DescParserType::MySt {
+                primary_domain: emmyrc.doc.rst_primary_domain.clone(),
+            },
+            DocSyntax::Rst => DescParserType::Rst {
+                primary_domain: emmyrc.doc.rst_primary_domain.clone(),
+                default_role: emmyrc.doc.rst_default_role.clone(),
+            },
+        }
+    };
+
+    emmylua_parser_desc::parse(parser_kind, text, desc, offset)
+}
+
+pub fn find_ref_at(
+    workspace_id: WorkspaceId,
+    emmyrc: &Emmyrc,
+    text: &str,
+    desc: LuaDocDescription,
+    offset: TextSize,
+) -> Option<Vec<(LuaDescRefPathItem, TextRange)>> {
+    let items = parse_desc(workspace_id, emmyrc, text, desc, Some(offset.into()));
+
+    for item in items {
+        if item.kind == DescItemKind::Ref {
+            if !item.range.contains_inclusive(offset) {
+                continue;
+            }
+
+            return parse_ref_target(text, item.range, offset);
+        }
+    }
+
+    None
+}
+
+pub fn resolve_ref_single<'a>(
+    db: &DbIndex,
+    file_id: FileId,
+    path: &[(LuaDescRefPathItem, TextRange)],
+    desc: &LuaSyntaxToken,
+) -> Option<SemanticInfo> {
+    let results = resolve_ref(db, file_id, path, desc);
+    for (i, result) in results.iter().enumerate() {
+        if result.semantic_decl.is_some() {
+            return Some(results[i].clone());
+        }
+    }
+
+    results.into_iter().next()
+}
+
+pub fn resolve_ref<'a>(
+    db: &DbIndex,
+    file_id: FileId,
+    path: &[(LuaDescRefPathItem, TextRange)],
+    desc: &LuaSyntaxToken,
+) -> Vec<SemanticInfo> {
+    let mut result = Vec::new();
+
+    // Try resolving in comment's owner. I.e. documentation for a class
+    // can refer to class members without prefixing them by class name.
+    if let Some(scope) = find_comment_scope(db, file_id, desc) {
+        let scopes = vec![SemanticInfo {
+            typ: LuaType::Ref(scope.clone()),
+            semantic_decl: Some(scope.into()),
+        }];
+        if let Some(found_refs) = find_members(db, scopes, &path) {
+            result.extend(found_refs);
+        }
+    }
+
+    // Find in namespaces and modules.
+
+    // We need to deduplicate types found in namespace and module.
+    //
+    // For completion path `foo.bar`, we look up types in namespace
+    // `foo.bar`, as well as items exported from module `foo.bar`.
+    // This might result in duplicates when a module exports a definition
+    // of a type that's defined in a corresponding namespace.
+    //
+    // For example, consider this module:
+    //
+    // ```
+    // local mod = {}
+    // --- @class Foo
+    // mod.Foo = {}
+    // return mod
+    // ```
+    //
+    // Our search will find `@class` declaration `LuaType::Ref("mod.Foo")`,
+    // and also `mod.Foo` definition `LuaType::Def("mod.Foo")`,
+    // which we will ignore.
+    let mut seen_types = HashSet::new();
+
+    let last_name_index = path.iter().take_while(|(item, _)| item.is_name()).count();
+    for i in (1..=last_name_index).rev() {
+        let name = path[..i]
+            .iter()
+            .filter_map(|(item, _)| item.get_name())
+            .join(".");
+
+        if let Some(found) = db.get_type_index().find_type_decl(file_id, &name) {
+            let scopes = vec![SemanticInfo {
+                typ: LuaType::Ref(found.get_id()),
+                semantic_decl: Some(found.get_id().into()),
+            }];
+            if let Some(found_refs) = find_members(db, scopes, &path[i..]) {
+                seen_types.extend(found_refs.iter().filter_map(|item| match &item.typ {
+                    LuaType::Ref(id) => Some(LuaType::Def(id.clone())),
+                    _ => None,
+                }));
+                result.extend(found_refs);
+            }
+        }
+        if let Some(found) = db.get_module_index().find_module(&name) {
+            let scopes = vec![SemanticInfo {
+                typ: found.export_type.clone().unwrap_or(LuaType::Nil),
+                semantic_decl: found.semantic_id.clone(),
+            }];
+            if let Some(found_refs) = find_members(db, scopes, &path[i..]) {
+                result.extend(
+                    found_refs
+                        .into_iter()
+                        .filter(|item| !seen_types.contains(&item.typ)),
+                );
+            }
+        }
+    }
+
+    // Find in current module.
+    if let Some(module) = db.get_module_index().get_module(file_id) {
+        let scopes = vec![SemanticInfo {
+            typ: module.export_type.clone().unwrap_or(LuaType::Nil),
+            semantic_decl: module.semantic_id.clone(),
+        }];
+        if let Some(found_refs) = find_members(db, scopes, &path) {
+            result.extend(
+                found_refs
+                    .into_iter()
+                    .filter(|item| !seen_types.contains(&item.typ)),
+            );
+        }
+    }
+
+    // Find in globals.
+    if let Some((LuaDescRefPathItem::Name(name), _)) = path.first() {
+        if let Some(globals) = db.get_global_index().get_global_decl_ids(name) {
+            let scopes = globals
+                .into_iter()
+                .filter_map(|&global| {
+                    Some(SemanticInfo {
+                        typ: db
+                            .get_type_index()
+                            .get_type_cache(&global.into())?
+                            .as_type()
+                            .clone(),
+                        semantic_decl: Some(global.into()),
+                    })
+                })
+                .collect();
+            if let Some(found_refs) = find_members(db, scopes, &path[1..]) {
+                result.extend(found_refs);
+            }
+        }
+    }
+
+    result
+}
+
+pub fn find_comment_scope(
+    db: &DbIndex,
+    file_id: FileId,
+    desc: &LuaSyntaxToken,
+) -> Option<LuaTypeDeclId> {
+    let parent = LuaComment::cast(desc.parent()?.parent()?)?;
+
+    // 1. Try doc tags.
+    for tag in parent.get_doc_tags() {
+        let name_tag = match tag {
+            LuaDocTag::Class(def) => def.get_name_token()?,
+            LuaDocTag::Enum(def) => def.get_name_token()?,
+            LuaDocTag::Alias(def) => def.get_name_token()?,
+            _ => continue,
+        };
+
+        return Some(
+            db.get_type_index()
+                .find_type_decl(file_id, name_tag.get_name_text())?
+                .get_id(),
+        );
+    }
+
+    // Try comment owner.
+    let owner = parent.get_owner()?;
+    let owner_syntax_id = match owner {
+        LuaAst::LuaAssignStat(stat) => {
+            let first_var = stat.child::<LuaVarExpr>()?;
+            match first_var {
+                LuaVarExpr::NameExpr(name_expr) => name_expr.get_syntax_id(),
+                LuaVarExpr::IndexExpr(index_expr) => index_expr.get_syntax_id(),
+            }
+        }
+        LuaAst::LuaLocalStat(stat) => stat.child::<LuaLocalName>()?.get_syntax_id(),
+        LuaAst::LuaTableField(stat) => stat.get_syntax_id(),
+        LuaAst::LuaFuncStat(stat) => stat.get_func_name()?.get_syntax_id(),
+        _ => return None,
+    };
+    // Comment owner is a member of some class/type, try to find it.
+    let member_id = LuaMemberId::new(owner_syntax_id, file_id);
+    db.get_member_index()
+        .get_current_owner(&member_id)?
+        .get_type_id()
+        .cloned()
+}
+
+fn find_members(
+    db: &DbIndex,
+    mut scopes: Vec<SemanticInfo>,
+    path: &[(LuaDescRefPathItem, TextRange)],
+) -> Option<Vec<SemanticInfo>> {
+    for (item, _) in path {
+        let member_key = match item {
+            LuaDescRefPathItem::Name(name) => LuaMemberKey::Name(name.into()),
+            LuaDescRefPathItem::Number(num) => LuaMemberKey::Integer(*num),
+            LuaDescRefPathItem::Type(_) => {
+                // XXX: supporting complex types requires additional consideration,
+                //      skip it for now.
+                return None;
+            }
+        };
+
+        let mut new_scopes = Vec::new();
+
+        for scope in scopes {
+            let members = get_member_map(db, &scope.typ);
+            if let Some(found_members) = members
+                .as_ref()
+                .and_then(|members| members.get(&member_key))
+            {
+                new_scopes.extend(found_members.iter().map(|member| SemanticInfo {
+                    typ: member.typ.clone(),
+                    semantic_decl: member.property_owner_id.clone(),
+                }))
+            }
+        }
+
+        if new_scopes.is_empty() {
+            return None;
+        }
+
+        scopes = new_scopes;
+    }
+
+    Some(scopes)
+}

--- a/crates/emmylua_ls/src/util/mod.rs
+++ b/crates/emmylua_ls/src/util/mod.rs
@@ -1,5 +1,7 @@
+mod desc;
 mod module_name_convert;
 mod time_cancel_token;
 
+pub use desc::*;
 pub use module_name_convert::{key_name_convert, module_name_convert};
 pub use time_cancel_token::time_cancel_token;

--- a/crates/emmylua_parser/src/lexer/lua_doc_lexer.rs
+++ b/crates/emmylua_parser/src/lexer/lua_doc_lexer.rs
@@ -47,7 +47,8 @@ impl LuaDocLexer<'_> {
     }
 
     pub fn reset(&mut self, kind: LuaTokenKind, range: SourceRange) {
-        self.reader = Some(Reader::new_with_range(self.origin_text, range));
+        let text = &self.origin_text[range.start_offset..range.end_offset()];
+        self.reader = Some(Reader::new_with_range(text, range));
         self.origin_token_kind = kind;
     }
 
@@ -76,7 +77,7 @@ impl LuaDocLexer<'_> {
     }
 
     pub fn current_token_range(&self) -> SourceRange {
-        self.reader.as_ref().unwrap().saved_range()
+        self.reader.as_ref().unwrap().current_range()
     }
 
     fn lex_init(&mut self) -> LuaTokenKind {
@@ -135,7 +136,7 @@ impl LuaDocLexer<'_> {
             ch if is_name_start(ch) => {
                 reader.bump();
                 reader.eat_while(is_name_continue);
-                let text = reader.current_saved_text();
+                let text = reader.current_text();
                 to_tag(text)
             }
             _ => {
@@ -490,7 +491,7 @@ impl LuaDocLexer<'_> {
                 }
 
                 reader.eat_while(|c| c.is_ascii_alphabetic());
-                let text = reader.current_saved_text();
+                let text = reader.current_text();
                 match text {
                     "region" | "#region" => LuaTokenKind::TkDocRegion,
                     "endregion" | "#endregion" => LuaTokenKind::TkDocEndRegion,
@@ -651,7 +652,7 @@ fn read_doc_name<'a>(reader: &'a mut Reader) -> (&'a str, bool /* str tpl */) {
         }
     }
 
-    (reader.current_saved_text(), str_tpl)
+    (reader.current_text(), str_tpl)
 }
 
 fn is_source_continue(ch: char) -> bool {

--- a/crates/emmylua_parser/src/lexer/lua_lexer.rs
+++ b/crates/emmylua_parser/src/lexer/lua_lexer.rs
@@ -693,7 +693,7 @@ impl<'a> LuaLexer<'a> {
 
         if self.reader.current_char().is_alphabetic() {
             let ch = self.reader.current_char();
-            self.error(|| format!("unexpected character '{ch}' after number literal"));
+            self.error(|| t!("unexpected character '%{ch}' after number literal", ch = ch));
         }
 
         match state {

--- a/crates/emmylua_parser/src/lexer/lua_lexer.rs
+++ b/crates/emmylua_parser/src/lexer/lua_lexer.rs
@@ -30,7 +30,7 @@ impl LuaLexer<'_> {
                 break;
             }
 
-            tokens.push(LuaTokenData::new(kind, self.reader.saved_range()));
+            tokens.push(LuaTokenData::new(kind, self.reader.current_range()));
         }
 
         tokens
@@ -122,7 +122,7 @@ impl LuaLexer<'_> {
                 if self.reader.current_char() != '[' {
                     self.errors.push(LuaParseError::syntax_error_from(
                         &t!("invalid long string delimiter"),
-                        self.reader.saved_range(),
+                        self.reader.current_range(),
                     ));
                     return LuaTokenKind::TkLongString;
                 }
@@ -149,7 +149,7 @@ impl LuaLexer<'_> {
                         if !self.lexer_config.support_integer_operation() {
                             self.errors.push(LuaParseError::syntax_error_from(
                                 &t!("bitwise operation is not supported"),
-                                self.reader.saved_range(),
+                                self.reader.current_range(),
                             ));
                         }
 
@@ -176,7 +176,7 @@ impl LuaLexer<'_> {
                         if !self.lexer_config.support_integer_operation() {
                             self.errors.push(LuaParseError::syntax_error_from(
                                 &t!("bitwise operation is not supported"),
-                                self.reader.saved_range(),
+                                self.reader.current_range(),
                             ));
                         }
 
@@ -198,7 +198,7 @@ impl LuaLexer<'_> {
                     if !self.lexer_config.support_integer_operation() {
                         self.errors.push(LuaParseError::syntax_error_from(
                             &t!("bitwise operation is not supported"),
-                            self.reader.saved_range(),
+                            self.reader.current_range(),
                         ));
                     }
                     return LuaTokenKind::TkBitXor;
@@ -252,7 +252,7 @@ impl LuaLexer<'_> {
                 if self.reader.current_char() != quote {
                     self.errors.push(LuaParseError::syntax_error_from(
                         &t!("unfinished string"),
-                        self.reader.saved_range(),
+                        self.reader.current_range(),
                     ));
                     return LuaTokenKind::TkString;
                 }
@@ -297,7 +297,7 @@ impl LuaLexer<'_> {
                                 _ if self.reader.is_eof() => {
                                     self.errors.push(LuaParseError::syntax_error_from(
                                         &t!("unfinished long comment"),
-                                        self.reader.saved_range(),
+                                        self.reader.current_range(),
                                     ));
                                     return LuaTokenKind::TkLongComment;
                                 }
@@ -323,7 +323,7 @@ impl LuaLexer<'_> {
                         if !self.lexer_config.support_integer_operation() {
                             self.errors.push(LuaParseError::syntax_error_from(
                                 &t!("integer division is not supported"),
-                                self.reader.saved_range(),
+                                self.reader.current_range(),
                             ));
                         }
 
@@ -405,7 +405,7 @@ impl LuaLexer<'_> {
                 if !self.lexer_config.support_integer_operation() {
                     self.errors.push(LuaParseError::syntax_error_from(
                         &t!("bitwise operation is not supported"),
-                        self.reader.saved_range(),
+                        self.reader.current_range(),
                     ));
                 }
 
@@ -428,7 +428,7 @@ impl LuaLexer<'_> {
                 if !self.lexer_config.support_integer_operation() {
                     self.errors.push(LuaParseError::syntax_error_from(
                         &t!("bitwise operation is not supported"),
-                        self.reader.saved_range(),
+                        self.reader.current_range(),
                     ));
                 }
 
@@ -483,7 +483,7 @@ impl LuaLexer<'_> {
             ch if is_name_start(ch) => {
                 self.reader.bump();
                 self.reader.eat_while(is_name_continue);
-                let name = self.reader.current_saved_text();
+                let name = self.reader.current_text();
                 self.name_to_kind(name)
             }
             _ => {
@@ -546,7 +546,7 @@ impl LuaLexer<'_> {
         if !end {
             self.errors.push(LuaParseError::syntax_error_from(
                 &t!("unfinished long string or comment"),
-                self.reader.saved_range(),
+                self.reader.current_range(),
             ));
         }
 
@@ -671,7 +671,7 @@ impl LuaLexer<'_> {
                     "unexpected character '{}' after number literal",
                     self.reader.current_char()
                 ),
-                self.reader.saved_range(),
+                self.reader.current_range(),
             ));
         }
 

--- a/crates/emmylua_parser/src/lexer/lua_lexer.rs
+++ b/crates/emmylua_parser/src/lexer/lua_lexer.rs
@@ -5,19 +5,42 @@ use super::{is_name_continue, is_name_start, lexer_config::LexerConfig, token_da
 pub struct LuaLexer<'a> {
     reader: Reader<'a>,
     lexer_config: LexerConfig,
-    errors: &'a mut Vec<LuaParseError>,
+    errors: Option<&'a mut Vec<LuaParseError>>,
+    state: LuaLexerState,
 }
 
-impl LuaLexer<'_> {
-    pub fn new<'a>(
-        text: &'a str,
+/// This enum allows preserving lexer state between reader resets. This is used
+/// when lexer doesn't see the whole input source, and only sees a reader
+/// for each individual line. It happens when we're lexing
+/// code blocks in comments.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LuaLexerState {
+    Normal,
+    String(char),
+    LongString(usize),
+    LongComment(usize),
+}
+
+impl<'a> LuaLexer<'a> {
+    pub fn new(
+        reader: Reader<'a>,
         lexer_config: LexerConfig,
-        errors: &'a mut Vec<LuaParseError>,
-    ) -> LuaLexer<'a> {
+        errors: Option<&'a mut Vec<LuaParseError>>,
+    ) -> Self {
+        Self::new_with_state(reader, LuaLexerState::Normal, lexer_config, errors)
+    }
+
+    pub fn new_with_state(
+        reader: Reader<'a>,
+        state: LuaLexerState,
+        lexer_config: LexerConfig,
+        errors: Option<&'a mut Vec<LuaParseError>>,
+    ) -> Self {
         LuaLexer {
-            reader: Reader::new(text),
+            reader,
             lexer_config,
             errors,
+            state,
         }
     }
 
@@ -25,7 +48,15 @@ impl LuaLexer<'_> {
         let mut tokens = vec![];
 
         while !self.reader.is_eof() {
-            let kind = self.lex();
+            let kind = match self.state {
+                LuaLexerState::Normal => self.lex(),
+                LuaLexerState::String(quote) => self.lex_string(quote),
+                LuaLexerState::LongString(sep) => self.lex_long_string(sep),
+                LuaLexerState::LongComment(sep) => {
+                    self.lex_long_string(sep);
+                    LuaTokenKind::TkLongComment
+                }
+            };
             if kind == LuaTokenKind::TkEof {
                 break;
             }
@@ -34,6 +65,16 @@ impl LuaLexer<'_> {
         }
 
         tokens
+    }
+
+    pub fn get_state(&self) -> LuaLexerState {
+        self.state
+    }
+
+    pub fn continue_with_new_reader(&mut self, reader: Reader<'a>) -> Vec<LuaTokenData> {
+        assert!(self.reader.is_eof(), "previous reader wasn't exhausted");
+        self.reader = reader;
+        self.tokenize()
     }
 
     fn support_non_std_symbol(&self, symbol: LuaNonStdSymbol) -> bool {
@@ -105,6 +146,7 @@ impl LuaLexer<'_> {
                     let sep = self.skip_sep();
                     if self.reader.current_char() == '[' {
                         self.reader.bump();
+                        self.state = LuaLexerState::LongComment(sep);
                         self.lex_long_string(sep);
                         return LuaTokenKind::TkLongComment;
                     }
@@ -120,14 +162,12 @@ impl LuaLexer<'_> {
                     return LuaTokenKind::TkLeftBracket;
                 }
                 if self.reader.current_char() != '[' {
-                    self.errors.push(LuaParseError::syntax_error_from(
-                        &t!("invalid long string delimiter"),
-                        self.reader.current_range(),
-                    ));
+                    self.error(|| t!("invalid long string delimiter"));
                     return LuaTokenKind::TkLongString;
                 }
 
                 self.reader.bump();
+                self.state = LuaLexerState::LongString(sep);
                 self.lex_long_string(sep)
             }
             '=' => {
@@ -147,10 +187,7 @@ impl LuaLexer<'_> {
                     }
                     '<' => {
                         if !self.lexer_config.support_integer_operation() {
-                            self.errors.push(LuaParseError::syntax_error_from(
-                                &t!("bitwise operation is not supported"),
-                                self.reader.current_range(),
-                            ));
+                            self.error(|| t!("bitwise operation is not supported"));
                         }
 
                         self.reader.bump();
@@ -174,10 +211,7 @@ impl LuaLexer<'_> {
                     }
                     '>' => {
                         if !self.lexer_config.support_integer_operation() {
-                            self.errors.push(LuaParseError::syntax_error_from(
-                                &t!("bitwise operation is not supported"),
-                                self.reader.current_range(),
-                            ));
+                            self.error(|| t!("bitwise operation is not supported"));
                         }
 
                         self.reader.bump();
@@ -196,10 +230,7 @@ impl LuaLexer<'_> {
                 self.reader.bump();
                 if self.reader.current_char() != '=' {
                     if !self.lexer_config.support_integer_operation() {
-                        self.errors.push(LuaParseError::syntax_error_from(
-                            &t!("bitwise operation is not supported"),
-                            self.reader.current_range(),
-                        ));
+                        self.error(|| t!("bitwise operation is not supported"));
                     }
                     return LuaTokenKind::TkBitXor;
                 }
@@ -222,43 +253,8 @@ impl LuaLexer<'_> {
                 }
 
                 self.reader.bump();
-                while !self.reader.is_eof() {
-                    let ch = self.reader.current_char();
-                    if ch == quote || ch == '\n' || ch == '\r' {
-                        break;
-                    }
-
-                    if ch != '\\' {
-                        self.reader.bump();
-                        continue;
-                    }
-
-                    self.reader.bump();
-                    match self.reader.current_char() {
-                        'z' => {
-                            self.reader.bump();
-                            self.reader
-                                .eat_while(|c| c == ' ' || c == '\t' || c == '\r' || c == '\n');
-                        }
-                        '\r' | '\n' => {
-                            self.lex_new_line();
-                        }
-                        _ => {
-                            self.reader.bump();
-                        }
-                    }
-                }
-
-                if self.reader.current_char() != quote {
-                    self.errors.push(LuaParseError::syntax_error_from(
-                        &t!("unfinished string"),
-                        self.reader.current_range(),
-                    ));
-                    return LuaTokenKind::TkString;
-                }
-
-                self.reader.bump();
-                LuaTokenKind::TkString
+                self.state = LuaLexerState::String(quote);
+                self.lex_string(quote)
             }
             '.' => {
                 if self.reader.next_char().is_ascii_digit() {
@@ -295,10 +291,7 @@ impl LuaLexer<'_> {
                                     }
                                 }
                                 _ if self.reader.is_eof() => {
-                                    self.errors.push(LuaParseError::syntax_error_from(
-                                        &t!("unfinished long comment"),
-                                        self.reader.current_range(),
-                                    ));
+                                    self.error(|| t!("unfinished long comment"));
                                     return LuaTokenKind::TkLongComment;
                                 }
                                 _ => {
@@ -321,10 +314,7 @@ impl LuaLexer<'_> {
                     }
                     _ => {
                         if !self.lexer_config.support_integer_operation() {
-                            self.errors.push(LuaParseError::syntax_error_from(
-                                &t!("integer division is not supported"),
-                                self.reader.current_range(),
-                            ));
+                            self.error(|| t!("integer division is not supported"));
                         }
 
                         self.reader.bump();
@@ -403,10 +393,7 @@ impl LuaLexer<'_> {
             }
             '&' => {
                 if !self.lexer_config.support_integer_operation() {
-                    self.errors.push(LuaParseError::syntax_error_from(
-                        &t!("bitwise operation is not supported"),
-                        self.reader.current_range(),
-                    ));
+                    self.error(|| t!("bitwise operation is not supported"));
                 }
 
                 self.reader.bump();
@@ -426,10 +413,7 @@ impl LuaLexer<'_> {
             }
             '|' => {
                 if !self.lexer_config.support_integer_operation() {
-                    self.errors.push(LuaParseError::syntax_error_from(
-                        &t!("bitwise operation is not supported"),
-                        self.reader.current_range(),
-                    ));
+                    self.error(|| t!("bitwise operation is not supported"));
                 }
 
                 self.reader.bump();
@@ -524,6 +508,47 @@ impl LuaLexer<'_> {
         self.reader.eat_when('=')
     }
 
+    fn lex_string(&mut self, quote: char) -> LuaTokenKind {
+        while !self.reader.is_eof() {
+            let ch = self.reader.current_char();
+            if ch == quote || ch == '\n' || ch == '\r' {
+                break;
+            }
+
+            if ch != '\\' {
+                self.reader.bump();
+                continue;
+            }
+
+            self.reader.bump();
+            match self.reader.current_char() {
+                'z' => {
+                    self.reader.bump();
+                    self.reader
+                        .eat_while(|c| c == ' ' || c == '\t' || c == '\r' || c == '\n');
+                }
+                '\r' | '\n' => {
+                    self.lex_new_line();
+                }
+                _ => {
+                    self.reader.bump();
+                }
+            }
+        }
+
+        if self.reader.current_char() == quote || !self.reader.is_eof() {
+            self.state = LuaLexerState::Normal;
+        }
+
+        if self.reader.current_char() != quote {
+            self.error(|| t!("unfinished string"));
+            return LuaTokenKind::TkString;
+        }
+
+        self.reader.bump();
+        LuaTokenKind::TkString
+    }
+
     fn lex_long_string(&mut self, sep: usize) -> LuaTokenKind {
         let mut end = false;
         while !self.reader.is_eof() {
@@ -543,11 +568,12 @@ impl LuaLexer<'_> {
             }
         }
 
+        if end || !self.reader.is_eof() {
+            self.state = LuaLexerState::Normal;
+        }
+
         if !end {
-            self.errors.push(LuaParseError::syntax_error_from(
-                &t!("unfinished long string or comment"),
-                self.reader.current_range(),
-            ));
+            self.error(|| t!("unfinished long string or comment"));
         }
 
         LuaTokenKind::TkLongString
@@ -666,18 +692,26 @@ impl LuaLexer<'_> {
         }
 
         if self.reader.current_char().is_alphabetic() {
-            self.errors.push(LuaParseError::syntax_error_from(
-                &format!(
-                    "unexpected character '{}' after number literal",
-                    self.reader.current_char()
-                ),
-                self.reader.current_range(),
-            ));
+            let ch = self.reader.current_char();
+            self.error(|| format!("unexpected character '{ch}' after number literal"));
         }
 
         match state {
             NumberState::Int | NumberState::Hex => LuaTokenKind::TkInt,
             _ => LuaTokenKind::TkFloat,
+        }
+    }
+
+    fn error<F, R>(&mut self, msg: F)
+    where
+        F: FnOnce() -> R,
+        R: AsRef<str>,
+    {
+        if let Some(errors) = &mut self.errors {
+            errors.push(LuaParseError::syntax_error_from(
+                msg().as_ref(),
+                self.reader.current_range(),
+            ))
         }
     }
 }

--- a/crates/emmylua_parser/src/lexer/mod.rs
+++ b/crates/emmylua_parser/src/lexer/mod.rs
@@ -6,7 +6,7 @@ mod token_data;
 
 pub use lexer_config::LexerConfig;
 pub use lua_doc_lexer::{LuaDocLexer, LuaDocLexerState};
-pub use lua_lexer::LuaLexer;
+pub use lua_lexer::{LuaLexer, LuaLexerState};
 pub use token_data::LuaTokenData;
 
 fn is_name_start(ch: char) -> bool {

--- a/crates/emmylua_parser/src/lexer/test.rs
+++ b/crates/emmylua_parser/src/lexer/test.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 mod tests {
+    use crate::text::Reader;
     use crate::{
         LuaNonStdSymbol,
         lexer::{LexerConfig, LuaLexer},
@@ -83,7 +84,7 @@ mod tests {
         "#;
         let config = LexerConfig::default();
         let mut errors: Vec<LuaParseError> = Vec::new();
-        let mut lexer = LuaLexer::new(text, config, &mut errors);
+        let mut lexer = LuaLexer::new(Reader::new(text), config, Some(&mut errors));
         let tokens = lexer.tokenize();
         // for token in &tokens {
         //     println!("{:?}", token);
@@ -1141,7 +1142,7 @@ LuaTokenData { kind: TkWhitespace, range: SourceRange { start_offset: 2036, leng
         ]);
 
         let mut errors: Vec<LuaParseError> = Vec::new();
-        let mut lexer = LuaLexer::new(text, config, &mut errors);
+        let mut lexer = LuaLexer::new(Reader::new(text), config, Some(&mut errors));
         let tokens = lexer.tokenize();
 
         let test_str = tokens

--- a/crates/emmylua_parser/src/lib.rs
+++ b/crates/emmylua_parser/src/lib.rs
@@ -7,10 +7,12 @@ mod syntax;
 mod text;
 
 pub use kind::*;
+pub use lexer::{LexerConfig, LuaLexer, LuaLexerState, LuaTokenData};
 pub use parser::{LuaParser, ParserConfig, SpecialFunction};
 pub use parser_error::{LuaParseError, LuaParseErrorKind};
 pub use syntax::*;
 pub use text::LineIndex;
+pub use text::{Reader, SourceRange};
 
 #[macro_use]
 extern crate rust_i18n;

--- a/crates/emmylua_parser/src/parser/lua_parser.rs
+++ b/crates/emmylua_parser/src/parser/lua_parser.rs
@@ -1,3 +1,9 @@
+use super::{
+    lua_doc_parser::LuaDocParser,
+    marker::{MarkEvent, MarkerEventContainer},
+    parser_config::ParserConfig,
+};
+use crate::text::Reader;
 use crate::{
     LuaSyntaxTree, LuaTreeBuilder,
     grammar::parse_chunk,
@@ -5,12 +11,6 @@ use crate::{
     lexer::{LuaLexer, LuaTokenData},
     parser_error::LuaParseError,
     text::SourceRange,
-};
-
-use super::{
-    lua_doc_parser::LuaDocParser,
-    marker::{MarkEvent, MarkerEventContainer},
-    parser_config::ParserConfig,
 };
 
 #[allow(unused)]
@@ -48,7 +48,8 @@ impl<'a> LuaParser<'a> {
     pub fn parse(text: &'a str, config: ParserConfig) -> LuaSyntaxTree {
         let mut errors: Vec<LuaParseError> = Vec::new();
         let tokens = {
-            let mut lexer = LuaLexer::new(text, config.lexer_config(), &mut errors);
+            let mut lexer =
+                LuaLexer::new(Reader::new(text), config.lexer_config(), Some(&mut errors));
             lexer.tokenize()
         };
 
@@ -320,6 +321,7 @@ fn is_invalid_kind(kind: LuaTokenKind) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use crate::text::Reader;
     use crate::{
         LuaParser, kind::LuaTokenKind, lexer::LuaLexer, parser::ParserConfig,
         parser_error::LuaParseError,
@@ -333,7 +335,7 @@ mod tests {
         show_tokens: bool,
     ) -> LuaParser<'a> {
         let tokens = {
-            let mut lexer = LuaLexer::new(text, config.lexer_config(), errors);
+            let mut lexer = LuaLexer::new(Reader::new(text), config.lexer_config(), Some(errors));
             lexer.tokenize()
         };
 

--- a/crates/emmylua_parser/src/syntax/node/mod.rs
+++ b/crates/emmylua_parser/src/syntax/node/mod.rs
@@ -88,6 +88,8 @@ pub enum LuaAst {
     LuaDocTagAs(LuaDocTagAs),
     LuaDocTagReturnCast(LuaDocTagReturnCast),
     LuaDocTagExport(LuaDocTagExport),
+    // doc description
+    LuaDocDescription(LuaDocDescription),
 
     // doc type
     LuaDocNameType(LuaDocNameType),
@@ -173,6 +175,7 @@ impl LuaAstNode for LuaAst {
             LuaAst::LuaDocTagAs(node) => node.syntax(),
             LuaAst::LuaDocTagReturnCast(node) => node.syntax(),
             LuaAst::LuaDocTagExport(node) => node.syntax(),
+            LuaAst::LuaDocDescription(node) => node.syntax(),
             LuaAst::LuaDocNameType(node) => node.syntax(),
             LuaAst::LuaDocArrayType(node) => node.syntax(),
             LuaAst::LuaDocFuncType(node) => node.syntax(),
@@ -403,6 +406,9 @@ impl LuaAstNode for LuaAst {
             }
             LuaSyntaxKind::DocTagExport => {
                 LuaDocTagExport::cast(syntax).map(LuaAst::LuaDocTagExport)
+            }
+            LuaSyntaxKind::DocDescription => {
+                LuaDocDescription::cast(syntax).map(LuaAst::LuaDocDescription)
             }
             LuaSyntaxKind::TypeName => LuaDocNameType::cast(syntax).map(LuaAst::LuaDocNameType),
             LuaSyntaxKind::TypeArray => LuaDocArrayType::cast(syntax).map(LuaAst::LuaDocArrayType),

--- a/crates/emmylua_parser/src/text/mod.rs
+++ b/crates/emmylua_parser/src/text/mod.rs
@@ -5,4 +5,4 @@ mod text_range;
 
 pub use line_index::LineIndex;
 pub use reader::Reader;
-pub(crate) use text_range::SourceRange;
+pub use text_range::SourceRange;

--- a/crates/emmylua_parser/src/text/reader.rs
+++ b/crates/emmylua_parser/src/text/reader.rs
@@ -1,18 +1,51 @@
-use std::{iter::Peekable, str::Chars};
-
 use super::text_range::SourceRange;
+use std::str::Chars;
+
 pub const EOF: char = '\0';
 
+/// Reader with look-ahead and look-behind methods.
+///
+/// As you read text, the part that you've read is accumulated
+/// in `current_range`. The part that you haven't seen yet is available
+/// in `tail_range`:
+///
+/// ```text
+/// valid range: a b c d e f g
+///                ^^^          - current range
+///                    ^^^^^^^  - tail range
+///                  ^          - prev char
+///                    ^        - current char
+///                      ^      - next char
+/// ```
+///
+/// Once you call `reset_buff`, current range is advanced to start
+/// at the current char, and shrunk to zero length:
+///
+/// ```text
+/// valid range: a b c d e f g
+///                    .       - current range (empty, starts at `d`)
+///                    ^^^^^^  - tail range
+///                  ^         - prev char
+///                    ^       - current char
+///                      ^     - next char
+/// ```
+///
+/// The workflow in roughly this:
+///
+/// - you read characters, they're put into `saved_range`;
+/// - once you're at a token boundary, you emit a token with `saved_range`,
+///   then call `reset_buff`,
+/// - you continue onto the next token.
 #[derive(Debug, Clone)]
 pub struct Reader<'a> {
     text: &'a str,
     valid_range: SourceRange,
-    chars: Peekable<Chars<'a>>,
-    save_buffer_byte_pos: usize,
-    save_buffer_byte_len: usize,
-    current_char_len: usize,
+    chars: Chars<'a>,
+    current_buffer_byte_pos: usize,
+    current_buffer_byte_len: usize,
+    next: char,
     current: char,
-    start: bool,
+    prev: char,
 }
 
 impl<'a> Reader<'a> {
@@ -21,48 +54,60 @@ impl<'a> Reader<'a> {
     }
 
     pub fn new_with_range(text: &'a str, range: SourceRange) -> Self {
-        let text = text[range.start_offset..range.end_offset()].as_ref();
-        Self {
+        assert_eq!(text.len(), range.length);
+        let mut res = Self {
             text,
             valid_range: range,
-            chars: text.chars().peekable(),
-            save_buffer_byte_pos: 0,
-            save_buffer_byte_len: 0,
-            current_char_len: 0,
+            chars: text.chars(),
+            current_buffer_byte_pos: 0,
+            current_buffer_byte_len: 0,
+            next: EOF,
             current: EOF,
-            start: false,
-        }
+            prev: EOF,
+        };
+
+        res.current = res.chars.next().unwrap_or(EOF);
+        res.next = res.chars.next().unwrap_or(EOF);
+
+        res
     }
 
     pub fn bump(&mut self) {
-        if let Some(c) = self.chars.next() {
-            self.current = c;
-            self.save_buffer_byte_len += self.current_char_len;
-            self.current_char_len = c.len_utf8();
-        } else {
-            self.current = EOF;
-            if self.current_char_len > 0 {
-                self.save_buffer_byte_len += self.current_char_len;
-                self.current_char_len = 0;
-            }
+        if self.current != EOF {
+            self.current_buffer_byte_len += self.current.len_utf8();
+            self.prev = self.current;
+            self.current = self.next;
+            self.next = self.chars.next().unwrap_or(EOF);
         }
     }
 
     pub fn reset_buff(&mut self) {
-        self.save_buffer_byte_pos += self.save_buffer_byte_len;
-        self.save_buffer_byte_len = 0;
-        if !self.start {
-            self.start = true;
-            self.bump();
+        self.current_buffer_byte_pos += self.current_buffer_byte_len;
+        self.current_buffer_byte_len = 0;
+    }
+
+    pub fn reset_buff_into_sub_reader(&mut self) -> Reader<'a> {
+        let mut reader = Reader::new_with_range(self.current_text(), self.current_range());
+        if let Some(prev) = &self.text[..self.current_buffer_byte_pos]
+            .chars()
+            .next_back()
+        {
+            reader.prev = *prev;
         }
+        self.reset_buff();
+        reader
     }
 
     pub fn is_eof(&self) -> bool {
-        self.current == EOF && self.start
+        self.current == EOF
     }
 
     pub fn is_start_of_line(&self) -> bool {
-        self.save_buffer_byte_pos == 0
+        self.current_buffer_byte_pos == 0
+    }
+
+    pub fn prev_char(&self) -> char {
+        self.prev
     }
 
     pub fn current_char(&self) -> char {
@@ -70,19 +115,28 @@ impl<'a> Reader<'a> {
     }
 
     pub fn next_char(&mut self) -> char {
-        self.chars.peek().cloned().unwrap_or(EOF)
+        self.next
     }
 
-    pub fn saved_range(&self) -> SourceRange {
+    pub fn current_range(&self) -> SourceRange {
         SourceRange::new(
-            self.valid_range.start_offset + self.save_buffer_byte_pos,
-            self.save_buffer_byte_len,
+            self.valid_range.start_offset + self.current_buffer_byte_pos,
+            self.current_buffer_byte_len,
         )
     }
 
-    pub fn current_saved_text(&self) -> &str {
-        &self.text
-            [self.save_buffer_byte_pos..(self.save_buffer_byte_pos + self.save_buffer_byte_len)]
+    pub fn tail_range(&self) -> SourceRange {
+        self.valid_range
+            .moved(self.current_buffer_byte_pos + self.current_buffer_byte_len)
+    }
+
+    pub fn current_text(&self) -> &'a str {
+        &self.text[self.current_buffer_byte_pos
+            ..(self.current_buffer_byte_pos + self.current_buffer_byte_len)]
+    }
+
+    pub fn tail_text(&self) -> &'a str {
+        &self.text[self.current_buffer_byte_pos + self.current_buffer_byte_len..]
     }
 
     pub fn eat_when(&mut self, ch: char) -> usize {
@@ -103,6 +157,18 @@ impl<'a> Reader<'a> {
         eaten
     }
 
+    pub fn consume_n_times<F>(&mut self, func: F, count: usize) -> usize
+    where
+        F: Fn(char) -> bool,
+    {
+        let mut eaten = 0;
+        while !self.is_eof() && func(self.current_char()) && eaten < count {
+            eaten += 1;
+            self.bump();
+        }
+        eaten
+    }
+
     pub fn eat_while<F>(&mut self, func: F) -> usize
     where
         F: Fn(char) -> bool,
@@ -115,12 +181,16 @@ impl<'a> Reader<'a> {
         count
     }
 
-    pub fn get_source_text(&self) -> &str {
+    pub fn eat_till_end(&mut self) -> usize {
+        self.eat_while(|_| true)
+    }
+
+    pub fn get_source_text(&self) -> &'a str {
         self.text
     }
 
     pub fn get_current_end_pos(&self) -> usize {
-        self.save_buffer_byte_pos + self.save_buffer_byte_len
+        self.current_buffer_byte_pos + self.current_buffer_byte_len
     }
 }
 
@@ -181,13 +251,13 @@ mod tests {
         let mut reader = Reader::new(text);
         reader.reset_buff();
         reader.bump();
-        let range = reader.saved_range();
+        let range = reader.current_range();
         assert_eq!(range.start_offset, 0);
         assert_eq!(range.length, 1);
 
         reader.reset_buff();
         reader.bump();
-        let range2 = reader.saved_range();
+        let range2 = reader.current_range();
         assert_eq!(range2.start_offset, 1);
         assert_eq!(range2.length, 1);
     }
@@ -198,7 +268,7 @@ mod tests {
         let mut reader = Reader::new(text);
         reader.reset_buff();
         reader.bump();
-        assert_eq!(reader.current_saved_text(), "H");
+        assert_eq!(reader.current_text(), "H");
     }
 
     #[test]
@@ -209,7 +279,7 @@ mod tests {
         let count = reader.eat_when('a');
         assert_eq!(count, 3);
         assert_eq!(reader.current_char(), 'H');
-        assert_eq!(reader.current_saved_text(), "aaa");
+        assert_eq!(reader.current_text(), "aaa");
     }
 
     #[test]

--- a/crates/emmylua_parser/src/text/text_range.rs
+++ b/crates/emmylua_parser/src/text/text_range.rs
@@ -14,6 +14,11 @@ impl SourceRange {
         }
     }
 
+    pub fn from_start_end(start_offset: usize, end_offset: usize) -> Self {
+        assert!(start_offset <= end_offset);
+        Self::new(start_offset, end_offset - start_offset)
+    }
+
     pub const EMPTY: SourceRange = SourceRange {
         start_offset: 0,
         length: 0,
@@ -23,8 +28,12 @@ impl SourceRange {
         self.start_offset + self.length
     }
 
-    pub fn contain(&self, offset: usize) -> bool {
+    pub fn contains(&self, offset: usize) -> bool {
         offset >= self.start_offset && offset < self.end_offset()
+    }
+
+    pub fn contains_inclusive(&self, offset: usize) -> bool {
+        offset >= self.start_offset && offset <= self.end_offset()
     }
 
     pub fn contain_range(&self, range: &SourceRange) -> bool {
@@ -33,6 +42,11 @@ impl SourceRange {
 
     pub fn intersect(&self, range: &SourceRange) -> bool {
         self.start_offset < range.end_offset() && range.start_offset < self.end_offset()
+    }
+
+    pub fn moved(&self, offset: usize) -> SourceRange {
+        debug_assert!(offset <= self.length);
+        SourceRange::new(self.start_offset + offset, self.length - offset)
     }
 
     pub fn merge(&self, range: &SourceRange) -> SourceRange {
@@ -61,5 +75,11 @@ impl From<SourceRange> for TextRange {
             (val.start_offset as u32).into(),
             (val.end_offset() as u32).into(),
         )
+    }
+}
+
+impl From<TextRange> for SourceRange {
+    fn from(val: TextRange) -> Self {
+        SourceRange::new(val.start().into(), val.len().into())
     }
 }

--- a/crates/emmylua_parser_desc/Cargo.toml
+++ b/crates/emmylua_parser_desc/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "emmylua_parser_desc"
+version = "0.12.0"
+edition = "2024"
+authors = ["CppCXY", "taminomara"]
+description = "A parser for markup within Lua comments"
+license = "MIT"
+repository = "https://github.com/CppCXY/emmylua-analyzer-rust"
+readme = "README.md"
+keywords = ["emmylua", "luals", "parser", "lua"]
+categories = ["development-tools", "parsing"]
+
+[dependencies]
+# local
+emmylua_parser.workspace = true
+
+# external
+rowan.workspace = true
+unicode-general-category.workspace = true

--- a/crates/emmylua_parser_desc/README.md
+++ b/crates/emmylua_parser_desc/README.md
@@ -1,0 +1,35 @@
+## EmmyLua-Parser-Desc
+
+EmmyLua-Parser-Desc is an extension for EmmyLua-Parser that uses its internal machinery to provide lexic information about markup of documentation comments. It supports parsing Markdown, MyST and RST.
+
+
+### Features
+
+- Ability to parse description blocks provided by EmmyLua-Parser and report ranges of interest: highlighted keywords,  code blocks, cross-references and so on
+- Supports Markdown, MyST and RST
+- Ability to parse possible broken or unterminated MyST and RST cross-references in order to facilitate Autocompletion and Go To Definition functionality
+
+### Usage
+
+```rust
+let code = r#"
+    --- Description in **markdown format**, with example code:
+    ---
+    --- ```lua
+    --- print(a)
+    --- ```
+    local a = 1
+"#;
+let tree = LuaParser::parse(code, ParserConfig::default());
+
+let chunk = tree.get_chunk_node();
+for desc in chunk.descendants::<LuaDocDescription>() {
+    let doc_items = emmylua_parser_desc::parse(
+        DescParserType::Md,
+        code,
+        desc,
+        None
+    );
+    println!("{:?}", doc_items);
+}
+```

--- a/crates/emmylua_parser_desc/src/lib.rs
+++ b/crates/emmylua_parser_desc/src/lib.rs
@@ -1,0 +1,101 @@
+use emmylua_parser::{LuaDocDescription, LuaTokenKind};
+use rowan::TextRange;
+
+mod md;
+mod ref_target;
+mod rst;
+mod util;
+
+pub use ref_target::*;
+use util::sort_result;
+
+#[cfg(test)]
+mod testlib;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum DescItemKind {
+    /// Generic block of documentation.
+    Scope,
+
+    /// Cross-reference to a Lua object.
+    Ref,
+
+    /// Emphasis.
+    Em,
+
+    /// Strong emphasis.
+    Strong,
+
+    /// Code markup.
+    Code,
+
+    /// Hyperlink.
+    Link,
+
+    /// Inline markup, like stars around emphasized text.
+    Markup,
+
+    /// Directive name, code-block syntax name, role name,
+    /// or some other form of argument.
+    Arg,
+
+    /// Line of code in a code block.
+    CodeBlock,
+
+    /// Line of code in a code block highlighted by Lua lexer.
+    CodeBlockHl(LuaTokenKind),
+}
+
+#[derive(Debug, Clone)]
+pub struct DescItem {
+    pub range: TextRange,
+    pub kind: DescItemKind,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub enum DescParserType {
+    None,
+    Md,
+    MySt {
+        primary_domain: Option<String>,
+    },
+    Rst {
+        primary_domain: Option<String>,
+        default_role: Option<String>,
+    },
+}
+
+impl Default for DescParserType {
+    fn default() -> Self {
+        DescParserType::None
+    }
+}
+
+/// Parses markup in comments.
+pub trait LuaDescParser {
+    /// Process a description node and yield found documentation ranges.
+    fn parse(&mut self, text: &str, desc: LuaDocDescription) -> Vec<DescItem>;
+}
+
+pub fn parse(
+    kind: DescParserType,
+    text: &str,
+    desc: LuaDocDescription,
+    cursor_position: Option<usize>,
+) -> Vec<DescItem> {
+    let mut items = match kind {
+        DescParserType::None => Vec::new(),
+        DescParserType::Md => md::MdParser::new(cursor_position).parse(text, desc),
+        DescParserType::MySt { primary_domain } => {
+            md::MdParser::new_myst(primary_domain, cursor_position).parse(text, desc)
+        }
+        DescParserType::Rst {
+            primary_domain,
+            default_role,
+        } => rst::RstParser::new(primary_domain, default_role, cursor_position).parse(text, desc),
+    };
+
+    sort_result(&mut items);
+
+    items
+}

--- a/crates/emmylua_parser_desc/src/md.rs
+++ b/crates/emmylua_parser_desc/src/md.rs
@@ -1,0 +1,1918 @@
+use crate::rst::{eat_rst_flag_body, process_inline_code, process_lua_ref};
+use crate::util::{
+    BacktrackPoint, ResultContainer, desc_to_lines, is_blank, is_code_directive, is_lua_role,
+    is_punct, is_ws, process_lua_code,
+};
+use crate::{DescItem, DescItemKind, LuaDescParser};
+use emmylua_parser::{LexerConfig, LuaLexer, LuaLexerState, Reader, SourceRange};
+use emmylua_parser::{LuaAstNode, LuaDocDescription};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+pub struct MdParser {
+    states: Rc<RefCell<Vec<State>>>,
+    inline_state: Vec<InlineState>,
+    primary_domain: Option<String>,
+    enable_myst: bool,
+    results: Vec<DescItem>,
+    cursor_position: Option<usize>,
+    lua_lexer_state: LuaLexerState,
+}
+
+#[derive(Copy, Clone)]
+enum State {
+    Quote {
+        scope_start: usize,
+    },
+    Indented {
+        indent: usize,
+        scope_start: usize,
+    },
+    Code {
+        scope_start: usize,
+    },
+    FencedCode {
+        n_fences: usize,
+        fence: char,
+        is_lua: bool,
+        scope_start: usize,
+    },
+    FencedDirectiveParams {
+        n_fences: usize,
+        fence: char,
+        is_code: bool,
+        is_lua: bool,
+        scope_start: usize,
+    },
+    FencedDirectiveParamsLong {
+        n_fences: usize,
+        fence: char,
+        is_code: bool,
+        is_lua: bool,
+        scope_start: usize,
+    },
+    FencedDirectiveBody {
+        n_fences: usize,
+        fence: char,
+        scope_start: usize,
+    },
+    Math {
+        scope_start: usize,
+    },
+}
+
+enum InlineState {
+    Em(char, SourceRange, usize),
+    Strong(char, SourceRange, usize),
+    Both(char, SourceRange, usize),
+}
+
+impl LuaDescParser for MdParser {
+    fn parse(&mut self, text: &str, desc: LuaDocDescription) -> Vec<DescItem> {
+        assert!(self.results.is_empty());
+
+        self.states.borrow_mut().clear();
+        self.inline_state.clear();
+
+        let desc_end = desc.get_range().end().into();
+
+        for range in desc_to_lines(text, desc, self.cursor_position) {
+            // Process line.
+            let line = &text[range.start_offset..range.end_offset()];
+            self.process_line(&mut Reader::new_with_range(line, range));
+        }
+
+        self.flush_state(
+            &mut self.states.clone().borrow_mut(),
+            0,
+            &mut Reader::new_with_range("", SourceRange::new(desc_end, 0)),
+        );
+
+        std::mem::take(&mut self.results)
+    }
+}
+
+impl ResultContainer for MdParser {
+    fn results(&self) -> &Vec<DescItem> {
+        &self.results
+    }
+
+    fn results_mut(&mut self) -> &mut Vec<DescItem> {
+        &mut self.results
+    }
+
+    fn cursor_position(&self) -> Option<usize> {
+        self.cursor_position
+    }
+}
+
+impl MdParser {
+    pub fn new(cursor_position: Option<usize>) -> Self {
+        Self {
+            states: Default::default(),
+            inline_state: Default::default(),
+            primary_domain: None,
+            enable_myst: false,
+            results: Vec::new(),
+            cursor_position,
+            lua_lexer_state: LuaLexerState::Normal,
+        }
+    }
+
+    pub fn new_myst(primary_domain: Option<String>, cursor_position: Option<usize>) -> Self {
+        Self {
+            states: Default::default(),
+            inline_state: Default::default(),
+            primary_domain,
+            enable_myst: true,
+            results: Vec::new(),
+            cursor_position,
+            lua_lexer_state: LuaLexerState::Normal,
+        }
+    }
+
+    fn process_line(&mut self, reader: &mut Reader) {
+        // First, find out which blocks are still present
+        // and which finished.
+        let mut last_state = 0;
+        let states = self.states.clone();
+        let mut states = states.borrow_mut();
+        for (i, &state) in states.iter().enumerate() {
+            match state {
+                State::Quote { .. } => {
+                    if self.try_process_quote_continuation(reader).is_ok() {
+                        // Continue with nested states.
+                    } else {
+                        break;
+                    }
+                }
+                State::Indented { indent, .. } => {
+                    if self.try_process_indented(reader, indent).is_ok() {
+                        // Continue with nested states.
+                    } else {
+                        break;
+                    }
+                }
+                State::Code { .. } => {
+                    if self.try_process_code(reader).is_ok() {
+                        return;
+                    } else {
+                        break;
+                    }
+                }
+                State::FencedCode {
+                    n_fences,
+                    fence,
+                    is_lua,
+                    ..
+                } => {
+                    if self.try_process_fence_end(reader, n_fences, fence).is_ok() {
+                        self.flush_state(&mut states, i, reader);
+                        return;
+                    } else {
+                        self.process_code_line(reader, is_lua);
+                        return;
+                    }
+                }
+                State::FencedDirectiveParams {
+                    n_fences,
+                    fence,
+                    is_code,
+                    is_lua,
+                    scope_start,
+                } => {
+                    if self.try_process_fence_end(reader, n_fences, fence).is_ok() {
+                        self.flush_state(&mut states, i, reader);
+                        return;
+                    } else if self.try_process_fence_long_params_marker(reader).is_ok() {
+                        self.flush_state(&mut states, i + 1, reader);
+                        states.pop();
+                        states.push(State::FencedDirectiveParamsLong {
+                            n_fences,
+                            fence,
+                            is_code,
+                            is_lua,
+                            scope_start,
+                        });
+                        return;
+                    }
+                    if self.try_process_fence_short_param(reader).is_ok() {
+                        return;
+                    } else if is_code {
+                        self.flush_state(&mut states, i + 1, reader);
+                        states.pop();
+                        states.push(State::FencedCode {
+                            n_fences,
+                            fence,
+                            is_lua,
+                            scope_start,
+                        });
+                        self.process_code_line(reader, is_lua);
+                        return;
+                    } else {
+                        self.flush_state(&mut states, i + 1, reader);
+                        states.pop();
+                        states.push(State::FencedDirectiveBody {
+                            n_fences,
+                            fence,
+                            scope_start,
+                        });
+                        last_state = i + 1;
+                        break;
+                    }
+                }
+                State::FencedDirectiveParamsLong {
+                    n_fences,
+                    fence,
+                    is_code,
+                    is_lua,
+                    scope_start,
+                } => {
+                    if self.try_process_fence_end(reader, n_fences, fence).is_ok() {
+                        self.flush_state(&mut states, i, reader);
+                        return;
+                    } else if self.try_process_fence_long_params_marker(reader).is_ok() {
+                        self.flush_state(&mut states, i + 1, reader);
+                        states.pop();
+                        if is_code {
+                            states.push(State::FencedCode {
+                                n_fences,
+                                fence,
+                                is_lua,
+                                scope_start,
+                            });
+                        } else {
+                            states.push(State::FencedDirectiveBody {
+                                n_fences,
+                                fence,
+                                scope_start,
+                            });
+                        }
+                        return;
+                    } else {
+                        self.process_code_line(reader, is_lua);
+                        return;
+                    }
+                }
+                State::FencedDirectiveBody {
+                    n_fences, fence, ..
+                } => {
+                    if self.try_process_fence_end(reader, n_fences, fence).is_ok() {
+                        self.flush_state(&mut states, i, reader);
+                        return;
+                    } else {
+                        // Continue with nested states.
+                    }
+                }
+                State::Math { .. } => {
+                    if self.try_process_math_end(reader).is_ok() {
+                        self.flush_state(&mut states, i, reader);
+                        return;
+                    } else {
+                        reader.eat_till_end();
+                        self.emit(reader, DescItemKind::CodeBlock);
+                        return;
+                    }
+                }
+            }
+
+            last_state = i + 1;
+        }
+
+        drop(states);
+
+        self.flush_state(&mut self.states.clone().borrow_mut(), last_state, reader);
+
+        // Second, handle the rest of the line. Each iteration will add a new block
+        // onto the state stack. The final iteration will handle inline content.
+        loop {
+            if !self.try_start_new_block(reader) {
+                // No more blocks to start.
+                break;
+            }
+        }
+    }
+
+    #[must_use]
+    fn try_start_new_block(&mut self, reader: &mut Reader) -> bool {
+        const HAS_MORE_CONTENT: bool = true;
+        const NO_MORE_CONTENT: bool = false;
+
+        if is_blank(reader.tail_text()) {
+            // Just an empty line, nothing to do here.
+            reader.eat_till_end();
+            reader.reset_buff();
+            return NO_MORE_CONTENT;
+        }
+
+        // All markdown blocks can start with at most 3 whitespaces.
+        // 4 whitespaces start a code block.
+        let mut indent = reader.consume_n_times(is_ws, 3);
+
+        match reader.current_char() {
+            // Thematic break or list start.
+            '-' | '_' | '*' | '+' => {
+                if self.try_process_thematic_break(reader).is_ok() {
+                    return NO_MORE_CONTENT;
+                } else if let Ok((indent_more, scope_start)) = self.try_process_list(reader) {
+                    indent += indent_more;
+                    self.states.borrow_mut().push(State::Indented {
+                        indent,
+                        scope_start,
+                    });
+                    return HAS_MORE_CONTENT;
+                } else {
+                    // This is a normal text, continue to inline parsing.
+                }
+            }
+            // Heading.
+            '#' => {
+                let scope_start = reader.current_range().start_offset;
+
+                reader.reset_buff();
+                reader.eat_when('#');
+                self.emit(reader, DescItemKind::Markup);
+                self.process_inline_content(reader);
+
+                let scope_end = reader.current_range().end_offset();
+                self.emit_range(
+                    SourceRange::from_start_end(scope_start, scope_end),
+                    DescItemKind::Scope,
+                );
+
+                return NO_MORE_CONTENT;
+            }
+            // Fenced code.
+            '`' | '~' | ':' => {
+                if let Ok((n_fences, fence, scope_start)) = self.try_process_fence_start(reader) {
+                    if let Ok((dir_name, dir_args)) = self.try_process_fence_directive_name(reader)
+                    {
+                        // This is a directive.
+                        let is_code = is_code_directive(dir_name);
+                        let is_lua = is_code && dir_args.trim() == "lua";
+                        self.states.borrow_mut().push(State::FencedDirectiveParams {
+                            n_fences,
+                            fence,
+                            is_code,
+                            is_lua,
+                            scope_start,
+                        });
+                    } else {
+                        // This is a code block.
+                        reader.eat_till_end();
+                        let is_lua = reader.current_text().trim() == "lua";
+                        self.emit(reader, DescItemKind::CodeBlock);
+                        self.states.borrow_mut().push(State::FencedCode {
+                            n_fences,
+                            fence,
+                            is_lua,
+                            scope_start,
+                        });
+                    }
+                    return NO_MORE_CONTENT;
+                } else {
+                    // This is a normal text, continue to inline parsing.
+                }
+            }
+            // Indented code.
+            ' ' | '\t' => {
+                let scope_start = reader.current_range().start_offset;
+                reader.bump();
+                reader.reset_buff();
+                reader.eat_till_end();
+                self.emit(reader, DescItemKind::CodeBlock);
+                self.states.borrow_mut().push(State::Code { scope_start });
+                return NO_MORE_CONTENT;
+            }
+            // Numbered list.
+            '0'..='9' => {
+                if let Ok((indent_more, scope_start)) = self.try_process_list(reader) {
+                    indent += indent_more;
+                    self.states.borrow_mut().push(State::Indented {
+                        indent,
+                        scope_start,
+                    });
+                    return HAS_MORE_CONTENT;
+                } else {
+                    // This is a normal text, continue to inline parsing.
+                }
+            }
+            // Quote.
+            '>' => {
+                if let Ok(scope_start) = self.try_process_quote(reader) {
+                    self.states.borrow_mut().push(State::Quote { scope_start });
+                    return HAS_MORE_CONTENT;
+                } else {
+                    // This is a normal text, continue to inline parsing.
+                }
+            }
+            // Math block.
+            '$' if self.enable_myst => {
+                if let Ok(scope_start) = self.try_process_math(reader) {
+                    self.states.borrow_mut().push(State::Math { scope_start });
+                    return NO_MORE_CONTENT;
+                } else {
+                    // This is a normal text, continue to inline parsing.
+                }
+            }
+            // Maybe a link anchor.
+            '[' => {
+                let bt = BacktrackPoint::new(self, reader);
+
+                let scope_start = reader.current_range().start_offset;
+
+                if Self::eat_link_title(reader)
+                    && reader.current_char() == ':'
+                    && is_ws(reader.next_char())
+                {
+                    self.emit(reader, DescItemKind::Link);
+                    reader.bump();
+                    self.emit(reader, DescItemKind::Markup);
+                    reader.eat_while(is_ws);
+                    reader.reset_buff();
+                    reader.eat_till_end();
+                    self.emit(reader, DescItemKind::Link);
+
+                    let scope_end = reader.current_range().end_offset();
+                    self.emit_range(
+                        SourceRange::from_start_end(scope_start, scope_end),
+                        DescItemKind::Scope,
+                    );
+
+                    bt.commit(self, reader);
+                    return NO_MORE_CONTENT;
+                } else {
+                    bt.rollback(self, reader);
+                }
+            }
+            // Normal text.
+            _ => {
+                // Continue to inline parsing.
+            }
+        }
+
+        // Didn't detect start of any nested block. Parse the rest of the line
+        // as an inline context.
+        reader.reset_buff();
+        self.process_inline_content(reader);
+        NO_MORE_CONTENT
+    }
+
+    fn try_process_thematic_break<'a>(&mut self, reader: &mut Reader<'a>) -> Result<(), ()> {
+        // Line that consists of three or more of the same symbol (`-`, `*`, or `_`),
+        // possibly separated by spaces. I.e.: `" - - - "`.
+
+        let bt = BacktrackPoint::new(self, reader);
+
+        let scope_start = reader.current_range().start_offset;
+
+        reader.eat_while(is_ws);
+        reader.reset_buff();
+
+        let first_char = reader.current_char();
+        if !matches!(first_char, '-' | '*' | '_') {
+            bt.rollback(self, reader);
+            return Err(());
+        } else {
+            reader.bump();
+            self.emit(reader, DescItemKind::Markup);
+        }
+
+        let mut n_marks = 1;
+        loop {
+            reader.eat_while(is_ws);
+            reader.reset_buff();
+            if reader.is_eof() {
+                break;
+            } else if reader.current_char() == first_char {
+                reader.bump();
+                self.emit(reader, DescItemKind::Markup);
+                n_marks += 1;
+            } else {
+                bt.rollback(self, reader);
+                return Err(());
+            }
+        }
+
+        if n_marks >= 3 {
+            reader.eat_till_end();
+            reader.reset_buff();
+
+            let scope_end = reader.current_range().end_offset();
+            self.emit_range(
+                SourceRange::from_start_end(scope_start, scope_end),
+                DescItemKind::Scope,
+            );
+
+            bt.commit(self, reader);
+            Ok(())
+        } else {
+            bt.rollback(self, reader);
+            Err(())
+        }
+    }
+
+    fn try_process_quote<'a>(&mut self, reader: &mut Reader<'a>) -> Result<usize, ()> {
+        // Quote start, i.e. `"   > text..."`.
+
+        let bt = BacktrackPoint::new(self, reader);
+        let scope_start = reader.current_range().start_offset;
+
+        match self.try_process_quote_continuation(reader) {
+            Ok(()) => {
+                bt.commit(self, reader);
+                Ok(scope_start)
+            }
+            Err(()) => {
+                bt.rollback(self, reader);
+                Err(())
+            }
+        }
+    }
+
+    fn try_process_quote_continuation<'a>(&mut self, reader: &mut Reader<'a>) -> Result<(), ()> {
+        // Quote start, i.e. `"   > text..."`.
+
+        let bt = BacktrackPoint::new(self, reader);
+
+        reader.consume_n_times(is_ws, 3);
+
+        if reader.current_char() == '>' {
+            reader.reset_buff();
+            reader.bump();
+            self.emit(reader, DescItemKind::Markup);
+            reader.consume_n_times(is_ws, 1);
+            reader.reset_buff();
+
+            bt.commit(self, reader);
+            Ok(())
+        } else {
+            bt.rollback(self, reader);
+            Err(())
+        }
+    }
+
+    fn try_process_indented<'a>(
+        &mut self,
+        reader: &mut Reader<'a>,
+        indent: usize,
+    ) -> Result<(), ()> {
+        // Block indented by at least `indent` spaces. This continues a list,
+        // i.e.:
+        //
+        //     - list
+        //       list continuation, indented by at least 2 spaces.
+
+        let bt = BacktrackPoint::new(self, reader);
+
+        let found_indent = reader.consume_n_times(is_ws, indent);
+        if reader.is_eof() || found_indent == indent {
+            reader.reset_buff();
+            bt.commit(self, reader);
+            Ok(())
+        } else {
+            bt.rollback(self, reader);
+            Err(())
+        }
+    }
+
+    fn try_process_code<'a>(&mut self, reader: &mut Reader<'a>) -> Result<(), ()> {
+        // Block indented by at least 4 spaces, i.e. `"    code"`.
+        let bt = BacktrackPoint::new(self, reader);
+
+        let found_indent = reader.consume_n_times(is_ws, 4);
+        if found_indent == 4 || reader.is_eof() {
+            reader.reset_buff();
+            self.process_code_line(reader, false);
+            bt.commit(self, reader);
+            Ok(())
+        } else {
+            bt.rollback(self, reader);
+            Err(())
+        }
+    }
+
+    fn try_process_list<'a>(&mut self, reader: &mut Reader<'a>) -> Result<(usize, usize), ()> {
+        // Either numbered or non-numbered list start.
+        let bt = BacktrackPoint::new(self, reader);
+        let scope_start = reader.current_range().start_offset;
+
+        let mut indent = reader.consume_n_times(is_ws, 3);
+        match reader.current_char() {
+            '-' | '*' | '+' => {
+                indent += 2;
+                reader.reset_buff();
+                reader.bump();
+                self.emit(reader, DescItemKind::Markup);
+                if reader.is_eof() {
+                    bt.commit(self, reader);
+                    return Ok((indent, scope_start));
+                } else if !is_ws(reader.current_char()) {
+                    bt.rollback(self, reader);
+                    return Err(());
+                }
+                reader.bump();
+            }
+            '0'..='9' => {
+                reader.reset_buff();
+                indent += reader.eat_while(|c| c.is_ascii_digit()) + 2;
+                if !matches!(reader.current_char(), '.' | ')' | ':') {
+                    bt.rollback(self, reader);
+                    return Err(());
+                }
+                reader.bump();
+                self.emit(reader, DescItemKind::Markup);
+                if reader.is_eof() {
+                    bt.commit(self, reader);
+                    return Ok((indent, scope_start));
+                } else if !is_ws(reader.current_char()) {
+                    bt.rollback(self, reader);
+                    return Err(());
+                }
+                reader.bump();
+            }
+            _ => {
+                bt.rollback(self, reader);
+                return Err(());
+            }
+        }
+
+        let text = reader.tail_text();
+        if text.len() >= 4 && is_blank(&text[..4]) {
+            // List marker followed by a space, then 4 more spaces
+            // is parsed as a list marker followed by a space,
+            // then code block.
+            reader.reset_buff();
+            bt.commit(self, reader);
+            Ok((indent, scope_start))
+        } else {
+            // List marker followed by a space, then up to 3 more spaces
+            // is parsed as a list marker
+            indent += reader.eat_while(is_ws);
+            reader.reset_buff();
+            bt.commit(self, reader);
+            Ok((indent, scope_start))
+        }
+    }
+
+    fn try_process_fence_start<'a>(
+        &mut self,
+        reader: &mut Reader<'a>,
+    ) -> Result<(usize, char, usize), ()> {
+        // Start of a fenced block. MySt allows fenced blocks
+        // using colons, i.e.:
+        //
+        //     :::syntax
+        //     code
+        //     :::
+
+        let bt = BacktrackPoint::new(self, reader);
+        let scope_start = reader.current_range().start_offset;
+
+        reader.consume_n_times(is_ws, 3);
+        match reader.current_char() {
+            '`' => {
+                reader.reset_buff();
+                let n_fences = reader.eat_when('`');
+                if n_fences < 3 {
+                    bt.rollback(self, reader);
+                    return Err(());
+                }
+                if reader.tail_text().contains('`') {
+                    bt.rollback(self, reader);
+                    return Err(());
+                }
+                self.emit(reader, DescItemKind::Markup);
+
+                bt.commit(self, reader);
+                Ok((n_fences, '`', scope_start))
+            }
+            '~' => {
+                reader.reset_buff();
+                let n_fences = reader.eat_when('~');
+                if n_fences < 3 {
+                    bt.rollback(self, reader);
+                    return Err(());
+                }
+                self.emit(reader, DescItemKind::Markup);
+
+                bt.commit(self, reader);
+                Ok((n_fences, '~', scope_start))
+            }
+            ':' if self.enable_myst => {
+                reader.reset_buff();
+                let n_fences = reader.eat_when(':');
+                if n_fences < 3 {
+                    bt.rollback(self, reader);
+                    return Err(());
+                }
+                self.emit(reader, DescItemKind::Markup);
+
+                bt.commit(self, reader);
+                Ok((n_fences, ':', scope_start))
+            }
+            _ => {
+                bt.rollback(self, reader);
+                Err(())
+            }
+        }
+    }
+
+    fn try_process_fence_directive_name<'a>(
+        &mut self,
+        reader: &mut Reader<'a>,
+    ) -> Result<(&'a str, &'a str), ()> {
+        // MySt extension for embedding RST directives
+        // into markdown code blocks:
+        //
+        //     ```{dir_name} dir_args
+        //     :dir_short_param: dir_short_param_value
+        //     dir_body
+        //     ```
+
+        if !self.enable_myst {
+            return Err(());
+        }
+
+        let bt = BacktrackPoint::new(self, reader);
+
+        if reader.current_char() != '{' {
+            bt.rollback(self, reader);
+            return Err(());
+        }
+        reader.bump();
+        self.emit(reader, DescItemKind::Markup);
+        reader.eat_while(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | ':' | '+' | '_' | '-'));
+        if reader.current_char() != '}' {
+            bt.rollback(self, reader);
+            return Err(());
+        }
+        let dir_name = reader.current_text();
+        self.emit(reader, DescItemKind::Arg);
+        reader.bump();
+        self.emit(reader, DescItemKind::Markup);
+        reader.eat_while(is_ws);
+        reader.reset_buff();
+        reader.eat_till_end();
+        let dir_args = reader.current_text();
+        self.emit(reader, DescItemKind::CodeBlock);
+        bt.commit(self, reader);
+        Ok((dir_name, dir_args))
+    }
+
+    fn try_process_fence_short_param<'a>(&mut self, reader: &mut Reader<'a>) -> Result<(), ()> {
+        let bt = BacktrackPoint::new(self, reader);
+
+        reader.eat_while(is_ws);
+        if reader.current_char() != ':' {
+            bt.rollback(self, reader);
+            return Err(());
+        }
+        reader.reset_buff();
+        reader.bump();
+        self.emit(reader, DescItemKind::Markup);
+        eat_rst_flag_body(reader);
+        self.emit(reader, DescItemKind::Arg);
+        if reader.current_char() != ':' {
+            bt.rollback(self, reader);
+            return Err(());
+        }
+        reader.bump();
+        self.emit(reader, DescItemKind::Markup);
+        reader.eat_while(is_ws);
+        reader.reset_buff();
+        reader.eat_till_end();
+        self.emit(reader, DescItemKind::CodeBlock);
+        bt.commit(self, reader);
+        Ok(())
+    }
+
+    fn try_process_fence_long_params_marker<'a>(
+        &mut self,
+        reader: &mut Reader<'a>,
+    ) -> Result<(), ()> {
+        let bt = BacktrackPoint::new(self, reader);
+
+        reader.eat_while(is_ws);
+        if !reader.tail_text().starts_with("---") {
+            bt.rollback(self, reader);
+            return Err(());
+        }
+        if !is_blank(&reader.tail_text()[3..]) {
+            bt.rollback(self, reader);
+            return Err(());
+        }
+        reader.reset_buff();
+        reader.bump();
+        reader.bump();
+        reader.bump();
+        self.emit(reader, DescItemKind::Markup);
+        reader.eat_till_end();
+        reader.reset_buff();
+        bt.commit(self, reader);
+        Ok(())
+    }
+
+    fn try_process_fence_end<'a>(
+        &mut self,
+        reader: &mut Reader<'a>,
+        n_fences: usize,
+        fence: char,
+    ) -> Result<(), ()> {
+        let bt = BacktrackPoint::new(self, reader);
+
+        reader.consume_n_times(is_ws, 3);
+        reader.reset_buff();
+        if reader.eat_when(fence) != n_fences {
+            bt.rollback(self, reader);
+            return Err(());
+        }
+        if !is_blank(&reader.tail_text()) {
+            bt.rollback(self, reader);
+            return Err(());
+        }
+        self.emit(reader, DescItemKind::Markup);
+        reader.eat_till_end();
+        reader.reset_buff();
+
+        bt.commit(self, reader);
+        Ok(())
+    }
+
+    fn try_process_math<'a>(&mut self, reader: &mut Reader<'a>) -> Result<usize, ()> {
+        // MySt extension for LaTaX-like math markup:
+        //
+        //     $$
+        //     \frac{1}{2}
+        //     $$ (anchor)
+
+        if !self.enable_myst {
+            return Err(());
+        }
+
+        let bt = BacktrackPoint::new(self, reader);
+        let scope_start = reader.current_range().start_offset;
+
+        reader.consume_n_times(is_ws, 3);
+        if reader.current_char() == '$' && reader.next_char() == '$' {
+            reader.reset_buff();
+            reader.bump();
+            reader.bump();
+            if !is_blank(&reader.tail_text()) {
+                bt.rollback(self, reader);
+                return Err(());
+            }
+            self.emit(reader, DescItemKind::Markup);
+            reader.eat_till_end();
+            reader.reset_buff();
+
+            bt.commit(self, reader);
+            Ok(scope_start)
+        } else {
+            bt.rollback(self, reader);
+            Err(())
+        }
+    }
+
+    fn try_process_math_end<'a>(&mut self, reader: &mut Reader<'a>) -> Result<(), ()> {
+        // MySt extension for LaTaX-like math markup:
+        //
+        //     $$
+        //     \frac{1}{2}
+        //     $$ (anchor)
+
+        if !self.enable_myst {
+            return Err(());
+        }
+
+        let bt = BacktrackPoint::new(self, reader);
+
+        reader.consume_n_times(is_ws, 3);
+        if reader.current_char() == '$' && reader.next_char() == '$' {
+            reader.reset_buff();
+            reader.bump();
+            reader.bump();
+            self.emit(reader, DescItemKind::Markup);
+            reader.eat_while(is_ws);
+            reader.reset_buff();
+            if reader.current_char() == '(' {
+                reader.bump();
+                reader.eat_while(|c| {
+                    c.is_ascii_alphanumeric() || matches!(c, '.' | ':' | '+' | '_' | '-')
+                });
+                if reader.current_char() != ')' {
+                    bt.rollback(self, reader);
+                    return Err(());
+                }
+                reader.bump();
+                self.emit(reader, DescItemKind::Arg);
+            }
+            reader.eat_till_end();
+            reader.reset_buff();
+
+            bt.commit(self, reader);
+            Ok(())
+        } else {
+            bt.rollback(self, reader);
+            Err(())
+        }
+    }
+
+    fn process_code_line(&mut self, reader: &mut Reader, is_lua: bool) {
+        if self.cursor_position.is_some() {
+            // No point in calculating this when all we care
+            // is what's under the user's cursor.
+            return;
+        }
+
+        reader.eat_till_end();
+        if is_lua && self.cursor_position.is_none() {
+            let line_range = reader.current_range();
+            let mut lexer = LuaLexer::new_with_state(
+                reader.reset_buff_into_sub_reader(),
+                self.lua_lexer_state,
+                LexerConfig::default(),
+                None,
+            );
+            let lua_tokens = lexer.tokenize();
+            self.lua_lexer_state = lexer.get_state();
+
+            process_lua_code(self, line_range, lua_tokens);
+        } else {
+            self.emit(reader, DescItemKind::CodeBlock);
+        }
+    }
+
+    fn process_inline_content(&mut self, reader: &mut Reader) {
+        assert!(self.inline_state.is_empty());
+
+        if self
+            .cursor_position
+            .is_some_and(|offset| !reader.tail_range().contains_inclusive(offset))
+        {
+            // No point in calculating this when all we care
+            // is what's under the user's cursor.
+            return;
+        }
+
+        while !reader.is_eof() {
+            match reader.current_char() {
+                '\\' => {
+                    reader.bump();
+                    reader.bump();
+                }
+                '`' => {
+                    let bt = BacktrackPoint::new(self, reader);
+
+                    let prev = reader.reset_buff_into_sub_reader();
+                    let after_prev = reader.current_char();
+
+                    if !Self::eat_inline_code(reader, None) {
+                        bt.rollback(self, reader);
+                        reader.bump();
+                        // guard.backtrack(reader);
+                        continue;
+                    }
+
+                    self.process_inline_content_style(prev, after_prev);
+                    process_inline_code(
+                        self,
+                        reader.reset_buff_into_sub_reader(),
+                        DescItemKind::Code,
+                    );
+
+                    bt.commit(self, reader);
+                }
+                '$' if self.enable_myst => {
+                    let bt = BacktrackPoint::new(self, reader);
+
+                    let prev = reader.reset_buff_into_sub_reader();
+                    let after_prev = reader.current_char();
+
+                    if !Self::eat_inline_math(reader) {
+                        bt.rollback(self, reader);
+                        reader.bump();
+                        // guard.backtrack(reader);
+                        continue;
+                    }
+
+                    self.process_inline_content_style(prev, after_prev);
+
+                    self.process_inline_math(reader.reset_buff_into_sub_reader());
+
+                    bt.commit(self, reader);
+                }
+                '[' => {
+                    let bt = BacktrackPoint::new(self, reader);
+
+                    let prev = reader.reset_buff_into_sub_reader();
+                    let after_prev = reader.current_char();
+
+                    if !Self::eat_link_title(reader) {
+                        bt.rollback(self, reader);
+                        reader.bump();
+                        // guard.backtrack(reader);
+                        continue;
+                    }
+
+                    let title_range = reader.current_range();
+                    reader.reset_buff();
+
+                    if reader.current_char() == '(' && !Self::eat_link_url(reader) {
+                        bt.rollback(self, reader);
+                        reader.bump();
+                        // guard.backtrack(reader);
+                        continue;
+                    }
+
+                    let url_range = reader.current_range();
+                    reader.reset_buff();
+
+                    self.process_inline_content_style(prev, after_prev);
+
+                    self.emit_range(title_range, DescItemKind::Link);
+                    self.emit_range(url_range, DescItemKind::Link);
+
+                    bt.commit(self, reader);
+                }
+                '{' if self.enable_myst => {
+                    let bt = BacktrackPoint::new(self, reader);
+
+                    let prev = reader.reset_buff_into_sub_reader();
+                    let after_prev = reader.current_char();
+
+                    let Ok(role_text) = self.process_role_name(reader) else {
+                        bt.rollback(self, reader);
+                        reader.bump();
+                        // guard.backtrack(reader);
+                        continue;
+                    };
+
+                    if !Self::eat_inline_code(reader, self.cursor_position) {
+                        bt.rollback(self, reader);
+                        reader.bump();
+                        // guard.backtrack(reader);
+                        continue;
+                    }
+
+                    let code = reader.reset_buff_into_sub_reader();
+
+                    self.process_inline_content_style(prev, after_prev);
+
+                    let is_lua_ref = role_text.starts_with("lua:")
+                        || (self.primary_domain.as_deref() == Some("lua")
+                            && !role_text.contains(":")
+                            && is_lua_role(role_text));
+
+                    if is_lua_ref {
+                        process_lua_ref(self, code);
+                    } else {
+                        process_inline_code(self, code, DescItemKind::Code);
+                    }
+
+                    bt.commit(self, reader);
+                }
+                _ => {
+                    reader.bump();
+                }
+            }
+        }
+
+        if !reader.current_range().is_empty() {
+            self.process_inline_content_style(reader.reset_buff_into_sub_reader(), ' ');
+        }
+        self.inline_state.clear();
+    }
+
+    #[must_use]
+    fn eat_inline_code(reader: &mut Reader, cursor_position: Option<usize>) -> bool {
+        let n_backticks = reader.eat_when('`');
+        if n_backticks == 0 {
+            return false;
+        }
+        while !reader.is_eof() {
+            if reader.current_char() == '`' {
+                let found_n_backticks = reader.eat_when('`');
+                if found_n_backticks == n_backticks {
+                    return true;
+                }
+            } else {
+                reader.bump();
+            }
+        }
+
+        if let Some(cursor_position) = cursor_position {
+            reader.current_range().contains_inclusive(cursor_position)
+        } else {
+            false
+        }
+    }
+
+    #[must_use]
+    fn eat_inline_math(reader: &mut Reader) -> bool {
+        let n_marks = reader.eat_when('$');
+        if n_marks == 0 || n_marks > 2 {
+            return false;
+        }
+        while !reader.is_eof() {
+            if reader.current_char() == '$' {
+                let found_n_marks = reader.eat_when('$');
+                if found_n_marks == n_marks {
+                    return true;
+                }
+            } else {
+                reader.bump();
+            }
+        }
+
+        false
+    }
+
+    #[must_use]
+    fn eat_link_title(reader: &mut Reader) -> bool {
+        if reader.current_char() != '[' {
+            return false;
+        }
+        reader.bump();
+
+        let mut depth = 1;
+
+        while !reader.is_eof() {
+            match reader.current_char() {
+                '[' => {
+                    depth += 1;
+                    reader.bump();
+                }
+                ']' => {
+                    depth -= 1;
+                    reader.bump();
+                    if depth == 0 {
+                        return true;
+                    }
+                }
+                '\\' => {
+                    reader.bump();
+                    reader.bump();
+                }
+                '`' => {
+                    let prev_reader = reader.clone();
+                    if !Self::eat_inline_code(reader, None) {
+                        *reader = prev_reader;
+                        reader.bump();
+                    }
+                }
+                '$' => {
+                    let prev_reader = reader.clone();
+                    if !Self::eat_inline_math(reader) {
+                        *reader = prev_reader;
+                        reader.bump();
+                    }
+                }
+                _ => reader.bump(),
+            }
+        }
+
+        false
+    }
+
+    #[must_use]
+    fn eat_link_url(reader: &mut Reader) -> bool {
+        if reader.current_char() != '(' {
+            return false;
+        }
+        reader.bump();
+
+        if reader.current_char() == '<' {
+            while !reader.is_eof() {
+                if reader.current_char() == '>' && reader.next_char() == ')' {
+                    reader.bump();
+                    reader.bump();
+                    return true;
+                } else if reader.current_char() == '\\' {
+                    reader.bump();
+                    reader.bump();
+                } else {
+                    reader.bump();
+                }
+            }
+        } else {
+            let mut depth = 1;
+
+            while !reader.is_eof() {
+                match reader.current_char() {
+                    '(' => {
+                        depth += 1;
+                        reader.bump();
+                    }
+                    ')' => {
+                        depth -= 1;
+                        reader.bump();
+                        if depth == 0 {
+                            return true;
+                        }
+                    }
+                    '\\' => {
+                        reader.bump();
+                        reader.bump();
+                    }
+                    ' ' | '\t' => {
+                        return false;
+                    }
+                    _ => reader.bump(),
+                }
+            }
+        }
+
+        false
+    }
+
+    fn process_inline_math(&mut self, mut reader: Reader) {
+        let n_backticks = reader.eat_when('$');
+        self.emit(&mut reader, DescItemKind::Markup);
+        while reader.tail_range().length > n_backticks {
+            reader.bump();
+        }
+        self.emit(&mut reader, DescItemKind::Code);
+        reader.eat_till_end();
+        self.emit(&mut reader, DescItemKind::Markup);
+    }
+
+    fn process_role_name<'a>(&mut self, reader: &mut Reader<'a>) -> Result<&'a str, ()> {
+        if reader.current_char() != '{' {
+            return Err(());
+        }
+        reader.bump();
+        self.emit(reader, DescItemKind::Markup);
+        reader.eat_while(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | ':' | '+' | '_' | '-'));
+        if reader.current_char() == '}' {
+            let role_text = reader.current_text();
+            self.emit(reader, DescItemKind::Arg);
+            reader.bump();
+            self.emit(reader, DescItemKind::Markup);
+            Ok(role_text)
+        } else {
+            Err(())
+        }
+    }
+
+    fn process_inline_content_style(&mut self, mut reader: Reader, char_after: char) {
+        if self.cursor_position.is_some() {
+            // No point in calculating this when all we care
+            // is what's under the user's cursor.
+            return;
+        }
+
+        let char_after = if char_after == '\0' { ' ' } else { char_after };
+        while !reader.is_eof() {
+            match reader.current_char() {
+                '\\' => {
+                    reader.reset_buff();
+                    reader.bump();
+                    reader.bump();
+                    self.emit(&mut reader, DescItemKind::Markup);
+                }
+                ch @ '*' | ch @ '_' => {
+                    reader.reset_buff();
+
+                    let mut left_char = reader.prev_char();
+                    let n_chars = reader.eat_when(ch);
+                    let mut right_char = reader.current_char();
+
+                    if left_char == '\0' {
+                        left_char = ' ';
+                    }
+                    if right_char == '\0' {
+                        right_char = char_after;
+                    }
+
+                    let left_is_punct = is_punct(left_char);
+                    let left_is_ws = left_char.is_whitespace();
+                    let right_is_punct = is_punct(left_char);
+                    let right_is_ws = right_char.is_whitespace();
+
+                    let is_left_flanking =
+                        !right_is_ws && (!right_is_punct || (left_is_ws || left_is_punct));
+                    let is_right_flanking =
+                        !left_is_ws && (!left_is_punct || (right_is_ws || right_is_punct));
+
+                    let can_start_highlight;
+                    let can_end_highlight;
+                    if ch == '*' {
+                        can_start_highlight = is_left_flanking;
+                        can_end_highlight = is_right_flanking;
+                    } else {
+                        can_start_highlight =
+                            is_left_flanking && (!is_right_flanking || left_is_punct);
+                        can_end_highlight =
+                            is_right_flanking && (!is_left_flanking || right_is_punct);
+                    }
+
+                    if can_start_highlight && can_end_highlight {
+                        if self.has_highlight(ch, n_chars) {
+                            self.end_highlight(ch, n_chars, &mut reader);
+                        } else {
+                            self.start_highlight(ch, n_chars, &mut reader);
+                        }
+                    } else if can_start_highlight {
+                        self.start_highlight(ch, n_chars, &mut reader);
+                    } else if can_end_highlight {
+                        self.end_highlight(ch, n_chars, &mut reader);
+                    }
+                }
+                _ => {
+                    reader.bump();
+                }
+            }
+        }
+
+        reader.reset_buff();
+    }
+
+    fn flush_state(&mut self, states: &mut Vec<State>, end: usize, reader: &mut Reader) {
+        for state in states.drain(end..).rev() {
+            let scope_start = match state {
+                State::Quote { scope_start, .. } => scope_start,
+                State::Indented { scope_start, .. } => scope_start,
+                State::Code { scope_start, .. } => scope_start,
+                State::FencedCode { scope_start, .. } => scope_start,
+                State::FencedDirectiveParams { scope_start, .. } => scope_start,
+                State::FencedDirectiveParamsLong { scope_start, .. } => scope_start,
+                State::FencedDirectiveBody { scope_start, .. } => scope_start,
+                State::Math { scope_start, .. } => scope_start,
+            };
+
+            self.lua_lexer_state = LuaLexerState::Normal;
+
+            let scope_end = reader.current_range().end_offset();
+            self.emit_range(
+                SourceRange::from_start_end(scope_start, scope_end),
+                DescItemKind::Scope,
+            );
+        }
+    }
+
+    fn has_highlight(&mut self, r_ch: char, r_n_chars: usize) -> bool {
+        match self.inline_state.last() {
+            Some(&InlineState::Em(ch, ..)) => ch == r_ch && r_n_chars == 1,
+            Some(&InlineState::Strong(ch, ..)) => ch == r_ch && r_n_chars == 2,
+            Some(&InlineState::Both(ch, ..)) => ch == r_ch,
+            _ => false,
+        }
+    }
+
+    fn start_highlight(&mut self, r_ch: char, r_n_chars: usize, reader: &mut Reader) {
+        match r_n_chars {
+            0 => {}
+            1 => self.inline_state.push(InlineState::Em(
+                r_ch,
+                reader.current_range(),
+                reader.current_range().start_offset,
+            )),
+            2 => self.inline_state.push(InlineState::Strong(
+                r_ch,
+                reader.current_range(),
+                reader.current_range().start_offset,
+            )),
+            _ => self.inline_state.push(InlineState::Both(
+                r_ch,
+                reader.current_range(),
+                reader.current_range().start_offset,
+            )),
+        }
+        reader.reset_buff();
+    }
+
+    fn end_highlight(&mut self, r_ch: char, mut r_n_chars: usize, reader: &mut Reader) {
+        while r_n_chars > 0 {
+            match self.inline_state.last() {
+                Some(InlineState::Em(ch, ..)) => {
+                    if ch == &r_ch && (r_n_chars == 1 || r_n_chars >= 3) {
+                        let Some(InlineState::Em(_, start_markup_range, scope_start)) =
+                            self.inline_state.pop()
+                        else {
+                            unreachable!();
+                        };
+
+                        let scope_end = reader.current_range().end_offset();
+                        self.emit_range(
+                            SourceRange::from_start_end(scope_start, scope_end),
+                            DescItemKind::Em,
+                        );
+                        self.emit_range(start_markup_range, DescItemKind::Markup);
+                        self.emit(reader, DescItemKind::Markup);
+
+                        r_n_chars -= 1;
+                    } else {
+                        break;
+                    }
+                }
+                Some(InlineState::Strong(ch, ..)) => {
+                    if ch == &r_ch && r_n_chars >= 2 {
+                        let Some(InlineState::Strong(_, start_markup_range, scope_start)) =
+                            self.inline_state.pop()
+                        else {
+                            unreachable!();
+                        };
+
+                        let scope_end = reader.current_range().end_offset();
+                        self.emit_range(
+                            SourceRange::from_start_end(scope_start, scope_end),
+                            DescItemKind::Strong,
+                        );
+                        self.emit_range(start_markup_range, DescItemKind::Markup);
+                        self.emit(reader, DescItemKind::Markup);
+
+                        r_n_chars -= 2;
+                    } else {
+                        break;
+                    }
+                }
+                Some(InlineState::Both(ch, ..)) => {
+                    if ch == &r_ch {
+                        let Some(InlineState::Both(_, start_markup_range, scope_start)) =
+                            self.inline_state.pop()
+                        else {
+                            unreachable!();
+                        };
+
+                        let scope_end = reader.current_range().end_offset();
+                        self.emit_range(
+                            SourceRange::from_start_end(scope_start, scope_end),
+                            DescItemKind::Em,
+                        );
+                        self.emit_range(
+                            SourceRange::from_start_end(scope_start, scope_end),
+                            DescItemKind::Strong,
+                        );
+                        self.emit_range(start_markup_range, DescItemKind::Markup);
+                        self.emit(reader, DescItemKind::Markup);
+
+                        if r_n_chars == 1 {
+                            self.start_highlight(r_ch, 2, reader);
+                            r_n_chars = 0;
+                        } else if r_n_chars == 2 {
+                            self.start_highlight(r_ch, 1, reader);
+                            r_n_chars = 0;
+                        } else {
+                            r_n_chars -= 3;
+                        }
+                    } else {
+                        break;
+                    }
+                }
+                _ => {
+                    break;
+                }
+            }
+        }
+        reader.reset_buff();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testlib::test;
+
+    #[test]
+    fn test_md() {
+        let code = r#"
+--- # Inline code
+---
+--- `code`
+--- `` code ` with ` backticks ``
+--- `code``with``backticks`
+--- `broken code
+--- [link]
+--- [link `with backticks]`]
+--- [link [with brackets] ]
+--- [link](explicit_href)
+--- [link](explicit()href)
+--- [link](<explicit)href>)
+--- Paragraph with `code`!
+--- Paragraph with [link]!
+--- \` escaped backtick
+--- *em* em*in*text
+--- _em_ em_in_text
+--- **strong** strong**in**text
+--- __strong__ strong__in__text
+--- broken *em
+--- broken em*
+--- broken **strong
+--- broken strong**
+--- ***both*** both***in***text
+--- ***both end* separately**
+--- ***both end** separately*
+--- *both **start separately***
+--- **both *start separately***
+--- *`foo`*
+---
+--- # Blocks
+---
+--- ## Thematic breaks
+---
+--- - - -
+--- _ _ _
+--- * * *
+--- - _ -
+---
+--- ## Lists
+---
+--- - List
+--- * List 2
+--- + List 3
+--- -Broken list
+---
+--- -    List with indented text
+---
+--- -     List with code
+---       Continuation
+---
+---       Continuation 2
+---
+--- -
+---   List that starts with empty string
+---
+---  Not list
+---
+---   -  not code
+---
+---         still not code
+---
+---     code
+---
+--- ## Numbered lists
+---
+--- 1. List
+--- 2: List
+--- 3) List
+---   Not list
+---
+--- ## Code
+---
+---     This is code
+---      This is also code
+---       function foo() end
+---
+--- ## Fenced code
+---
+--- ```syntax
+--- code
+--- ```
+--- not code
+--- ~~~syntax
+--- code
+--- ```
+--- still code
+--- ~~~
+---
+--- ````code with 4 fences
+--- ```
+--- ````
+---
+--- ```inline code```
+--- not code
+---
+--- ```lua
+--- function foo()
+---     local long_string = [[
+---         content
+---     ]]
+--- end
+--- ```
+---
+--- ## Quotes
+---
+--- > Quote
+--- > Continues
+---
+--- > Quote 2
+---
+--- ## Disabled MySt extensions
+---
+--- $$
+--- math
+--- $$
+---
+--- ```{directive}
+--- ```
+---
+--- ## Link anchor
+---
+--- [link]: https://example.com
+"#;
+        let expected = r#"
+--- <Scope><Markup>#</Markup> Inline code</Scope>
+---
+--- <Markup>`</Markup><Code>code</Code><Markup>`</Markup>
+--- <Markup>``</Markup><Code> code ` with ` backticks </Code><Markup>``</Markup>
+--- <Markup>`</Markup><Code>code``with``backticks</Code><Markup>`</Markup>
+--- `broken code
+--- <Link>[link]</Link>
+--- <Link>[link `with backticks]`]</Link>
+--- <Link>[link [with brackets] ]</Link>
+--- <Link>[link](explicit_href)</Link>
+--- <Link>[link](explicit()href)</Link>
+--- <Link>[link](<explicit)href>)</Link>
+--- Paragraph with <Markup>`</Markup><Code>code</Code><Markup>`</Markup>!
+--- Paragraph with <Link>[link]</Link>!
+--- <Markup>\`</Markup> escaped backtick
+--- <Em><Markup>*</Markup>em<Markup>*</Markup></Em> em<Em><Markup>*</Markup>in<Markup>*</Markup></Em>text
+--- <Em><Markup>_</Markup>em<Markup>_</Markup></Em> em_in_text
+--- <Strong><Markup>**</Markup>strong<Markup>**</Markup></Strong> strong<Strong><Markup>**</Markup>in<Markup>**</Markup></Strong>text
+--- <Strong><Markup>__</Markup>strong<Markup>__</Markup></Strong> strong__in__text
+--- broken *em
+--- broken em*
+--- broken **strong
+--- broken strong**
+--- <Em><Strong><Markup>***</Markup>both<Markup>***</Markup></Strong></Em> both<Em><Strong><Markup>***</Markup>in<Markup>***</Markup></Strong></Em>text
+--- <Em><Strong><Markup>***</Markup>both end<Markup>*</Markup></Strong></Em><Strong> separately<Markup>**</Markup></Strong>
+--- <Em><Strong><Markup>***</Markup>both end<Markup>**</Markup></Strong></Em><Em> separately<Markup>*</Markup></Em>
+--- <Em><Markup>*</Markup>both <Strong><Markup>**</Markup>start separately<Markup>***</Markup></Strong></Em>
+--- <Strong><Markup>**</Markup>both <Em><Markup>*</Markup>start separately<Markup>***</Markup></Em></Strong>
+--- <Em><Markup>*</Markup><Markup>`</Markup><Code>foo</Code><Markup>`</Markup><Markup>*</Markup></Em>
+---
+--- <Scope><Markup>#</Markup> Blocks</Scope>
+---
+--- <Scope><Markup>##</Markup> Thematic breaks</Scope>
+---
+--- <Scope><Markup>-</Markup> <Markup>-</Markup> <Markup>-</Markup></Scope>
+--- <Scope><Markup>_</Markup> <Markup>_</Markup> <Markup>_</Markup></Scope>
+--- <Scope><Markup>*</Markup> <Markup>*</Markup> <Markup>*</Markup></Scope>
+--- <Scope><Markup>-</Markup> _ -
+---
+--- </Scope><Scope><Markup>##</Markup> Lists</Scope>
+---
+--- <Scope><Markup>-</Markup> List
+--- </Scope><Scope><Markup>*</Markup> List 2
+--- </Scope><Scope><Markup>+</Markup> List 3
+--- </Scope>-Broken list
+---
+--- <Scope><Markup>-</Markup>    List with indented text
+---
+--- </Scope><Scope><Markup>-</Markup> <Scope>    <CodeBlock>List with code</CodeBlock>
+---       <CodeBlock>Continuation</CodeBlock>
+---
+---       <CodeBlock>Continuation 2</CodeBlock>
+---
+--- </Scope></Scope><Scope><Markup>-</Markup>
+---   List that starts with empty string
+---
+--- </Scope> Not list
+---
+--- <Scope>  <Markup>-</Markup>  not code
+---
+---         still not code
+---
+--- </Scope><Scope>    <CodeBlock>code</CodeBlock>
+---
+--- </Scope><Scope><Markup>##</Markup> Numbered lists</Scope>
+---
+--- <Scope><Markup>1.</Markup> List
+--- </Scope><Scope><Markup>2:</Markup> List
+--- </Scope><Scope><Markup>3)</Markup> List
+--- </Scope>  Not list
+---
+--- <Scope><Markup>##</Markup> Code</Scope>
+---
+--- <Scope>    <CodeBlock>This is code</CodeBlock>
+---     <CodeBlock> This is also code</CodeBlock>
+---     <CodeBlock>  function foo() end</CodeBlock>
+---
+--- </Scope><Scope><Markup>##</Markup> Fenced code</Scope>
+---
+--- <Scope><Markup>```</Markup><CodeBlock>syntax</CodeBlock>
+--- <CodeBlock>code</CodeBlock>
+--- <Markup>```</Markup></Scope>
+--- not code
+--- <Scope><Markup>~~~</Markup><CodeBlock>syntax</CodeBlock>
+--- <CodeBlock>code</CodeBlock>
+--- <CodeBlock>```</CodeBlock>
+--- <CodeBlock>still code</CodeBlock>
+--- <Markup>~~~</Markup></Scope>
+---
+--- <Scope><Markup>````</Markup><CodeBlock>code with 4 fences</CodeBlock>
+--- <CodeBlock>```</CodeBlock>
+--- <Markup>````</Markup></Scope>
+---
+--- <Markup>```</Markup><Code>inline code</Code><Markup>```</Markup>
+--- not code
+---
+--- <Scope><Markup>```</Markup><CodeBlock>lua</CodeBlock>
+--- <CodeBlockHl(TkFunction)>function</CodeBlockHl(TkFunction)><CodeBlock> </CodeBlock><CodeBlockHl(TkName)>foo</CodeBlockHl(TkName)><CodeBlockHl(TkLeftParen)>(</CodeBlockHl(TkLeftParen)><CodeBlockHl(TkRightParen)>)</CodeBlockHl(TkRightParen)>
+--- <CodeBlock>    </CodeBlock><CodeBlockHl(TkLocal)>local</CodeBlockHl(TkLocal)><CodeBlock> </CodeBlock><CodeBlockHl(TkName)>long_string</CodeBlockHl(TkName)><CodeBlock> </CodeBlock><CodeBlockHl(TkAssign)>=</CodeBlockHl(TkAssign)><CodeBlock> </CodeBlock><CodeBlockHl(TkLongString)>[[</CodeBlockHl(TkLongString)>
+--- <CodeBlockHl(TkLongString)>        content</CodeBlockHl(TkLongString)>
+--- <CodeBlockHl(TkLongString)>    ]]</CodeBlockHl(TkLongString)>
+--- <CodeBlockHl(TkEnd)>end</CodeBlockHl(TkEnd)>
+--- <Markup>```</Markup></Scope>
+---
+--- <Scope><Markup>##</Markup> Quotes</Scope>
+---
+--- <Scope><Markup>></Markup> Quote
+--- <Markup>></Markup> Continues
+---</Scope>
+--- <Scope><Markup>></Markup> Quote 2
+---</Scope>
+--- <Scope><Markup>##</Markup> Disabled MySt extensions</Scope>
+---
+--- $$
+--- math
+--- $$
+---
+--- <Scope><Markup>```</Markup><CodeBlock>{directive}</CodeBlock>
+--- <Markup>```</Markup></Scope>
+---
+--- <Scope><Markup>##</Markup> Link anchor</Scope>
+---
+--- <Scope><Link>[link]</Link><Markup>:</Markup> <Link>https://example.com</Link></Scope>
+"#;
+
+        test(&code, Box::new(MdParser::new(None)), &expected);
+    }
+
+    #[test]
+    fn test_myst() {
+        let code = r#"
+--- # Inline
+---
+--- {lua:obj}`a.b.c`, {lua:obj}`~a.b.c`,
+--- {lua:obj}`<a.b.c>`, {lua:obj}`<~a.b.c>`, {lua:obj}`title <~a.b.c>`.
+--- $inline math$, text, $$more inline math$$, a simple $dollar,
+--- $$even more inline math$$.
+---
+--- # Directives
+---
+--- ```{directive}
+--- ```
+--- ```{directive}
+--- Body
+--- ```
+--- ```{directive}
+--- :param: value
+--- Body
+--- ```
+--- ```{directive}
+--- ---
+--- param
+--- ---
+--- Body
+--- ```
+--- ````{directive1}
+--- Body
+--- ```{directive2}
+--- Body
+--- ```
+--- Body
+--- ````
+--- ```{code-block} lua
+--- function foo() end
+--- ```
+---
+--- # Math
+---
+--- $$
+--- \frac{1}{2}
+--- $$
+---
+--- Text
+---
+--- $$
+--- \frac{1}{2}
+--- $$ (anchor)
+"#;
+
+        let expected = r#"
+--- <Scope><Markup>#</Markup> Inline</Scope>
+---
+--- <Markup>{</Markup><Arg>lua:obj</Arg><Markup>}`</Markup><Ref>a.b.c</Ref><Markup>`</Markup>, <Markup>{</Markup><Arg>lua:obj</Arg><Markup>}`</Markup><Code>~</Code><Ref>a.b.c</Ref><Markup>`</Markup>,
+--- <Markup>{</Markup><Arg>lua:obj</Arg><Markup>}`</Markup><Code><</Code><Ref>a.b.c</Ref><Code>></Code><Markup>`</Markup>, <Markup>{</Markup><Arg>lua:obj</Arg><Markup>}`</Markup><Code><~</Code><Ref>a.b.c</Ref><Code>></Code><Markup>`</Markup>, <Markup>{</Markup><Arg>lua:obj</Arg><Markup>}`</Markup><Code>title <~</Code><Ref>a.b.c</Ref><Code>></Code><Markup>`</Markup>.
+--- <Markup>$</Markup><Code>inline math</Code><Markup>$</Markup>, text, <Markup>$$</Markup><Code>more inline math</Code><Markup>$$</Markup>, a simple $dollar,
+--- <Markup>$$</Markup><Code>even more inline math</Code><Markup>$$</Markup>.
+---
+--- <Scope><Markup>#</Markup> Directives</Scope>
+---
+--- <Scope><Markup>```{</Markup><Arg>directive</Arg><Markup>}</Markup>
+--- <Markup>```</Markup></Scope>
+--- <Scope><Markup>```{</Markup><Arg>directive</Arg><Markup>}</Markup>
+--- Body
+--- <Markup>```</Markup></Scope>
+--- <Scope><Markup>```{</Markup><Arg>directive</Arg><Markup>}</Markup>
+--- <Markup>:</Markup><Arg>param</Arg><Markup>:</Markup> <CodeBlock>value</CodeBlock>
+--- Body
+--- <Markup>```</Markup></Scope>
+--- <Scope><Markup>```{</Markup><Arg>directive</Arg><Markup>}</Markup>
+--- <Markup>---</Markup>
+--- <CodeBlock>param</CodeBlock>
+--- <Markup>---</Markup>
+--- Body
+--- <Markup>```</Markup></Scope>
+--- <Scope><Markup>````{</Markup><Arg>directive1</Arg><Markup>}</Markup>
+--- Body
+--- <Scope><Markup>```{</Markup><Arg>directive2</Arg><Markup>}</Markup>
+--- Body
+--- <Markup>```</Markup></Scope>
+--- Body
+--- <Markup>````</Markup></Scope>
+--- <Scope><Markup>```{</Markup><Arg>code-block</Arg><Markup>}</Markup> <CodeBlock>lua</CodeBlock>
+--- <CodeBlockHl(TkFunction)>function</CodeBlockHl(TkFunction)><CodeBlock> </CodeBlock><CodeBlockHl(TkName)>foo</CodeBlockHl(TkName)><CodeBlockHl(TkLeftParen)>(</CodeBlockHl(TkLeftParen)><CodeBlockHl(TkRightParen)>)</CodeBlockHl(TkRightParen)><CodeBlock> </CodeBlock><CodeBlockHl(TkEnd)>end</CodeBlockHl(TkEnd)>
+--- <Markup>```</Markup></Scope>
+---
+--- <Scope><Markup>#</Markup> Math</Scope>
+---
+--- <Scope><Markup>$$</Markup>
+--- <CodeBlock>\frac{1}{2}</CodeBlock>
+--- <Markup>$$</Markup></Scope>
+---
+--- Text
+---
+--- <Scope><Markup>$$</Markup>
+--- <CodeBlock>\frac{1}{2}</CodeBlock>
+--- <Markup>$$</Markup> <Arg>(anchor)</Arg></Scope>
+"#;
+
+        test(&code, Box::new(MdParser::new_myst(None, None)), &expected);
+    }
+
+    #[test]
+    fn test_myst_primary_domain() {
+        let code = r#"--- See {obj}`ref`"#;
+
+        let expected = r#"
+            --- See <Markup>{</Markup><Arg>obj</Arg><Markup>}`</Markup><Ref>ref</Ref><Markup>`</Markup>
+        "#;
+
+        test(
+            &code,
+            Box::new(MdParser::new_myst(Some("lua".to_string()), None)),
+            &expected,
+        );
+    }
+
+    #[test]
+    fn test_myst_search_at_offset() {
+        let code = r#"--- See {lua:obj}`x` {lua:obj}`ref`"#;
+        let expected = r#"--- See {lua:obj}`x` {lua:obj}`<Ref>ref</Ref>`"#;
+        test(
+            &code,
+            Box::new(MdParser::new_myst(None, Some(31))),
+            &expected,
+        );
+        test(
+            &code,
+            Box::new(MdParser::new_myst(None, Some(32))),
+            &expected,
+        );
+        test(
+            &code,
+            Box::new(MdParser::new_myst(None, Some(34))),
+            &expected,
+        );
+
+        let code = r#"--- See {lua:obj}`x` {lua:obj}`"#;
+        let expected = r#"--- See {lua:obj}`x` {lua:obj}`<Ref></Ref>"#;
+        test(
+            &code,
+            Box::new(MdParser::new_myst(None, Some(31))),
+            &expected,
+        );
+
+        let code = r#"--- See {lua:obj}`x` {lua:obj}``..."#;
+        let expected = r#"--- See {lua:obj}`x` {lua:obj}`<Ref>`...</Ref>"#;
+        test(
+            &code,
+            Box::new(MdParser::new_myst(None, Some(31))),
+            &expected,
+        );
+    }
+
+    #[test]
+    fn test_md_no_indent() {
+        let code = r#"
+---```lua
+---
+--- local t = 213
+---```
+---
+--- .. code-block:: lua
+---
+---    local t = 123
+---    yes = 1123
+local t = 123
+"#;
+
+        let expected = r#"
+---<Scope><Markup>```</Markup><CodeBlock>lua</CodeBlock>
+---
+---<CodeBlock> </CodeBlock><CodeBlockHl(TkLocal)>local</CodeBlockHl(TkLocal)><CodeBlock> </CodeBlock><CodeBlockHl(TkName)>t</CodeBlockHl(TkName)><CodeBlock> </CodeBlock><CodeBlockHl(TkAssign)>=</CodeBlockHl(TkAssign)><CodeBlock> </CodeBlock><CodeBlockHl(TkInt)>213</CodeBlockHl(TkInt)>
+---<Markup>```</Markup></Scope>
+---
+--- .. code-block:: lua
+---
+---<Scope>    <CodeBlock>local t = 123</CodeBlock>
+---    <CodeBlock>yes = 1123</CodeBlock></Scope>
+local t = 123
+"#;
+
+        test(&code, Box::new(MdParser::new(None)), &expected);
+    }
+}

--- a/crates/emmylua_parser_desc/src/ref_target.rs
+++ b/crates/emmylua_parser_desc/src/ref_target.rs
@@ -1,0 +1,378 @@
+use emmylua_parser::{Reader, SourceRange};
+use rowan::{TextRange, TextSize};
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum LuaDescRefPathItem {
+    Name(String),
+    Number(i64),
+    Type(String),
+}
+
+impl LuaDescRefPathItem {
+    pub fn is_name(&self) -> bool {
+        matches!(self, LuaDescRefPathItem::Name(_))
+    }
+
+    pub fn get_name(&self) -> Option<&str> {
+        match self {
+            LuaDescRefPathItem::Name(name) => Some(name),
+            _ => None,
+        }
+    }
+}
+
+pub fn parse_ref_target(
+    text: &str,
+    range: TextRange,
+    cursor_offset: TextSize,
+) -> Option<Vec<(LuaDescRefPathItem, TextRange)>> {
+    let cursor_offset: usize = cursor_offset.into();
+
+    let mut reader = Reader::new_with_range(&text[range], range.into());
+    let mut result = Vec::new();
+
+    while !reader.is_eof() {
+        match reader.current_char() {
+            '[' if reader.prev_char() == '.' => {
+                reader.bump();
+                reader.reset_buff();
+                match eat_type(&mut reader) {
+                    Ok(Type::String) => {
+                        let name = reader.current_text();
+                        result.push((
+                            LuaDescRefPathItem::Name(name[1..name.len() - 1].to_string()),
+                            SourceRange::new(
+                                reader.current_range().start_offset + 1,
+                                reader.current_range().length - 2,
+                            )
+                            .into(),
+                        ));
+                    }
+                    Ok(Type::Number) => {
+                        if let Ok(num) = i64::from_str(reader.current_text()) {
+                            result.push((
+                                LuaDescRefPathItem::Number(num),
+                                reader.current_range().into(),
+                            ));
+                        } else {
+                            result.push((
+                                LuaDescRefPathItem::Name(reader.current_text().to_string()),
+                                reader.current_range().into(),
+                            ));
+                        }
+                    }
+                    Ok(Type::Complex) => {
+                        result.push((
+                            LuaDescRefPathItem::Type(reader.current_text().to_string()),
+                            reader.current_range().into(),
+                        ));
+                    }
+                    Err(()) => return None,
+                }
+
+                if reader.current_range().end_offset() >= cursor_offset {
+                    reader.reset_buff();
+                    break;
+                }
+
+                reader.bump();
+                reader.bump();
+                reader.reset_buff();
+            }
+            '.' => {
+                result.push((
+                    LuaDescRefPathItem::Name(reader.current_text().to_string()),
+                    reader.current_range().into(),
+                ));
+
+                if reader.current_range().end_offset() >= cursor_offset {
+                    reader.reset_buff();
+                    break;
+                }
+
+                reader.bump();
+                reader.reset_buff();
+            }
+            '-' | '_' | 'a'..='z' | 'A'..='Z' | '0'..='9' => reader.bump(),
+            _ => {
+                if reader.current_range().end_offset() < cursor_offset {
+                    // Illegal character before cursor, bail.
+                    return None;
+                } else {
+                    // Illegal character after cursor, ignore.
+                    break;
+                }
+            }
+        }
+    }
+
+    if !reader.current_range().is_empty() {
+        result.push((
+            LuaDescRefPathItem::Name(reader.current_text().to_string()),
+            reader.current_range().into(),
+        ));
+    }
+
+    Some(result)
+}
+
+enum Type {
+    String,
+    Number,
+    Complex,
+}
+
+fn eat_type(reader: &mut Reader) -> Result<Type, ()> {
+    if matches!(reader.current_char(), '"' | '\'') {
+        if !eat_string(reader) {
+            return Err(());
+        }
+
+        if reader.current_char() == ']' {
+            return if matches!(reader.next_char(), '.' | '\0') {
+                Ok(Type::String)
+            } else {
+                Err(())
+            };
+        }
+    }
+
+    let mut depth = 1;
+    while !reader.is_eof() {
+        match reader.current_char() {
+            ']' | ')' | '>' | '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return if matches!(reader.next_char(), '.' | '\0') {
+                        if reader
+                            .current_text()
+                            .chars()
+                            .skip_while(|c| *c == '-')
+                            .all(|c| c.is_ascii_digit())
+                        {
+                            Ok(Type::Number)
+                        } else {
+                            Ok(Type::Complex)
+                        }
+                    } else {
+                        Err(())
+                    };
+                }
+                reader.bump()
+            }
+            '[' | '(' | '<' | '{' => {
+                depth += 1;
+                reader.bump()
+            }
+            '"' | '\'' => {
+                if !eat_string(reader) {
+                    return Err(());
+                }
+            }
+            _ => reader.bump(),
+        }
+    }
+
+    Err(())
+}
+
+#[must_use]
+fn eat_string(reader: &mut Reader) -> bool {
+    let end_ch = reader.current_char();
+    reader.bump();
+    while !reader.is_eof() {
+        match reader.current_char() {
+            '\\' => {
+                reader.bump();
+                reader.bump();
+            }
+            ch if ch == end_ch => {
+                reader.bump();
+                return true;
+            }
+            _ => {
+                reader.bump();
+            }
+        }
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_ref_target_simple() {
+        let res = parse_ref_target("a.b.c.d", TextRange::up_to(7.into()), 7.into());
+        assert_eq!(
+            res,
+            Some(vec![
+                (
+                    LuaDescRefPathItem::Name("a".to_string()),
+                    TextRange::at(0.into(), 1.into())
+                ),
+                (
+                    LuaDescRefPathItem::Name("b".to_string()),
+                    TextRange::at(2.into(), 1.into())
+                ),
+                (
+                    LuaDescRefPathItem::Name("c".to_string()),
+                    TextRange::at(4.into(), 1.into())
+                ),
+                (
+                    LuaDescRefPathItem::Name("d".to_string()),
+                    TextRange::at(6.into(), 1.into())
+                ),
+            ])
+        )
+    }
+
+    #[test]
+    fn test_parse_ref_target_simple_partial() {
+        let res = parse_ref_target("a.abc.d", TextRange::up_to(7.into()), 2.into());
+        assert_eq!(
+            res,
+            Some(vec![
+                (
+                    LuaDescRefPathItem::Name("a".to_string()),
+                    TextRange::at(0.into(), 1.into())
+                ),
+                (
+                    LuaDescRefPathItem::Name("abc".to_string()),
+                    TextRange::at(2.into(), 3.into())
+                ),
+            ])
+        );
+
+        let res = parse_ref_target("a.abc.d", TextRange::up_to(7.into()), 3.into());
+        assert_eq!(
+            res,
+            Some(vec![
+                (
+                    LuaDescRefPathItem::Name("a".to_string()),
+                    TextRange::at(0.into(), 1.into())
+                ),
+                (
+                    LuaDescRefPathItem::Name("abc".to_string()),
+                    TextRange::at(2.into(), 3.into())
+                ),
+            ])
+        );
+
+        let res = parse_ref_target("a.abc.d", TextRange::up_to(7.into()), 5.into());
+        assert_eq!(
+            res,
+            Some(vec![
+                (
+                    LuaDescRefPathItem::Name("a".to_string()),
+                    TextRange::at(0.into(), 1.into())
+                ),
+                (
+                    LuaDescRefPathItem::Name("abc".to_string()),
+                    TextRange::at(2.into(), 3.into())
+                ),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_parse_ref_target_type() {
+        let res = parse_ref_target("a.b.[c.d].e", TextRange::up_to(11.into()), 11.into());
+        assert_eq!(
+            res,
+            Some(vec![
+                (
+                    LuaDescRefPathItem::Name("a".to_string()),
+                    TextRange::at(0.into(), 1.into())
+                ),
+                (
+                    LuaDescRefPathItem::Name("b".to_string()),
+                    TextRange::at(2.into(), 1.into())
+                ),
+                (
+                    LuaDescRefPathItem::Type("c.d".to_string()),
+                    TextRange::at(5.into(), 3.into())
+                ),
+                (
+                    LuaDescRefPathItem::Name("e".to_string()),
+                    TextRange::at(10.into(), 1.into())
+                ),
+            ])
+        )
+    }
+
+    #[test]
+    fn test_parse_ref_target_type_at_end() {
+        let res = parse_ref_target("a.b.[c.d]", TextRange::up_to(9.into()), 9.into());
+        assert_eq!(
+            res,
+            Some(vec![
+                (
+                    LuaDescRefPathItem::Name("a".to_string()),
+                    TextRange::at(0.into(), 1.into())
+                ),
+                (
+                    LuaDescRefPathItem::Name("b".to_string()),
+                    TextRange::at(2.into(), 1.into())
+                ),
+                (
+                    LuaDescRefPathItem::Type("c.d".to_string()),
+                    TextRange::at(5.into(), 3.into())
+                ),
+            ])
+        )
+    }
+
+    #[test]
+    fn test_parse_ref_target_type_braces_strings() {
+        let res = parse_ref_target(
+            "a.b.[fun(x: table<int, string>): { n: int, lit: \"}]\" }]",
+            TextRange::up_to(55.into()),
+            55.into(),
+        );
+        assert_eq!(
+            res,
+            Some(vec![
+                (
+                    LuaDescRefPathItem::Name("a".to_string()),
+                    TextRange::at(0.into(), 1.into())
+                ),
+                (
+                    LuaDescRefPathItem::Name("b".to_string()),
+                    TextRange::at(2.into(), 1.into())
+                ),
+                (
+                    LuaDescRefPathItem::Type(
+                        "fun(x: table<int, string>): { n: int, lit: \"}]\" }".to_string()
+                    ),
+                    TextRange::at(5.into(), 49.into())
+                ),
+            ])
+        )
+    }
+
+    #[test]
+    fn test_parse_ref_target_type_string_literal() {
+        let res = parse_ref_target("a.b.['c']", TextRange::up_to(9.into()), 9.into());
+        assert_eq!(
+            res,
+            Some(vec![
+                (
+                    LuaDescRefPathItem::Name("a".to_string()),
+                    TextRange::at(0.into(), 1.into())
+                ),
+                (
+                    LuaDescRefPathItem::Name("b".to_string()),
+                    TextRange::at(2.into(), 1.into())
+                ),
+                (
+                    LuaDescRefPathItem::Name("c".to_string()),
+                    TextRange::at(6.into(), 1.into())
+                ),
+            ])
+        )
+    }
+}

--- a/crates/emmylua_parser_desc/src/rst.rs
+++ b/crates/emmylua_parser_desc/src/rst.rs
@@ -1,0 +1,2317 @@
+use crate::LuaDocDescription;
+use crate::util::{
+    BacktrackPoint, ResultContainer, desc_to_lines, is_blank, is_closing_quote, is_code_directive,
+    is_lua_role, is_opening_quote, is_quote_match, is_ws, process_lua_code,
+};
+use crate::{DescItem, DescItemKind, LuaDescParser};
+use emmylua_parser::{LexerConfig, LuaLexer, Reader, SourceRange};
+use std::cmp::min;
+use unicode_general_category::{GeneralCategory, get_general_category};
+
+pub struct RstParser {
+    primary_domain: Option<String>,
+    default_role: Option<String>,
+    result: Vec<DescItem>,
+    cursor_position: Option<usize>,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+enum LineEnding {
+    Normal,
+    LiteralMark, // Line ends with double colon.
+}
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+enum ListEnumeratorKind {
+    Auto,
+    Number,
+    SmallLetter,
+    CapitalLetter,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+enum ListMarkerKind {
+    Dot,
+    Paren,
+    Enclosed,
+}
+
+impl LuaDescParser for RstParser {
+    fn parse(&mut self, text: &str, desc: LuaDocDescription) -> Vec<DescItem> {
+        assert!(self.result.is_empty());
+
+        let lines = desc_to_lines(text, desc, self.cursor_position);
+        let mut readers: Vec<_> = lines
+            .iter()
+            .map(|range| {
+                let line = &text[range.start_offset..range.end_offset()];
+                Reader::new_with_range(line, *range)
+            })
+            .collect();
+
+        self.process_block(&mut readers);
+
+        std::mem::take(&mut self.result)
+    }
+}
+
+impl ResultContainer for RstParser {
+    fn results(&self) -> &Vec<DescItem> {
+        &self.result
+    }
+
+    fn results_mut(&mut self) -> &mut Vec<DescItem> {
+        &mut self.result
+    }
+
+    fn cursor_position(&self) -> Option<usize> {
+        self.cursor_position
+    }
+}
+
+impl RstParser {
+    pub fn new(
+        primary_domain: Option<String>,
+        default_role: Option<String>,
+        cursor_position: Option<usize>,
+    ) -> Self {
+        Self {
+            primary_domain,
+            default_role,
+            result: Vec::new(),
+            cursor_position,
+        }
+    }
+
+    fn process_block(&mut self, lines: &mut [Reader]) {
+        let mut i = 0;
+        let mut prev_line_ending = LineEnding::Normal;
+        while i < lines.len() {
+            (i, prev_line_ending) = self.consume_block(lines, i, prev_line_ending)
+        }
+    }
+
+    fn consume_block(
+        &mut self,
+        lines: &mut [Reader],
+        start: usize,
+        prev_line_ending: LineEnding,
+    ) -> (usize, LineEnding) {
+        let line = &mut lines[start];
+
+        if is_blank(line.tail_text()) {
+            line.eat_till_end();
+            line.reset_buff();
+            return (start + 1, prev_line_ending);
+        }
+
+        let res = match line.current_char() {
+            // Indented literal text.
+            ch if prev_line_ending == LineEnding::LiteralMark
+                && (is_ws(ch) || Self::is_indent_c(ch)) =>
+            {
+                self.try_process_literal_text(lines, start)
+            }
+
+            // Line block.
+            '|' if is_ws(line.next_char()) || line.next_char() == '\0' => {
+                self.process_line_block(lines, start)
+            }
+
+            // Bullet list.
+            '*' | '+' | '-' | '•' | '‣' | '⁃'
+                if is_ws(line.next_char()) || line.next_char() == '\0' =>
+            {
+                self.process_bullet_list(lines, start)
+            }
+
+            // Maybe numbered list.
+            '0'..='9' | 'a'..='z' | 'A'..='Z' | '#' | '(' => {
+                self.try_process_numbered_list(lines, start)
+            }
+
+            // Maybe field list.
+            ':' if line.next_char() != ':' => self.try_process_field_list(lines, start),
+
+            // Doctest block.
+            '>' if line.tail_text().starts_with(">>>") => self.process_doctest_block(lines, start),
+
+            // Maybe explicit markup start.
+            '.' if line.next_char() == '.' => self.try_process_explicit_markup(lines, start),
+
+            // Block quote.
+            ' ' | '\t' => self.process_block_quote(lines, start),
+
+            // Maybe implicit hyperlink target.
+            '_' if line.next_char() == '_' => {
+                self.try_process_implicit_hyperlink_target(lines, start)
+            }
+
+            // Normal line, will be processed as inline contents.
+            _ => Err(()),
+        };
+
+        match res {
+            Ok(end) => (end, LineEnding::Normal),
+            Err(_) => {
+                // Paragraph.
+                self.process_paragraph(lines, start)
+            }
+        }
+    }
+
+    fn try_process_literal_text(
+        &mut self,
+        lines: &mut [Reader],
+        start: usize,
+    ) -> Result<usize, ()> {
+        //   Line
+        //
+        // > Line
+
+        let ch = lines[start].current_char();
+
+        let end = if is_ws(ch) {
+            self.gather_indented_lines(lines, start, true)
+        } else if Self::is_indent_c(ch) {
+            self.gather_prefixed_lines(lines, start, ch)
+        } else {
+            return Err(());
+        };
+
+        let scope_start = lines[start].current_range().start_offset;
+        for line in &mut lines[start..end] {
+            line.eat_till_end();
+            self.emit(line, DescItemKind::CodeBlock);
+        }
+        let scope_end = lines[end - 1].current_range().end_offset();
+        self.emit_range(
+            SourceRange::from_start_end(scope_start, scope_end),
+            DescItemKind::Scope,
+        );
+
+        Ok(end)
+    }
+
+    fn process_line_block(&mut self, lines: &mut [Reader], start: usize) -> Result<usize, ()> {
+        // | Line.
+        //   Line continuation.
+
+        let line = &mut lines[start];
+
+        if line.current_char() != '|' || !(is_ws(line.next_char()) || line.next_char() == '\0') {
+            return Err(());
+        }
+
+        let scope_start = line.current_range().start_offset;
+
+        line.bump();
+        self.emit(line, DescItemKind::Markup);
+        self.process_inline_content(line);
+
+        let end = self.gather_indented_lines(lines, start + 1, false);
+        for line in lines[start + 1..end].iter_mut() {
+            self.process_inline_content(line);
+        }
+
+        let scope_end = lines[end - 1].current_range().end_offset();
+        self.emit_range(
+            SourceRange::from_start_end(scope_start, scope_end),
+            DescItemKind::Scope,
+        );
+
+        Ok(end)
+    }
+
+    fn process_bullet_list(&mut self, lines: &mut [Reader], start: usize) -> Result<usize, ()> {
+        // - Line
+        let line = &mut lines[start];
+
+        if !matches!(line.current_char(), '*' | '+' | '-' | '•' | '‣' | '⁃')
+            || !(is_ws(line.next_char()) || line.next_char() == '\0')
+        {
+            return Err(());
+        }
+
+        let scope_start = line.current_range().start_offset;
+
+        line.bump();
+        self.emit(line, DescItemKind::Markup);
+
+        let end = {
+            if line.is_eof() {
+                self.gather_indented_lines(lines, start + 1, true)
+            } else {
+                let indent = line.eat_while(is_ws) + 1;
+                self.gather_exactly_indented_lines(lines, start + 1, indent, true)
+            }
+        };
+        self.process_block(&mut lines[start..end]);
+
+        let scope_end = lines[end - 1].current_range().end_offset();
+        self.emit_range(
+            SourceRange::from_start_end(scope_start, scope_end),
+            DescItemKind::Scope,
+        );
+
+        Ok(end)
+    }
+
+    fn try_process_numbered_list(
+        &mut self,
+        lines: &mut [Reader],
+        start: usize,
+    ) -> Result<usize, ()> {
+        // 1) Line
+        // #) Line
+        // a) Line
+        //
+        // 1. Line
+        // 1) Line
+        // (1) Line
+
+        let line;
+        let next_line;
+        if start + 1 < lines.len() {
+            let [got_line, got_next_line] = lines.get_disjoint_mut([start, start + 1]).unwrap();
+            line = got_line;
+            next_line = Some(got_next_line);
+        } else {
+            line = &mut lines[start];
+            next_line = None;
+        }
+
+        let bt = BacktrackPoint::new(self, line);
+        let scope_start = line.current_range().start_offset;
+
+        let mut indent = 0;
+
+        let starts_with_paren = line.current_char() == '(';
+        if starts_with_paren {
+            line.bump();
+            indent += 1;
+        }
+
+        let list_enumerator_kind = match line.current_char() {
+            '#' => {
+                line.bump();
+                indent += 1;
+                ListEnumeratorKind::Auto
+            }
+            '0'..='9' => {
+                indent += line.eat_while(|c| c.is_ascii_digit());
+                ListEnumeratorKind::Number
+            }
+            'a'..='z' => {
+                line.bump();
+                indent += 1;
+                ListEnumeratorKind::SmallLetter
+            }
+            'A'..='Z' => {
+                line.bump();
+                indent += 1;
+                ListEnumeratorKind::CapitalLetter
+            }
+            _ => {
+                bt.rollback(self, line);
+                return Err(());
+            }
+        };
+
+        let list_marker_kind = match line.current_char() {
+            ')' => {
+                line.bump();
+                indent += 1;
+                if starts_with_paren {
+                    ListMarkerKind::Enclosed
+                } else {
+                    ListMarkerKind::Paren
+                }
+            }
+            '.' if !starts_with_paren => {
+                line.bump();
+                indent += 1;
+                ListMarkerKind::Dot
+            }
+            _ => {
+                bt.rollback(self, line);
+                return Err(());
+            }
+        };
+
+        if !(is_ws(line.current_char()) || line.is_eof()) {
+            bt.rollback(self, line);
+            return Err(());
+        }
+
+        if let Some(next_line) = next_line {
+            if !(is_ws(next_line.current_char())
+                || next_line.is_eof()
+                || Self::is_list_start(
+                    next_line.tail_text(),
+                    list_enumerator_kind,
+                    list_marker_kind,
+                ))
+            {
+                bt.rollback(self, line);
+                return Err(());
+            }
+        }
+
+        self.emit(line, DescItemKind::Markup);
+        indent += line.eat_while(is_ws);
+        line.reset_buff();
+        bt.commit(self, line);
+
+        let end = self.gather_exactly_indented_lines(lines, start + 1, indent, true);
+        self.process_block(&mut lines[start..end]);
+
+        let scope_end = lines[end - 1].current_range().end_offset();
+        self.emit_range(
+            SourceRange::from_start_end(scope_start, scope_end),
+            DescItemKind::Scope,
+        );
+
+        Ok(end)
+    }
+
+    fn try_process_field_list(&mut self, lines: &mut [Reader], start: usize) -> Result<usize, ()> {
+        // :Flag: Line.
+        //        Line continuation.
+
+        let line = &mut lines[start];
+
+        if line.current_char() != ':' || line.next_char() != ':' {
+            return Err(());
+        }
+
+        let bt = BacktrackPoint::new(self, line);
+        let scope_start = line.current_range().start_offset;
+
+        line.bump();
+        self.emit(line, DescItemKind::Markup);
+        eat_rst_flag_body(line);
+        if line.current_char() != ':' {
+            bt.rollback(self, line);
+            return Err(());
+        }
+        self.emit(line, DescItemKind::Arg);
+        line.bump();
+        self.emit(line, DescItemKind::Markup);
+        line.eat_while(is_ws);
+        line.reset_buff();
+        bt.commit(self, line);
+
+        let end = self.gather_indented_lines(lines, start + 1, true);
+        self.process_block(&mut lines[start..end]);
+
+        let scope_end = lines[end - 1].current_range().end_offset();
+        self.emit_range(
+            SourceRange::from_start_end(scope_start, scope_end),
+            DescItemKind::Scope,
+        );
+
+        Ok(end)
+    }
+
+    fn process_doctest_block(&mut self, lines: &mut [Reader], start: usize) -> Result<usize, ()> {
+        // >>> Code.
+        // ... Continuation
+        // Result.
+
+        let line = &mut lines[start];
+
+        if !line.tail_text().starts_with(">>>") {
+            return Err(());
+        }
+
+        let scope_start = line.current_range().start_offset;
+
+        line.bump();
+        line.bump();
+        line.bump();
+        self.emit(line, DescItemKind::Markup);
+        line.eat_while(is_ws);
+        line.reset_buff();
+        line.eat_till_end();
+        self.emit(line, DescItemKind::CodeBlock);
+
+        for i in start + 1..lines.len() {
+            let line = &mut lines[i];
+
+            if is_blank(line.tail_text()) {
+                line.eat_till_end();
+                line.reset_buff();
+                let scope_end = line.current_range().end_offset();
+                self.emit_range(
+                    SourceRange::from_start_end(scope_start, scope_end),
+                    DescItemKind::Scope,
+                );
+                return Ok(i + 1);
+            }
+
+            if line.tail_text().starts_with("...") || line.tail_text().starts_with(">>>") {
+                line.bump();
+                line.bump();
+                line.bump();
+                self.emit(line, DescItemKind::Markup);
+                line.eat_while(is_ws);
+                line.reset_buff();
+                line.eat_till_end();
+                self.emit(line, DescItemKind::CodeBlock);
+            } else {
+                line.eat_till_end();
+                self.emit(line, DescItemKind::CodeBlock);
+            }
+        }
+
+        let scope_end = lines.last_mut().unwrap().current_range().end_offset();
+        self.emit_range(
+            SourceRange::from_start_end(scope_start, scope_end),
+            DescItemKind::Scope,
+        );
+        Ok(lines.len())
+    }
+
+    fn try_process_explicit_markup(
+        &mut self,
+        lines: &mut [Reader],
+        mut start: usize,
+    ) -> Result<usize, ()> {
+        // .. Line.
+        //    Line continuation.
+
+        let line = &mut lines[start];
+
+        if line.current_char() != '.' || line.next_char() != '.' {
+            return Err(());
+        }
+
+        let bt = BacktrackPoint::new(self, line);
+        let scope_start = line.current_range().start_offset;
+
+        line.bump();
+        line.bump();
+        if !is_ws(line.current_char()) {
+            bt.rollback(self, line);
+            return Err(());
+        }
+        self.emit(line, DescItemKind::Markup);
+        line.eat_while(is_ws);
+        line.reset_buff();
+
+        let is_code;
+        let is_lua;
+        match line.current_char() {
+            // Footnote/citation
+            '[' => {
+                line.bump();
+                self.emit(line, DescItemKind::Markup);
+                line.eat_while(|c| c != ']');
+                self.emit(line, DescItemKind::Arg);
+                if line.current_char() != ']' {
+                    bt.rollback(self, line);
+                    return Err(());
+                }
+                line.bump();
+                self.emit(line, DescItemKind::Markup);
+                line.eat_while(is_ws);
+                line.reset_buff();
+                self.process_inline_content(line);
+                bt.commit(self, line);
+
+                is_code = false;
+                is_lua = false;
+            }
+
+            // Hyperlink target
+            '_' => {
+                line.eat_when('_');
+                self.emit(line, DescItemKind::Markup);
+                if !Self::eat_target_name(line) || line.current_char() != ':' {
+                    bt.rollback(self, line);
+                    return Err(());
+                }
+                self.emit(line, DescItemKind::Arg);
+                line.bump();
+                self.emit(line, DescItemKind::Markup);
+                line.eat_while(is_ws);
+                line.reset_buff();
+                line.eat_till_end();
+                self.emit(line, DescItemKind::Link);
+                bt.commit(self, line);
+
+                let end = self.gather_indented_lines(lines, start + 1, true);
+                for line in lines[start + 1..end].iter_mut() {
+                    line.eat_till_end();
+                    self.emit(line, DescItemKind::Link);
+                }
+
+                let scope_end = lines[end - 1].current_range().end_offset();
+                self.emit_range(
+                    SourceRange::from_start_end(scope_start, scope_end),
+                    DescItemKind::Scope,
+                );
+
+                return Ok(end);
+            }
+
+            // Directive or comment
+            _ => {
+                if !Self::eat_directive_name(line) {
+                    // Comment.
+                    line.eat_till_end();
+                    line.reset_buff();
+                    bt.commit(self, line);
+
+                    let end = self.gather_indented_lines(lines, start + 1, true);
+                    for line in lines[start + 1..end].iter_mut() {
+                        line.eat_till_end();
+                        line.reset_buff();
+                    }
+
+                    let scope_end = lines[end - 1].current_range().end_offset();
+                    self.emit_range(
+                        SourceRange::from_start_end(scope_start, scope_end),
+                        DescItemKind::Scope,
+                    );
+
+                    return Ok(end);
+                }
+
+                is_code = is_code_directive(line.current_text());
+                self.emit(line, DescItemKind::Arg);
+                line.bump();
+                line.bump();
+                self.emit(line, DescItemKind::Markup);
+                line.eat_while(is_ws);
+                line.reset_buff();
+                line.eat_till_end();
+                is_lua = is_code && line.current_text().trim() == "lua";
+                self.emit(line, DescItemKind::CodeBlock);
+                bt.commit(self, line);
+            }
+        }
+
+        start += 1;
+        let end = self.gather_indented_lines(lines, start, true);
+        while start < end {
+            let line = &mut lines[start];
+            if is_blank(line.tail_text()) {
+                line.eat_till_end();
+                line.reset_buff();
+                start += 1;
+                break;
+            }
+
+            line.eat_while(is_ws);
+            line.reset_buff();
+            if line.current_char() == ':' {
+                let bt = BacktrackPoint::new(self, line);
+
+                line.bump();
+                self.emit(line, DescItemKind::Markup);
+                eat_rst_flag_body(line);
+                if line.current_char() == ':' {
+                    self.emit(line, DescItemKind::Arg);
+                    line.bump();
+                    self.emit(line, DescItemKind::Markup);
+                    line.eat_while(is_ws);
+                    line.reset_buff();
+                    bt.commit(self, line);
+                } else {
+                    bt.rollback(self, line);
+                }
+            }
+            line.eat_till_end();
+            self.emit(line, DescItemKind::CodeBlock);
+
+            start += 1;
+        }
+
+        if is_lua && self.cursor_position.is_none() {
+            let mut lexer = LuaLexer::new(Reader::new(""), LexerConfig::default(), None);
+            for line in lines[start..end].iter_mut() {
+                line.eat_till_end();
+                let line_range = line.current_range();
+                let lua_tokens = lexer.continue_with_new_reader(line.reset_buff_into_sub_reader());
+                process_lua_code(self, line_range, lua_tokens);
+            }
+        } else if is_code {
+            for line in lines[start..end].iter_mut() {
+                line.eat_till_end();
+                self.emit(line, DescItemKind::CodeBlock);
+            }
+        } else {
+            self.process_block(&mut lines[start..end]);
+        }
+
+        let scope_end = lines[end - 1].current_range().end_offset();
+        self.emit_range(
+            SourceRange::from_start_end(scope_start, scope_end),
+            DescItemKind::Scope,
+        );
+
+        Ok(end)
+    }
+
+    fn process_block_quote(&mut self, lines: &mut [Reader], start: usize) -> Result<usize, ()> {
+        // Indented lines.
+
+        let scope_start = lines[start].current_range().start_offset;
+
+        let end = self.gather_indented_lines(lines, start, true);
+        self.process_block(&mut lines[start..end]);
+
+        let scope_end = lines[end - 1].current_range().end_offset();
+        self.emit_range(
+            SourceRange::from_start_end(scope_start, scope_end),
+            DescItemKind::Scope,
+        );
+
+        Ok(end)
+    }
+
+    fn try_process_implicit_hyperlink_target(
+        &mut self,
+        lines: &mut [Reader],
+        start: usize,
+    ) -> Result<usize, ()> {
+        // __ Hyperlink.
+
+        let line = &mut lines[start];
+
+        if line.current_char() != '_' || line.next_char() != '_' {
+            return Err(());
+        }
+
+        let bt = BacktrackPoint::new(self, line);
+
+        let scope_start = line.current_range().start_offset;
+
+        line.bump();
+        line.bump();
+        if !is_ws(line.current_char()) {
+            bt.rollback(self, line);
+            return Err(());
+        }
+        self.emit(line, DescItemKind::Link);
+        line.eat_while(is_ws);
+        line.reset_buff();
+        line.eat_till_end();
+        self.emit(line, DescItemKind::Link);
+
+        bt.commit(self, line);
+
+        let scope_end = line.current_range().end_offset();
+        self.emit_range(
+            SourceRange::from_start_end(scope_start, scope_end),
+            DescItemKind::Scope,
+        );
+
+        Ok(start + 1)
+    }
+
+    fn process_paragraph(&mut self, lines: &mut [Reader], start: usize) -> (usize, LineEnding) {
+        // Non-indented lines.
+
+        let mut end = start + 1;
+        while end < lines.len() && !is_blank(lines[end].tail_text()) {
+            end += 1;
+
+            // Detect titles.
+            let len = end - start;
+            if len >= 3
+                && Self::is_title_mark(lines[start].tail_text())
+                && !Self::is_title_mark(lines[start + 1].tail_text())
+                && Self::is_title_mark(lines[start + 2].tail_text())
+            {
+                let scope_start = lines[start].current_range().start_offset;
+                self.process_title_mark(&mut lines[start]);
+                self.process_inline_content(&mut lines[start + 1]);
+                self.process_title_mark(&mut lines[start + 2]);
+
+                let scope_end = lines[start + 2].current_range().end_offset();
+                self.emit_range(
+                    SourceRange::from_start_end(scope_start, scope_end),
+                    DescItemKind::Scope,
+                );
+
+                return (start + 3, LineEnding::Normal);
+            } else if len >= 2
+                && !Self::is_title_mark(lines[start].tail_text())
+                && Self::is_title_mark(lines[start + 1].tail_text())
+            {
+                let scope_start = lines[start].current_range().start_offset;
+                self.process_inline_content(&mut lines[start]);
+                self.process_title_mark(&mut lines[start + 1]);
+
+                let scope_end = lines[start + 1].current_range().end_offset();
+                self.emit_range(
+                    SourceRange::from_start_end(scope_start, scope_end),
+                    DescItemKind::Scope,
+                );
+
+                return (start + 3, LineEnding::Normal);
+            }
+        }
+
+        let mut line_ending = LineEnding::Normal;
+        for i in start..end {
+            line_ending = self.process_inline_content(&mut lines[i]);
+        }
+
+        (end, line_ending)
+    }
+
+    fn gather_indented_lines(
+        &mut self,
+        lines: &mut [Reader],
+        start: usize,
+        allow_blank_lines: bool,
+    ) -> usize {
+        let mut end = start;
+        let mut common_indent = None;
+        for i in start..lines.len() {
+            let line = &lines[i];
+            let indent = line.tail_text().chars().take_while(|c| is_ws(*c)).count();
+            if indent >= 1 {
+                end = i + 1;
+                common_indent = match common_indent {
+                    None => Some(indent),
+                    Some(common_indent) => Some(min(common_indent, indent)),
+                };
+            } else if !allow_blank_lines || !is_blank(line.tail_text()) {
+                break;
+            }
+        }
+        if common_indent.is_some_and(|c| c > 0) {
+            let common_indent = common_indent.unwrap();
+            for line in lines[start..end].iter_mut() {
+                line.consume_n_times(is_ws, common_indent);
+                line.reset_buff();
+            }
+        }
+        end
+    }
+
+    fn gather_exactly_indented_lines(
+        &mut self,
+        lines: &mut [Reader],
+        start: usize,
+        min_indent: usize,
+        allow_blank_lines: bool,
+    ) -> usize {
+        let mut end = start;
+        for i in start..lines.len() {
+            let line = &mut lines[i];
+            let indent = line.tail_text().chars().take_while(|c| is_ws(*c)).count();
+            if indent >= min_indent {
+                end = i + 1;
+                line.consume_n_times(is_ws, min_indent);
+                line.reset_buff();
+            } else if !allow_blank_lines || !is_blank(line.tail_text()) {
+                break;
+            }
+        }
+        end
+    }
+
+    fn gather_prefixed_lines(&mut self, lines: &mut [Reader], start: usize, prefix: char) -> usize {
+        let mut end = start;
+        for i in start..lines.len() {
+            let line = &mut lines[i];
+            if line.current_char() == prefix {
+                end = i + 1;
+                line.bump();
+                self.emit(line, DescItemKind::Markup);
+            } else {
+                break;
+            }
+        }
+        end
+    }
+
+    #[must_use]
+    fn eat_target_name(line: &mut Reader) -> bool {
+        // .. _Target name: Hyperlink.
+        //     ^^^^^^^^^^^
+
+        if line.current_char() == '`' {
+            line.bump();
+            while !line.is_eof() {
+                match line.current_char() {
+                    '\\' => {
+                        line.bump();
+                        line.bump();
+                    }
+                    '`' => {
+                        line.bump();
+                        return true;
+                    }
+                    _ => {
+                        line.bump();
+                    }
+                }
+            }
+        } else {
+            while !line.is_eof() {
+                match line.current_char() {
+                    ':' if matches!(line.next_char(), ' ' | '\t' | '\0') => {
+                        return true;
+                    }
+                    '\\' => {
+                        line.bump();
+                        line.bump();
+                    }
+                    _ => {
+                        line.bump();
+                    }
+                }
+            }
+        }
+
+        false
+    }
+
+    #[must_use]
+    fn eat_directive_name(line: &mut Reader) -> bool {
+        // .. Directive name:: Arguments.
+        //    ^^^^^^^^^^^^^^
+
+        while !line.is_eof() {
+            match line.current_char() {
+                ':' if line.next_char() == ':' => {
+                    return true;
+                }
+                '.' | ':' | '+' | '_' | '-' | 'a'..='z' | 'A'..='Z' | '0'..='9' => {
+                    line.bump();
+                }
+                _ => {
+                    return false;
+                }
+            }
+        }
+
+        false
+    }
+
+    fn process_title_mark(&mut self, line: &mut Reader) {
+        line.eat_while(is_ws);
+        line.reset_buff();
+        line.eat_while(|c| !is_ws(c));
+        self.emit(line, DescItemKind::Markup);
+        line.eat_till_end();
+        line.reset_buff();
+    }
+
+    fn process_inline_content(&mut self, reader: &mut Reader) -> LineEnding {
+        let line_ending = {
+            let line = reader.tail_text().trim_end();
+            if line.ends_with("::") {
+                LineEnding::LiteralMark
+            } else {
+                LineEnding::Normal
+            }
+        };
+
+        if self
+            .cursor_position
+            .is_some_and(|offset| !reader.tail_range().contains_inclusive(offset))
+        {
+            // No point in calculating this when all we care
+            // is what's under the user's cursor.
+            return line_ending;
+        }
+
+        while !reader.is_eof() {
+            match reader.current_char() {
+                '\\' => {
+                    reader.reset_buff();
+                    reader.bump();
+                    reader.bump();
+                    self.emit(reader, DescItemKind::Markup);
+                }
+
+                // Explicit role.
+                ':' if reader.next_char() != ':' => {
+                    if !Self::is_start_string(reader.prev_char(), reader.next_char()) {
+                        reader.bump();
+                        continue;
+                    }
+
+                    reader.reset_buff();
+                    let bt = BacktrackPoint::new(self, reader);
+
+                    reader.bump();
+                    self.emit(reader, DescItemKind::Markup);
+                    if !Self::eat_role_name(reader)
+                        || reader.current_char() != ':'
+                        || reader.next_char() != '`'
+                    {
+                        bt.rollback(self, reader);
+                        reader.bump();
+                        // guard.backtrack(reader);
+                        continue;
+                    }
+
+                    let role_text = reader.current_text();
+                    let is_lua_ref = role_text.starts_with("lua:")
+                        || (self.primary_domain.as_deref() == Some("lua")
+                            && !role_text.contains(":")
+                            && is_lua_role(role_text));
+
+                    self.emit(reader, DescItemKind::Arg);
+                    reader.bump();
+                    self.emit(reader, DescItemKind::Markup);
+
+                    if !self.try_handle_role_body(reader, true, is_lua_ref, self.cursor_position) {
+                        bt.rollback(self, reader);
+                        reader.bump();
+                        // guard.backtrack(reader);
+                        continue;
+                    };
+
+                    bt.commit(self, reader);
+                }
+
+                // Inline code
+                '`' if reader.next_char() == '`'
+                    && !self.cursor_position.is_some_and(|offset| {
+                        reader.current_range().end_offset() + 1 == offset
+                    }) =>
+                {
+                    let bt = BacktrackPoint::new(self, reader);
+                    reader.reset_buff();
+
+                    let prev = reader.prev_char();
+                    reader.bump();
+                    reader.bump();
+                    let next = reader.current_char();
+
+                    if !Self::is_start_string(prev, next) {
+                        bt.rollback(self, reader);
+                        reader.bump();
+                        // guard.backtrack(reader);
+                        continue;
+                    }
+
+                    self.emit(reader, DescItemKind::Markup);
+
+                    if !self.try_handle_inline_code(reader) {
+                        bt.rollback(self, reader);
+                        reader.eat_when('`');
+                        // guard.backtrack(reader);
+                        continue;
+                    }
+
+                    bt.commit(self, reader);
+                }
+
+                // Role or hyperlink.
+                '`' => {
+                    let allow_broken_start_sequence = self
+                        .cursor_position
+                        .is_some_and(|offset| reader.current_range().end_offset() + 1 == offset);
+                    let next_char = if allow_broken_start_sequence {
+                        'x' // Any non-whitespace will do.
+                    } else {
+                        reader.next_char()
+                    };
+
+                    if !Self::is_start_string(reader.prev_char(), next_char) {
+                        reader.bump();
+                        continue;
+                    }
+
+                    let bt = BacktrackPoint::new(self, reader);
+                    reader.reset_buff();
+
+                    if !self.try_handle_role_body(
+                        reader,
+                        false,
+                        self.default_role
+                            .as_deref()
+                            .is_some_and(|r| r.starts_with("lua:")),
+                        self.cursor_position,
+                    ) {
+                        bt.rollback(self, reader);
+                        reader.bump();
+                        // guard.backtrack(reader);
+                        continue;
+                    };
+
+                    bt.commit(self, reader);
+                }
+
+                // Hyperlink reference.
+                '_' => {
+                    if reader.next_char() != '`' {
+                        let bt = BacktrackPoint::new(self, reader);
+                        let prev = reader.prev_char();
+                        let n_chars = reader.consume_char_n_times('_', 2);
+                        if Self::is_end_string(prev, reader.current_char()) {
+                            self.handle_simple_ref(reader, n_chars);
+                            bt.commit(self, reader);
+                            continue;
+                        } else {
+                            bt.rollback(self, reader);
+                            reader.eat_when('_');
+                            // guard.backtrack(reader);
+                            continue;
+                        }
+                    }
+
+                    let bt = BacktrackPoint::new(self, reader);
+                    reader.reset_buff();
+
+                    let prev = reader.prev_char();
+                    reader.bump();
+                    reader.bump();
+                    let next = reader.current_char();
+
+                    if !Self::is_start_string(prev, next) {
+                        bt.rollback(self, reader);
+                        reader.bump();
+                        reader.bump();
+                        // guard.backtrack(reader);
+                        continue;
+                    }
+
+                    self.emit(reader, DescItemKind::Markup);
+
+                    if !self.try_handle_hyperlink_ref(reader) {
+                        bt.rollback(self, reader);
+                        reader.bump();
+                        reader.bump();
+                        // guard.backtrack(reader);
+                        continue;
+                    }
+
+                    bt.commit(self, reader);
+                }
+
+                // Substitution.
+                '|' => {
+                    if !Self::is_start_string(reader.prev_char(), reader.next_char()) {
+                        reader.bump();
+                        continue;
+                    }
+
+                    let bt = BacktrackPoint::new(self, reader);
+                    reader.reset_buff();
+                    reader.bump();
+                    self.emit(reader, DescItemKind::Markup);
+
+                    if !self.try_handle_subst(reader) {
+                        bt.rollback(self, reader);
+                        reader.bump();
+                        // guard.backtrack(reader);
+                        continue;
+                    }
+
+                    bt.commit(self, reader);
+                }
+
+                // Footnote.
+                '[' => {
+                    if !Self::is_start_string(reader.prev_char(), reader.next_char()) {
+                        reader.bump();
+                        continue;
+                    }
+
+                    let bt = BacktrackPoint::new(self, reader);
+                    reader.reset_buff();
+                    reader.bump();
+                    self.emit(reader, DescItemKind::Markup);
+
+                    if !self.try_handle_footnote(reader) {
+                        bt.rollback(self, reader);
+                        reader.bump();
+                        // guard.backtrack(reader);
+                        continue;
+                    }
+
+                    bt.commit(self, reader);
+                }
+
+                // Emphasis.
+                '*' => {
+                    let bt = BacktrackPoint::new(self, reader);
+                    reader.reset_buff();
+
+                    let is_strong = reader.next_char() == '*';
+
+                    let prev = reader.prev_char();
+                    let start_range = reader.current_range().start_offset;
+                    if is_strong {
+                        reader.bump();
+                        reader.bump();
+                    } else {
+                        reader.bump();
+                    }
+                    let next = reader.current_char();
+
+                    if !Self::is_start_string(prev, next) {
+                        bt.rollback(self, reader);
+                        reader.eat_when('*');
+                        // guard.backtrack(reader);
+                        continue;
+                    }
+
+                    self.emit(reader, DescItemKind::Markup);
+
+                    if !self.try_handle_em(reader, is_strong) {
+                        bt.rollback(self, reader);
+                        reader.eat_when('*');
+                        // guard.backtrack(reader);
+                        continue;
+                    }
+
+                    let end_range = reader.current_range().end_offset();
+                    self.emit_range(
+                        SourceRange::from_start_end(start_range, end_range),
+                        if is_strong {
+                            DescItemKind::Strong
+                        } else {
+                            DescItemKind::Em
+                        },
+                    );
+
+                    bt.commit(self, reader);
+                }
+                _ => {
+                    reader.bump();
+                }
+            }
+        }
+
+        reader.reset_buff();
+
+        line_ending
+    }
+
+    #[must_use]
+    fn eat_role_name(reader: &mut Reader) -> bool {
+        // :RoleName:`Role content`
+        //  ^^^^^^^^
+
+        while !reader.is_eof() {
+            match reader.current_char() {
+                ':' if !reader.next_char().is_ascii_alphanumeric() => {
+                    return true;
+                }
+                '.' | ':' | '+' | '_' | '-' | 'a'..='z' | 'A'..='Z' | '0'..='9' => {
+                    reader.bump();
+                }
+                _ => {
+                    return false;
+                }
+            }
+        }
+
+        false
+    }
+
+    #[must_use]
+    fn try_handle_inline_code(&mut self, reader: &mut Reader) -> bool {
+        reader.bump(); // Should be at least 1 char long.
+        while !reader.is_eof() {
+            match reader.current_char() {
+                '`' if reader.next_char() == '`' => {
+                    let mut prev = reader.prev_char();
+                    let n_stars = reader.eat_when('`');
+                    if n_stars < 2 {
+                        continue;
+                    } else if n_stars > 2 {
+                        prev = '`';
+                    }
+                    if !Self::is_end_string(prev, reader.current_char()) {
+                        continue;
+                    }
+                    self.emit_mark_end(reader, Some(DescItemKind::Code), 2);
+                    return true;
+                }
+                _ => {
+                    reader.bump();
+                }
+            }
+        }
+
+        false
+    }
+
+    #[must_use]
+    fn try_handle_role_body(
+        &mut self,
+        reader: &mut Reader,
+        has_explicit_role: bool,
+        is_lua_role: bool,
+        cursor_position: Option<usize>,
+    ) -> bool {
+        if reader.current_char() != '`' {
+            return false;
+        }
+        reader.bump();
+
+        while !reader.is_eof() {
+            match reader.current_char() {
+                '`' => {
+                    let bt = BacktrackPoint::new(self, reader);
+
+                    let prev = reader.prev_char();
+                    reader.bump();
+
+                    let code = reader.reset_buff_into_sub_reader();
+
+                    let mark_len = reader.consume_n_times(|c| c == '_', 2) + 1;
+                    if !Self::is_end_string(prev, reader.current_char()) {
+                        bt.rollback(self, reader);
+                        reader.bump();
+                        continue;
+                    }
+
+                    if mark_len > 1 && !has_explicit_role {
+                        process_inline_code(self, code, DescItemKind::Link);
+                    } else if is_lua_role {
+                        process_lua_ref(self, code);
+                    } else {
+                        process_inline_code(self, code, DescItemKind::Code);
+                    }
+
+                    self.emit(reader, DescItemKind::Markup);
+                    bt.commit(self, reader);
+
+                    return true;
+                }
+                '\\' => {
+                    reader.bump();
+                    reader.bump();
+                }
+                _ => {
+                    reader.bump();
+                }
+            }
+        }
+
+        if let Some(cursor_position) = cursor_position {
+            if reader.current_range().contains_inclusive(cursor_position) {
+                process_lua_ref(self, reader.reset_buff_into_sub_reader());
+                return true;
+            }
+        }
+
+        false
+    }
+
+    fn handle_simple_ref(&mut self, reader: &mut Reader, n_chars: usize) {
+        let range = reader.current_range();
+
+        let mut content_range = SourceRange::new(range.start_offset, range.length - n_chars);
+
+        {
+            let mut next = '\0';
+            for ch in reader.current_text().chars().rev().skip(n_chars) {
+                if ch.is_ascii_alphanumeric()
+                    || (matches!(ch, '.' | ':' | '+' | '_' | '-') && !next.is_ascii_alphanumeric())
+                {
+                    content_range.length -= ch.len_utf8();
+                } else {
+                    if !Self::is_start_string(ch, next) {
+                        reader.reset_buff();
+                        return;
+                    }
+                    break;
+                }
+                next = ch;
+            }
+        }
+
+        reader.reset_buff();
+
+        let href_range = SourceRange::new(
+            content_range.start_offset + content_range.length,
+            range.length - n_chars - content_range.length,
+        );
+
+        let markup_range =
+            SourceRange::new(content_range.start_offset + range.length - n_chars, n_chars);
+
+        self.emit_range(href_range, DescItemKind::Link);
+        self.emit_range(markup_range, DescItemKind::Markup);
+    }
+
+    #[must_use]
+    fn try_handle_hyperlink_ref(&mut self, reader: &mut Reader) -> bool {
+        reader.bump(); // Should be at least 1 char long.
+
+        while !reader.is_eof() {
+            match reader.current_char() {
+                '`' => {
+                    if !Self::is_end_string(reader.prev_char(), reader.next_char()) {
+                        reader.bump();
+                        continue;
+                    }
+                    self.emit(reader, DescItemKind::Link);
+                    reader.bump();
+                    self.emit(reader, DescItemKind::Markup);
+                    return true;
+                }
+                '\\' => {
+                    reader.bump();
+                    reader.bump();
+                }
+                _ => {
+                    reader.bump();
+                }
+            }
+        }
+
+        false
+    }
+
+    #[must_use]
+    fn try_handle_subst(&mut self, reader: &mut Reader) -> bool {
+        reader.bump(); // Should be at least 1 char long.
+        while !reader.is_eof() {
+            match reader.current_char() {
+                '|' => {
+                    let prev = reader.prev_char();
+                    reader.bump();
+                    let mark_len = reader.consume_n_times(|c| c == '_', 2) + 1;
+                    if !Self::is_end_string(prev, reader.current_char()) {
+                        continue;
+                    }
+                    let kind = if mark_len == 1 {
+                        DescItemKind::Code
+                    } else {
+                        DescItemKind::Link
+                    };
+                    self.emit_mark_end(reader, Some(kind), mark_len);
+                    return true;
+                }
+                '\\' => {
+                    reader.bump();
+                    reader.bump();
+                }
+                _ => {
+                    reader.bump();
+                }
+            }
+        }
+
+        false
+    }
+
+    #[must_use]
+    fn try_handle_footnote(&mut self, reader: &mut Reader) -> bool {
+        reader.bump(); // Should be at least 1 char long.
+        while !reader.is_eof() {
+            match reader.current_char() {
+                ']' if reader.next_char() == '_' => {
+                    let prev = reader.prev_char();
+                    reader.bump();
+                    reader.bump();
+                    if !Self::is_end_string(prev, reader.current_char()) {
+                        continue;
+                    }
+                    self.emit_mark_end(reader, Some(DescItemKind::Link), 2);
+                    return true;
+                }
+                '\\' => {
+                    reader.bump();
+                    reader.bump();
+                }
+                _ => {
+                    reader.bump();
+                }
+            }
+        }
+
+        false
+    }
+
+    #[must_use]
+    fn try_handle_em(&mut self, reader: &mut Reader, is_strong: bool) -> bool {
+        let mark_len = 1 + is_strong as usize;
+        reader.bump(); // Should be at least 1 char long.
+        while !reader.is_eof() {
+            match reader.current_char() {
+                '*' => {
+                    let mut prev = reader.prev_char();
+                    let n_stars = reader.eat_when('*');
+                    if n_stars < mark_len {
+                        continue;
+                    } else if n_stars > mark_len {
+                        prev = '*';
+                    }
+                    if !Self::is_end_string(prev, reader.current_char()) {
+                        continue;
+                    }
+                    self.emit_mark_end(reader, None, mark_len);
+                    return true;
+                }
+                '\\' => {
+                    reader.bump();
+                    reader.bump();
+                }
+                _ => {
+                    reader.bump();
+                }
+            }
+        }
+
+        false
+    }
+
+    fn emit_mark_end(
+        &mut self,
+        line: &mut Reader,
+        content_kind: Option<DescItemKind>,
+        mark_len: usize,
+    ) {
+        let range = line.current_range();
+
+        assert!(range.length > mark_len);
+
+        let content_range = SourceRange::new(range.start_offset, range.length - mark_len);
+        if let Some(content_kind) = content_kind {
+            self.emit_range(content_range, content_kind);
+        }
+
+        let mark_range = SourceRange::new(range.start_offset + range.length - mark_len, mark_len);
+        self.emit_range(mark_range, DescItemKind::Markup);
+        line.reset_buff();
+    }
+
+    fn is_indent_c(c: char) -> bool {
+        // Any punctuation character can start character-indented block.
+        c.is_ascii_punctuation()
+    }
+
+    fn is_list_start(
+        line: &str,
+        list_enumerator_kind: ListEnumeratorKind,
+        list_marker_kind: ListMarkerKind,
+    ) -> bool {
+        let mut chars = line.chars();
+
+        if list_marker_kind == ListMarkerKind::Enclosed && chars.next() != Some('(') {
+            return false;
+        }
+
+        let ch = match list_enumerator_kind {
+            ListEnumeratorKind::Auto => {
+                if chars.next() != Some('#') {
+                    return false;
+                }
+                chars.next()
+            }
+            ListEnumeratorKind::Number => {
+                if !matches!(chars.next(), Some('0'..='9')) {
+                    return false;
+                }
+                loop {
+                    let ch = chars.next();
+                    if !matches!(ch, Some('0'..='9')) {
+                        break ch;
+                    }
+                }
+            }
+            ListEnumeratorKind::SmallLetter => {
+                if !matches!(chars.next(), Some('a'..='z')) {
+                    return false;
+                }
+                chars.next()
+            }
+            ListEnumeratorKind::CapitalLetter => {
+                if !matches!(chars.next(), Some('A'..='Z')) {
+                    return false;
+                }
+                chars.next()
+            }
+        };
+
+        let expected_ch = match list_marker_kind {
+            ListMarkerKind::Dot => '.',
+            ListMarkerKind::Paren | ListMarkerKind::Enclosed => ')',
+        };
+
+        ch == Some(expected_ch) && matches!(chars.next(), None | Some(' ' | '\t'))
+    }
+
+    fn is_title_mark(s: &str) -> bool {
+        // This is a heuristic to avoid calculating width of title text.
+        let s = s.trim_end();
+        s.len() >= 3 && s.chars().all(|c| c.is_ascii_punctuation())
+    }
+
+    fn is_start_string(prev: char, next: char) -> bool {
+        // 1
+        if next.is_whitespace() {
+            return false;
+        }
+
+        // 5
+        if is_opening_quote(prev) && is_closing_quote(next) && is_quote_match(prev, next) {
+            return false;
+        }
+
+        // 6
+        if prev.is_whitespace() {
+            return true;
+        }
+        if prev.is_ascii() {
+            matches!(
+                prev,
+                '-' | ':' | '/' | '\'' | '"' | '<' | '(' | '[' | '{' | '\0'
+            )
+        } else {
+            matches!(
+                get_general_category(prev),
+                GeneralCategory::OpenPunctuation
+                    | GeneralCategory::InitialPunctuation
+                    | GeneralCategory::FinalPunctuation
+                    | GeneralCategory::DashPunctuation
+                    | GeneralCategory::OtherPunctuation
+            )
+        }
+    }
+
+    fn is_end_string(prev: char, next: char) -> bool {
+        // 2
+        if prev.is_whitespace() {
+            return false;
+        }
+
+        // 7
+        if next.is_whitespace() {
+            return true;
+        }
+        if next.is_ascii() {
+            matches!(
+                next,
+                '-' | '.'
+                    | ','
+                    | ':'
+                    | ';'
+                    | '!'
+                    | '?'
+                    | '\\'
+                    | '/'
+                    | '\''
+                    | '"'
+                    | ')'
+                    | ']'
+                    | '}'
+                    | '>'
+                    | '\0'
+            )
+        } else {
+            matches!(
+                get_general_category(prev),
+                GeneralCategory::ClosePunctuation
+                    | GeneralCategory::InitialPunctuation
+                    | GeneralCategory::FinalPunctuation
+                    | GeneralCategory::DashPunctuation
+                    | GeneralCategory::OtherPunctuation
+            )
+        }
+    }
+}
+
+/// Eat contents of RST's flag field (directive parameters
+/// are also flag fields). Reader should be set to a range that contains
+/// the entire line after the initial colon.
+pub fn eat_rst_flag_body(reader: &mut Reader) {
+    while !reader.is_eof() {
+        match reader.current_char() {
+            '\\' => {
+                reader.bump();
+                reader.bump();
+            }
+            ':' if is_ws(reader.next_char()) || reader.next_char() == '\0' => {
+                break;
+            }
+            _ => {
+                reader.bump();
+            }
+        }
+    }
+}
+
+/// Parse contents of backtick-enclosed lua reference,
+/// supports both markdown and rst syntax.
+///
+/// Reader should be set to a range that only includes reference contents
+/// and backticks around it.
+pub fn process_lua_ref<C: ResultContainer>(container: &mut C, mut reader: Reader) {
+    if reader.tail_text().chars().all(|c| c == '`') || !reader.tail_text().ends_with("`") {
+        // Happens when auto complete called on an empty/incomplete reference.
+        reader.bump();
+        container.emit(&mut reader, DescItemKind::Markup);
+        reader.eat_till_end();
+        container.emit(&mut reader, DescItemKind::Ref);
+        return;
+    }
+
+    let n_backticks = reader.eat_when('`');
+    container.emit(&mut reader, DescItemKind::Markup);
+
+    let text = reader.tail_text().trim_matches('`');
+    let has_explicit_title = text.ends_with('>') && (text.starts_with('<') || text.contains(" <"));
+
+    if has_explicit_title {
+        while !reader.is_eof() {
+            if reader.current_char() == '<' && matches!(reader.prev_char(), ' ' | '`' | '\0') {
+                reader.bump();
+                break;
+            } else {
+                reader.bump();
+            }
+        }
+        reader.consume_char_n_times('~', 1);
+        container.emit(&mut reader, DescItemKind::Code);
+        while reader.tail_range().length > n_backticks + 1 {
+            reader.bump();
+        }
+        container.emit(&mut reader, DescItemKind::Ref);
+        reader.bump();
+        container.emit(&mut reader, DescItemKind::Code);
+        reader.eat_while(|_| true);
+        container.emit(&mut reader, DescItemKind::Markup);
+    } else {
+        reader.consume_char_n_times('~', 1);
+        container.emit(&mut reader, DescItemKind::Code);
+        while reader.tail_range().length > n_backticks {
+            reader.bump();
+        }
+        container.emit(&mut reader, DescItemKind::Ref);
+        reader.eat_while(|_| true);
+        container.emit(&mut reader, DescItemKind::Markup);
+    }
+}
+
+/// Parse contents of backtick-enclosed code block,
+/// supports both markdown and rst syntax.
+///
+/// Reader should be set to a range that only includes code block contents
+/// and backticks around it.
+pub fn process_inline_code<C: ResultContainer>(
+    container: &mut C,
+    mut reader: Reader,
+    kind: DescItemKind,
+) {
+    let n_backticks = reader.eat_when('`');
+    container.emit(&mut reader, DescItemKind::Markup);
+    while reader.tail_range().length > n_backticks {
+        reader.bump();
+    }
+    container.emit(&mut reader, kind);
+    reader.eat_while(|_| true);
+    container.emit(&mut reader, DescItemKind::Markup);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testlib::test;
+
+    #[test]
+    fn test_rst() {
+        let code = r#"
+--- Inline markup
+--- =============
+---
+--- Not valid markup
+--- ----------------
+---
+--- - 2 * x a ** b (* BOM32_* ` `` _ __ | (breaks rule 1)
+--- - || (breaks rule 3)
+--- - "*" '|' (*) [*] {*} <*> “*” »*« ›*‹ «*» »*» ›*› (breaks rule 5)
+--- - 2*x a**b O(N**2) e**(x*y) f(x)*f(y) a|b file*.* __init__ __init__() (breaks rule 6)
+---
+---
+--- Valid markup
+--- ------------
+---
+--- Style: *em*, **strong**, ***strong, with stars***, *broken `em`.
+--- Implicit ref: `something`, `a\` b`. Broken: `something
+--- Explicit ref: :role:`ref`. Broken: :role:`ref
+--- Lua ref: :lua:obj:`a.b.c`, :lua:obj:`~a.b.c`, :lua:obj:`title <a.b.c>`.
+--- Code block: ``code``, ``code `backticks```,
+--- ``escapes don't work here\``, ``{ 1, 2, nil, 4 }``.
+--- Broken code block: ``foo *bar*
+--- Implicit hyperlinks: target_, anonymous__, not a link___.
+--- Explicit hyperlinks: `target`_, `anonymous`__.
+--- Malformed ref: :lua:obj:`~a.b.c`__ (still parsed as ref).
+--- Hyperlink: `foo bar`_, `foo bar`__, `foo <bar>`_.
+--- Internal hyperlink: _`foo bar`. Broken _`foo bar
+--- Footnote: [1]_, [2], [3
+--- Replacement: |foo|, |bar|_, |baz|__.
+--- *2 * x  *a **b *.rst*
+--- *2*x a**b O(N**2) e**(x*y) f(x)*f(y) a*(1+2)*
+---
+--- Block markup
+--- ============
+---
+--- Lists
+--- -----
+---
+--- - List 1
+---   Continuation
+---
+---   Continuation 2
+---
+--- -  List 2
+---    Continuation
+---   Not a continuation
+---
+--- - List
+---
+---   - Nested list
+---
+--- - List
+--- Not list
+---
+--- - List
+--- -
+--- - List
+---
+---
+--- Numbered lists
+--- --------------
+---
+--- 1.  List.
+---
+--- 1)  List.
+---
+--- (1) List.
+---
+--- A) This is not
+--- a list
+---
+--- A) This is a list.
+---
+--- 1) This is not a list...
+--- 2. because list style changes without a blank line.
+---
+--- 1) This is a list...
+--- 2) because list style doesn't change.
+---
+--- \A. Einstein was a really smart dude.
+---
+--- 1. Item 1 initial text.
+---
+---    a) Item 1a.
+---    b) Item 1b.
+---
+--- 2. a) Item 2a.
+---    b) Item 2b.
+---
+--- 1. List
+--- 2.
+--- 3. List
+---
+---
+--- Field list
+--- ----------
+---
+--- :Field: content
+--- :Field:2: Content
+--- :Field:3: Content
+---           Continuation
+--- :Field\: 4: Content
+---
+---
+--- Line block
+--- ----------
+---
+--- | Lend us a couple of bob till Thursday.
+--- | I'm absolutely skint.
+--- | But I'm expecting a postal order and I can pay you back
+---   as soon as it comes.
+--- | Love, Ewan.
+---
+---   Not a continuation.
+---
+---
+--- Block quotes
+--- ------------
+---
+--- This is an ordinary paragraph, introducing a block quote.
+---
+---     "It is my business to know things.  That is my trade."
+---
+---     -- Sherlock Holmes
+---
+--- * List item.
+---
+--- ..
+---
+---     Block quote 3.
+---
+---
+--- Doctest blocks
+--- --------------
+---
+--- >>> print('this is a Doctest block')
+--- this is a Doctest block
+--- >>> print('foo bar')
+--- ... None
+--- foo bar
+---
+--- Explicit markup
+--- ---------------
+---
+--- .. Comment
+---
+---    With continuation
+---
+--- .. [1] Footnote
+---
+--- .. [#] Long footnote
+---    with continuation.
+---
+---    - And nested content.
+---
+--- .. _target:
+---
+--- .. _hyperlink-name: link-block
+---
+--- .. _`FAQTS: Computers: Programming: Languages: Python`:
+---    http://python.faqts.com/
+---
+--- .. _entirely-below:
+---    https://docutils.
+---    sourceforge.net/rst.html
+---
+--- .. _Chapter One\: "Tadpole Days":
+---
+--- It's not easy being green...
+---
+--- .. directive::
+---
+--- .. directive:: args
+---    :param: value
+---    param 2
+---
+---    Content.
+---
+---    - Nested content.
+---
+--- .. code-block:: python
+---
+---    def foo():
+---        pass
+---
+--- .. code-block:: lua
+---    :linenos:
+---
+---    function foo(x)
+---        print([[
+---            long string
+---        ]])
+---    end
+---
+---
+--- Implicit hyperlink target
+--- -------------------------
+---
+--- __ anonymous-hyperlink-target-link-block
+---
+---
+--- Literal blocks
+--- --------------
+---
+--- ::
+---
+---   This is code!
+---
+--- Some code::
+---
+---   Code...
+---
+---   ...continues.
+---
+--- ::
+---
+--- - This is also code!
+--- -
+--- - Continues.
+---
+--- - And this is list.
+"#;
+
+        let expected = r#"
+--- <Scope>Inline markup
+--- <Markup>=============</Markup></Scope>
+---
+--- <Scope>Not valid markup
+--- <Markup>----------------</Markup></Scope>
+---
+--- <Scope><Markup>-</Markup> 2 * x a ** b (* BOM32_* ` `` _ __ | (breaks rule 1)</Scope>
+--- <Scope><Markup>-</Markup> || (breaks rule 3)</Scope>
+--- <Scope><Markup>-</Markup> "*" '|' (*) [*] {*} <*> “*” »*« ›*‹ «*» »*» ›*› (breaks rule 5)</Scope>
+--- <Scope><Markup>-</Markup> 2*x a**b O(N**2) e**(x*y) f(x)*f(y) a|b file*.* __init__ __init__() (breaks rule 6)</Scope>
+---
+---
+--- <Scope>Valid markup
+--- <Markup>------------</Markup></Scope>
+---
+--- Style: <Em><Markup>*</Markup>em<Markup>*</Markup></Em>, <Strong><Markup>**</Markup>strong<Markup>**</Markup></Strong>, <Strong><Markup>**</Markup>*strong, with stars*<Markup>**</Markup></Strong>, *broken <Markup>`</Markup><Code>em</Code><Markup>`</Markup>.
+--- Implicit ref: <Markup>`</Markup><Code>something</Code><Markup>`</Markup>, <Markup>`</Markup><Code>a\` b</Code><Markup>`</Markup>. Broken: `something
+--- Explicit ref: <Markup>:</Markup><Arg>role</Arg><Markup>:`</Markup><Code>ref</Code><Markup>`</Markup>. Broken: :role:`ref
+--- Lua ref: <Markup>:</Markup><Arg>lua:obj</Arg><Markup>:`</Markup><Ref>a.b.c</Ref><Markup>`</Markup>, <Markup>:</Markup><Arg>lua:obj</Arg><Markup>:`</Markup><Code>~</Code><Ref>a.b.c</Ref><Markup>`</Markup>, <Markup>:</Markup><Arg>lua:obj</Arg><Markup>:`</Markup><Code>title <</Code><Ref>a.b.c</Ref><Code>></Code><Markup>`</Markup>.
+--- Code block: <Markup>``</Markup><Code>code</Code><Markup>``</Markup>, <Markup>``</Markup><Code>code `backticks`</Code><Markup>``</Markup>,
+--- <Markup>``</Markup><Code>escapes don't work here\</Code><Markup>``</Markup>, <Markup>``</Markup><Code>{ 1, 2, nil, 4 }</Code><Markup>``</Markup>.
+--- Broken code block: ``foo <Em><Markup>*</Markup>bar<Markup>*</Markup></Em>
+--- Implicit hyperlinks: <Link>target</Link><Markup>_</Markup>, <Link>anonymous</Link><Markup>__</Markup>, not a link___.
+--- Explicit hyperlinks: <Markup>`</Markup><Link>target</Link><Markup>`_</Markup>, <Markup>`</Markup><Link>anonymous</Link><Markup>`__</Markup>.
+--- Malformed ref: <Markup>:</Markup><Arg>lua:obj</Arg><Markup>:`</Markup><Code>~</Code><Ref>a.b.c</Ref><Markup>`__</Markup> (still parsed as ref).
+--- Hyperlink: <Markup>`</Markup><Link>foo bar</Link><Markup>`_</Markup>, <Markup>`</Markup><Link>foo bar</Link><Markup>`__</Markup>, <Markup>`</Markup><Link>foo <bar></Link><Markup>`_</Markup>.
+--- Internal hyperlink: <Markup>_`</Markup><Link>foo bar</Link><Markup>`</Markup>. Broken _`foo bar
+--- Footnote: <Markup>[</Markup><Link>1</Link><Markup>]_</Markup>, [2], [3
+--- Replacement: <Markup>|</Markup><Code>foo</Code><Markup>|</Markup>, <Markup>|</Markup><Link>bar</Link><Markup>|_</Markup>, <Markup>|</Markup><Link>baz</Link><Markup>|__</Markup>.
+--- <Em><Markup>*</Markup>2 * x  *a **b *.rst<Markup>*</Markup></Em>
+--- <Em><Markup>*</Markup>2*x a**b O(N**2) e**(x*y) f(x)*f(y) a*(1+2)<Markup>*</Markup></Em>
+---
+--- <Scope>Block markup
+--- <Markup>============</Markup></Scope>
+---
+--- <Scope>Lists
+--- <Markup>-----</Markup></Scope>
+---
+--- <Scope><Markup>-</Markup> List 1
+---   Continuation
+---
+---   Continuation 2</Scope>
+---
+--- <Scope><Markup>-</Markup>  List 2
+---    Continuation</Scope>
+--- <Scope>  Not a continuation</Scope>
+---
+--- <Scope><Markup>-</Markup> List
+---
+---   <Scope><Markup>-</Markup> Nested list</Scope></Scope>
+---
+--- <Scope><Markup>-</Markup> List</Scope>
+--- Not list
+---
+--- <Scope><Markup>-</Markup> List</Scope>
+--- <Scope><Markup>-</Markup></Scope>
+--- <Scope><Markup>-</Markup> List</Scope>
+---
+---
+--- <Scope>Numbered lists
+--- <Markup>--------------</Markup></Scope>
+---
+--- <Scope><Markup>1.</Markup>  List.</Scope>
+---
+--- <Scope><Markup>1)</Markup>  List.</Scope>
+---
+--- <Scope><Markup>(1)</Markup> List.</Scope>
+---
+--- A) This is not
+--- a list
+---
+--- <Scope><Markup>A)</Markup> This is a list.</Scope>
+---
+--- 1) This is not a list...
+--- 2. because list style changes without a blank line.
+---
+--- <Scope><Markup>1)</Markup> This is a list...</Scope>
+--- <Scope><Markup>2)</Markup> because list style doesn't change.</Scope>
+---
+--- <Markup>\A</Markup>. Einstein was a really smart dude.
+---
+--- <Scope><Markup>1.</Markup> Item 1 initial text.
+---
+---    <Scope><Markup>a)</Markup> Item 1a.</Scope>
+---    <Scope><Markup>b)</Markup> Item 1b.</Scope></Scope>
+---
+--- <Scope><Markup>2.</Markup> <Scope><Markup>a)</Markup> Item 2a.</Scope>
+---    <Scope><Markup>b)</Markup> Item 2b.</Scope></Scope>
+---
+--- <Scope><Markup>1.</Markup> List</Scope>
+--- <Scope><Markup>2.</Markup></Scope>
+--- <Scope><Markup>3.</Markup> List</Scope>
+---
+---
+--- <Scope>Field list
+--- <Markup>----------</Markup></Scope>
+---
+--- :Field: content
+--- :Field:2: Content
+--- :Field:3: Content
+---           Continuation
+--- :Field<Markup>\:</Markup> 4: Content
+---
+---
+--- <Scope>Line block
+--- <Markup>----------</Markup></Scope>
+---
+--- <Scope><Markup>|</Markup> Lend us a couple of bob till Thursday.</Scope>
+--- <Scope><Markup>|</Markup> I'm absolutely skint.</Scope>
+--- <Scope><Markup>|</Markup> But I'm expecting a postal order and I can pay you back
+---   as soon as it comes.</Scope>
+--- <Scope><Markup>|</Markup> Love, Ewan.</Scope>
+---
+--- <Scope>  Not a continuation.</Scope>
+---
+---
+--- <Scope>Block quotes
+--- <Markup>------------</Markup></Scope>
+---
+--- This is an ordinary paragraph, introducing a block quote.
+---
+--- <Scope>    "It is my business to know things.  That is my trade."
+---
+---     -- Sherlock Holmes</Scope>
+---
+--- <Scope><Markup>*</Markup> List item.</Scope>
+---
+--- ..
+---
+--- <Scope>    Block quote 3.</Scope>
+---
+---
+--- <Scope>Doctest blocks
+--- <Markup>--------------</Markup></Scope>
+---
+--- <Scope><Markup>>>></Markup> <CodeBlock>print('this is a Doctest block')</CodeBlock>
+--- <CodeBlock>this is a Doctest block</CodeBlock>
+--- <Markup>>>></Markup> <CodeBlock>print('foo bar')</CodeBlock>
+--- <Markup>...</Markup> <CodeBlock>None</CodeBlock>
+--- <CodeBlock>foo bar</CodeBlock>
+---</Scope>
+--- <Scope>Explicit markup
+--- <Markup>---------------</Markup></Scope>
+---
+--- <Scope><Markup>..</Markup> Comment
+---
+---    With continuation</Scope>
+---
+--- <Scope><Markup>..</Markup> <Markup>[</Markup><Arg>1</Arg><Markup>]</Markup> Footnote</Scope>
+---
+--- <Scope><Markup>..</Markup> <Markup>[</Markup><Arg>#</Arg><Markup>]</Markup> Long footnote
+---    <CodeBlock>with continuation.</CodeBlock>
+---
+---    <Scope><Markup>-</Markup> And nested content.</Scope></Scope>
+---
+--- <Scope><Markup>..</Markup> <Markup>_</Markup><Arg>target</Arg><Markup>:</Markup></Scope>
+---
+--- <Scope><Markup>..</Markup> <Markup>_</Markup><Arg>hyperlink-name</Arg><Markup>:</Markup> <Link>link-block</Link></Scope>
+---
+--- <Scope><Markup>..</Markup> <Markup>_</Markup><Arg>`FAQTS: Computers: Programming: Languages: Python`</Arg><Markup>:</Markup>
+---    <Link>http://python.faqts.com/</Link></Scope>
+---
+--- <Scope><Markup>..</Markup> <Markup>_</Markup><Arg>entirely-below</Arg><Markup>:</Markup>
+---    <Link>https://docutils.</Link>
+---    <Link>sourceforge.net/rst.html</Link></Scope>
+---
+--- <Scope><Markup>..</Markup> <Markup>_</Markup><Arg>Chapter One\: "Tadpole Days"</Arg><Markup>:</Markup></Scope>
+---
+--- It's not easy being green...
+---
+--- <Scope><Markup>..</Markup> <Arg>directive</Arg><Markup>::</Markup></Scope>
+---
+--- <Scope><Markup>..</Markup> <Arg>directive</Arg><Markup>::</Markup> <CodeBlock>args</CodeBlock>
+---    <Markup>:</Markup><Arg>param</Arg><Markup>:</Markup> <CodeBlock>value</CodeBlock>
+---    <CodeBlock>param 2</CodeBlock>
+---
+---    Content.
+---
+---    <Scope><Markup>-</Markup> Nested content.</Scope></Scope>
+---
+--- <Scope><Markup>..</Markup> <Arg>code-block</Arg><Markup>::</Markup> <CodeBlock>python</CodeBlock>
+---
+---    <CodeBlock>def foo():</CodeBlock>
+---    <CodeBlock>    pass</CodeBlock></Scope>
+---
+--- <Scope><Markup>..</Markup> <Arg>code-block</Arg><Markup>::</Markup> <CodeBlock>lua</CodeBlock>
+---    <Markup>:</Markup><Arg>linenos</Arg><Markup>:</Markup>
+---
+---    <CodeBlockHl(TkFunction)>function</CodeBlockHl(TkFunction)><CodeBlock> </CodeBlock><CodeBlockHl(TkName)>foo</CodeBlockHl(TkName)><CodeBlockHl(TkLeftParen)>(</CodeBlockHl(TkLeftParen)><CodeBlockHl(TkName)>x</CodeBlockHl(TkName)><CodeBlockHl(TkRightParen)>)</CodeBlockHl(TkRightParen)>
+---    <CodeBlock>    </CodeBlock><CodeBlockHl(TkName)>print</CodeBlockHl(TkName)><CodeBlockHl(TkLeftParen)>(</CodeBlockHl(TkLeftParen)><CodeBlockHl(TkLongString)>[[</CodeBlockHl(TkLongString)>
+---    <CodeBlockHl(TkLongString)>        long string</CodeBlockHl(TkLongString)>
+---    <CodeBlockHl(TkLongString)>    ]]</CodeBlockHl(TkLongString)><CodeBlockHl(TkRightParen)>)</CodeBlockHl(TkRightParen)>
+---    <CodeBlockHl(TkEnd)>end</CodeBlockHl(TkEnd)></Scope>
+---
+---
+--- <Scope>Implicit hyperlink target
+--- <Markup>-------------------------</Markup></Scope>
+---
+--- <Scope><Link>__</Link> <Link>anonymous-hyperlink-target-link-block</Link></Scope>
+---
+---
+--- <Scope>Literal blocks
+--- <Markup>--------------</Markup></Scope>
+---
+--- ::
+---
+---   <Scope><CodeBlock>This is code!</CodeBlock></Scope>
+---
+--- Some code::
+---
+---   <Scope><CodeBlock>Code...</CodeBlock>
+---
+---   <CodeBlock>...continues.</CodeBlock></Scope>
+---
+--- ::
+---
+--- <Markup>-</Markup><Scope><CodeBlock> This is also code!</CodeBlock>
+--- <Markup>-</Markup>
+--- <Markup>-</Markup><CodeBlock> Continues.</CodeBlock></Scope>
+---
+--- <Scope><Markup>-</Markup> And this is list.</Scope>
+"#;
+
+        test(&code, Box::new(RstParser::new(None, None, None)), &expected);
+    }
+
+    #[test]
+    fn test_rst_no_indent() {
+        let code = r#"
+---```lua
+---
+--- local t = 213
+---```
+---
+--- .. code-block:: lua
+---
+---    local t = 123
+---    yes = 1123
+local t = 123
+"#;
+
+        let expected = r#"
+---```lua
+---
+---<Scope> local t = 213</Scope>
+---```
+---
+---<Scope> <Scope><Markup>..</Markup> <Arg>code-block</Arg><Markup>::</Markup> <CodeBlock>lua</CodeBlock>
+---
+---    <CodeBlockHl(TkLocal)>local</CodeBlockHl(TkLocal)><CodeBlock> </CodeBlock><CodeBlockHl(TkName)>t</CodeBlockHl(TkName)><CodeBlock> </CodeBlock><CodeBlockHl(TkAssign)>=</CodeBlockHl(TkAssign)><CodeBlock> </CodeBlock><CodeBlockHl(TkInt)>123</CodeBlockHl(TkInt)>
+---    <CodeBlockHl(TkName)>yes</CodeBlockHl(TkName)><CodeBlock> </CodeBlock><CodeBlockHl(TkAssign)>=</CodeBlockHl(TkAssign)><CodeBlock> </CodeBlock><CodeBlockHl(TkInt)>1123</CodeBlockHl(TkInt)></Scope></Scope>
+local t = 123
+"#;
+
+        test(
+            &code,
+            Box::new(RstParser::new(None, Some("lua:obj".to_string()), None)),
+            &expected,
+        );
+    }
+
+    #[test]
+    fn test_rst_default_role() {
+        let code = r#"--- See `ref`"#;
+
+        let expected = r#"--- See <Markup>`</Markup><Ref>ref</Ref><Markup>`</Markup>"#;
+
+        test(
+            &code,
+            Box::new(RstParser::new(None, Some("lua:obj".to_string()), None)),
+            &expected,
+        );
+    }
+
+    #[test]
+    fn test_rst_primary_domain() {
+        let code = r#"--- See :obj:`ref`"#;
+
+        let expected = r#"
+            --- See <Markup>:</Markup><Arg>obj</Arg><Markup>:`</Markup><Ref>ref</Ref><Markup>`</Markup>
+        "#;
+
+        test(
+            &code,
+            Box::new(RstParser::new(Some("lua".to_string()), None, None)),
+            &expected,
+        );
+    }
+
+    #[test]
+    fn test_rst_search_at_offset() {
+        let code = r#"--- See :lua:obj:`x` :lua:obj:`ref`"#;
+        let expected = r#"--- See :lua:obj:`x` :lua:obj:`<Ref>ref</Ref>`"#;
+        test(
+            &code,
+            Box::new(RstParser::new(None, None, Some(31))),
+            &expected,
+        );
+        test(
+            &code,
+            Box::new(RstParser::new(None, None, Some(32))),
+            &expected,
+        );
+        test(
+            &code,
+            Box::new(RstParser::new(None, None, Some(34))),
+            &expected,
+        );
+
+        let code = r#"--- See :lua:obj:`x` :lua:obj:`"#;
+        let expected = r#"--- See :lua:obj:`x` :lua:obj:`<Ref></Ref>"#;
+        test(
+            &code,
+            Box::new(RstParser::new(None, None, Some(31))),
+            &expected,
+        );
+
+        let code = r#"--- See :lua:obj:`x` :lua:obj:``..."#;
+        let expected = r#"--- See :lua:obj:`x` :lua:obj:`<Ref>`</Ref>..."#;
+        test(
+            &code,
+            Box::new(RstParser::new(None, None, Some(31))),
+            &expected,
+        );
+    }
+
+    #[test]
+    fn test_rst_search_at_offset_default_role() {
+        let code = r#"--- See `ab`"#;
+        let expected = r#"--- See `<Ref>ab</Ref>`"#;
+        test(
+            &code,
+            Box::new(RstParser::new(None, Some("lua:obj".to_string()), Some(9))),
+            &expected,
+        );
+        test(
+            &code,
+            Box::new(RstParser::new(None, Some("lua:obj".to_string()), Some(10))),
+            &expected,
+        );
+        test(
+            &code,
+            Box::new(RstParser::new(None, Some("lua:obj".to_string()), Some(11))),
+            &expected,
+        );
+
+        let code = r#"--- See `"#;
+        let expected = r#"--- See `<Ref></Ref>"#;
+        test(
+            &code,
+            Box::new(RstParser::new(None, Some("lua:obj".to_string()), Some(9))),
+            &expected,
+        );
+
+        let code = r#"--- See `..."#;
+        let expected = r#"--- See `<Ref>...</Ref>"#;
+        test(
+            &code,
+            Box::new(RstParser::new(None, Some("lua:obj".to_string()), Some(9))),
+            &expected,
+        );
+
+        let code = r#"--- See ``"#;
+        let expected = r#"--- See `<Ref>`</Ref>"#;
+        test(
+            &code,
+            Box::new(RstParser::new(None, Some("lua:obj".to_string()), Some(9))),
+            &expected,
+        );
+    }
+}

--- a/crates/emmylua_parser_desc/src/testlib.rs
+++ b/crates/emmylua_parser_desc/src/testlib.rs
@@ -1,0 +1,70 @@
+use crate::util::sort_result;
+use crate::{DescItem, LuaDescParser};
+use emmylua_parser::{
+    LuaAstNode, LuaDocDescription, LuaKind, LuaParser, LuaSyntaxKind, ParserConfig,
+};
+
+pub fn test(code: &str, mut parser: Box<dyn LuaDescParser>, expected: &str) {
+    let tree = LuaParser::parse(code, ParserConfig::default());
+    let Some(desc) = tree
+        .get_red_root()
+        .descendants()
+        .filter(|node| matches!(node.kind(), LuaKind::Syntax(LuaSyntaxKind::DocDescription)))
+        .next()
+    else {
+        panic!("No desc found in {:?}", tree.get_red_root());
+    };
+    let ranges = parser.parse(code, LuaDocDescription::cast(desc).unwrap());
+    let result = format_result(code, ranges);
+    assert_eq!(result.trim(), expected.trim());
+}
+
+pub fn format_result(text: &str, mut items: Vec<DescItem>) -> String {
+    sort_result(&mut items);
+
+    let mut pos = 0;
+    let mut cur_items: Vec<DescItem> = Vec::new();
+    let mut res = String::new();
+
+    fn pop_cur_itemss(
+        text: &str,
+        cur_itemss: &mut Vec<DescItem>,
+        pos: &mut usize,
+        end: usize,
+        res: &mut String,
+    ) {
+        while let Some(cur_items) = cur_itemss.last() {
+            let cur_end: usize = cur_items.range.end().into();
+            if cur_end <= end {
+                *res += &text[*pos..cur_end];
+                *pos = cur_end;
+                *res += &format!("</{:?}>", cur_items.kind);
+                cur_itemss.pop();
+            } else {
+                break;
+            }
+        }
+
+        *res += &text[*pos..end];
+        *pos = end;
+    }
+
+    for next_item in items {
+        pop_cur_itemss(
+            text,
+            &mut cur_items,
+            &mut pos,
+            next_item.range.start().into(),
+            &mut res,
+        );
+        res += &text[pos..next_item.range.start().into()];
+        pos = next_item.range.start().into();
+        res += &format!("<{:?}>", next_item.kind);
+        cur_items.push(next_item);
+    }
+
+    pop_cur_itemss(text, &mut cur_items, &mut pos, text.len(), &mut res);
+    res += &text[pos..];
+
+    res
+}

--- a/crates/emmylua_parser_desc/src/util.rs
+++ b/crates/emmylua_parser_desc/src/util.rs
@@ -1,0 +1,519 @@
+use crate::{DescItem, DescItemKind};
+use emmylua_parser::{
+    LuaAstNode, LuaDocDescription, LuaKind, LuaSyntaxElement, LuaTokenData, LuaTokenKind, Reader,
+    SourceRange,
+};
+use rowan::Direction;
+use std::cmp::min;
+use unicode_general_category::{GeneralCategory, get_general_category};
+
+pub fn is_ws(c: char) -> bool {
+    matches!(c, ' ' | '\t')
+}
+
+pub fn desc_to_lines(
+    text: &str,
+    desc: LuaDocDescription,
+    cursor_position: Option<usize>,
+) -> Vec<SourceRange> {
+    let mut lines = Vec::new();
+    let mut line = SourceRange::EMPTY;
+    let mut skip_current_line_content = false;
+    let mut seen_doc_comments = false;
+
+    let mut handle_token = |token: &LuaSyntaxElement| {
+        let LuaSyntaxElement::Token(token) = token else {
+            return;
+        };
+
+        match token.kind() {
+            LuaKind::Token(LuaTokenKind::TkDocDetail) => {
+                if skip_current_line_content {
+                    return;
+                }
+
+                let range: SourceRange = token.text_range().into();
+                if line.end_offset() == range.start_offset {
+                    line.length += range.length;
+                } else {
+                    if line != SourceRange::EMPTY {
+                        seen_doc_comments |= !text[line.start_offset..line.end_offset()]
+                            .chars()
+                            .all(|c| c == '-');
+                        lines.push(line);
+                    }
+                    line = range;
+                }
+            }
+            LuaKind::Token(LuaTokenKind::TkEndOfLine) => {
+                seen_doc_comments |= !text[line.start_offset..line.end_offset()]
+                    .chars()
+                    .all(|c| c == '-');
+                lines.push(line);
+                line = SourceRange::EMPTY;
+                skip_current_line_content = false
+            }
+            LuaKind::Token(LuaTokenKind::TkNormalStart | LuaTokenKind::TkDocContinue) => {
+                let leading_marks = token.text().chars().take_while(|c| *c == '-').count();
+
+                // Skip content for lines that don't start with three dashes.
+                // Parser will see them as empty lines.
+                //
+                // Note: `leading_marks` can't be longer than three dashes.
+                // If comment starts with four or more dashes, the first three
+                // will end up in `TkNormalStart`, and the rest will be in `TkDocDetail`.
+                skip_current_line_content = leading_marks != 3;
+
+                if skip_current_line_content {
+                    line = SourceRange::new(token.text_range().start().into(), 0);
+                } else {
+                    line = token.text_range().into();
+                    line.start_offset += leading_marks;
+                    line.length -= leading_marks;
+                }
+            }
+            _ => {}
+        }
+    };
+
+    let prev_token = desc
+        .syntax()
+        .siblings_with_tokens(Direction::Prev)
+        .skip(1)
+        .skip_while(|tk| tk.kind() == LuaTokenKind::TkWhitespace.into())
+        .next();
+    if let Some(prev_token) = prev_token {
+        if prev_token.kind() == LuaTokenKind::TkNormalStart.into() {
+            handle_token(&prev_token);
+        }
+    }
+    for child in desc.syntax().children_with_tokens() {
+        handle_token(&child);
+    }
+
+    if !line.is_empty() {
+        seen_doc_comments |= !text[line.start_offset..line.end_offset()]
+            .trim_end()
+            .chars()
+            .all(|c| c == '-');
+        lines.push(line);
+    }
+
+    if !seen_doc_comments {
+        // Comment block consists entirely of lines that only start with
+        // two dashes, or lines that consist only of dashes and nothing else.
+        return Vec::new();
+    }
+
+    // Strip lines that consist entirely of dashes from start and end
+    // of the comment block.
+    //
+    // This handles cases where comment is adorned with long dashed lines:
+    //
+    // ```
+    // ---------------
+    // --- Comment ---
+    // ---------------
+    // ```
+    let mut new_start = 0;
+    for line in lines.iter() {
+        let line_text = &text[line.start_offset..line.end_offset()];
+        if line_text.trim_end().chars().all(|c| c == '-') {
+            new_start += 1;
+        } else {
+            break;
+        }
+    }
+    let mut new_end = lines.len();
+    for line in lines[new_start..].iter().rev() {
+        let line_text = &text[line.start_offset..line.end_offset()];
+        if line_text.trim_end().chars().all(|c| c == '-') {
+            new_end -= 1;
+        } else {
+            break;
+        }
+    }
+    if new_start > 0 || new_end < lines.len() {
+        lines = lines.drain(new_start..new_end).collect();
+    }
+
+    // Find and remove comment indentation.
+    let mut common_indent = None;
+    for line in lines.iter() {
+        let text = &text[line.start_offset..line.end_offset()];
+
+        if is_blank(text) {
+            continue;
+        }
+
+        let indent = text.chars().take_while(|c| is_ws(*c)).count();
+        common_indent = match common_indent {
+            None => Some(indent),
+            Some(common_indent) => Some(min(common_indent, indent)),
+        };
+    }
+
+    let common_indent = common_indent.unwrap_or_default();
+    if common_indent > 0 {
+        for line in lines.iter_mut() {
+            if line.length >= common_indent {
+                line.start_offset += common_indent;
+                line.length -= common_indent;
+            }
+        }
+    }
+
+    // Don't parse lines past user's cursor when calculating
+    // Go To Definition or Completion. We handle this here so that
+    // we don't affect common indent and other logic.
+    if let Some(cursor_position) = cursor_position {
+        for (i, line) in lines.iter().enumerate() {
+            let start: usize = line.start_offset.into();
+            if start > cursor_position {
+                lines.truncate(i);
+                break;
+            }
+        }
+    }
+
+    lines
+}
+
+pub trait ResultContainer {
+    fn results(&self) -> &Vec<DescItem>;
+
+    fn results_mut(&mut self) -> &mut Vec<DescItem>;
+
+    fn cursor_position(&self) -> Option<usize>;
+
+    fn emit_range(&mut self, range: SourceRange, kind: DescItemKind) {
+        let should_emit = if let Some(cursor_position) = self.cursor_position() {
+            kind == DescItemKind::Ref && range.contains_inclusive(cursor_position)
+        } else {
+            !range.is_empty()
+        };
+
+        if should_emit {
+            let Some(last) = self.results_mut().last_mut() else {
+                self.results_mut().push(DescItem {
+                    range: range.into(),
+                    kind,
+                });
+                return;
+            };
+
+            let end: usize = last.range.end().into();
+            if last.kind == kind && end == range.start_offset {
+                last.range = last.range.cover(range.into());
+            } else {
+                self.results_mut().push(DescItem {
+                    range: range.into(),
+                    kind,
+                });
+            }
+        }
+    }
+
+    fn emit(&mut self, reader: &mut Reader, kind: DescItemKind) {
+        self.emit_range(reader.current_range(), kind);
+        reader.reset_buff();
+    }
+}
+
+pub struct BacktrackPoint<'a> {
+    prev_reader: Reader<'a>,
+    prev_pos: usize,
+}
+
+impl<'a> BacktrackPoint<'a> {
+    pub fn new<C: ResultContainer>(c: &mut C, reader: &mut Reader<'a>) -> Self {
+        Self {
+            prev_reader: reader.clone(),
+            prev_pos: c.results().len(),
+        }
+    }
+
+    pub fn commit<C: ResultContainer>(self, c: &mut C, reader: &mut Reader<'a>) {
+        let (_c, _reader) = (c, reader); // We don't actually do anything.
+        std::mem::forget(self);
+    }
+
+    pub fn rollback<C: ResultContainer>(self, c: &mut C, reader: &mut Reader<'a>) {
+        *reader = self.prev_reader.clone();
+        c.results_mut().truncate(self.prev_pos);
+        std::mem::forget(self);
+    }
+}
+
+impl<'a> Drop for BacktrackPoint<'a> {
+    fn drop(&mut self) {
+        panic!("backtrack point should be committed or rolled back");
+    }
+}
+
+pub fn is_punct(c: char) -> bool {
+    if c.is_ascii() {
+        c.is_ascii_punctuation()
+    } else {
+        matches!(
+            get_general_category(c),
+            // P | S
+            GeneralCategory::ClosePunctuation
+                | GeneralCategory::ConnectorPunctuation
+                | GeneralCategory::DashPunctuation
+                | GeneralCategory::FinalPunctuation
+                | GeneralCategory::InitialPunctuation
+                | GeneralCategory::OpenPunctuation
+                | GeneralCategory::OtherPunctuation
+                | GeneralCategory::CurrencySymbol
+                | GeneralCategory::MathSymbol
+                | GeneralCategory::ModifierSymbol
+                | GeneralCategory::OtherSymbol
+        )
+    }
+}
+
+pub fn is_opening_quote(c: char) -> bool {
+    if c.is_ascii() {
+        matches!(c, '\'' | '"' | '<' | '(' | '[' | '{')
+    } else {
+        matches!(
+            get_general_category(c),
+            GeneralCategory::OpenPunctuation
+                | GeneralCategory::InitialPunctuation
+                | GeneralCategory::FinalPunctuation
+        )
+    }
+}
+
+pub fn is_closing_quote(c: char) -> bool {
+    if c.is_ascii() {
+        matches!(c, '\'' | '"' | '>' | ')' | ']' | '}')
+    } else {
+        matches!(
+            get_general_category(c),
+            GeneralCategory::ClosePunctuation
+                | GeneralCategory::InitialPunctuation
+                | GeneralCategory::FinalPunctuation
+        )
+    }
+}
+
+pub fn is_quote_match(l: char, r: char) -> bool {
+    if !l.is_ascii() || !r.is_ascii() {
+        return true;
+    }
+
+    match (l, r) {
+        ('\'', '\'') => true,
+        ('"', '"') => true,
+        ('<', '>') => true,
+        ('(', ')') => true,
+        ('[', ']') => true,
+        ('{', '}') => true,
+        _ => false,
+    }
+}
+
+pub fn is_blank(s: &str) -> bool {
+    s.is_empty() || s.chars().all(|c| c.is_ascii_whitespace())
+}
+
+pub fn is_code_directive(name: &str) -> bool {
+    matches!(
+        name,
+        "code-block" | "sourcecode" | "code" | "literalinclude" | "math"
+    )
+}
+
+pub fn is_lua_role(name: &str) -> bool {
+    matches!(
+        name,
+        "func"
+            | "data"
+            | "const"
+            | "class"
+            | "alias"
+            | "enum"
+            | "meth"
+            | "attr"
+            | "mod"
+            | "obj"
+            | "lua"
+    )
+}
+
+pub fn process_lua_code<'a, C: ResultContainer>(
+    c: &mut C,
+    range: SourceRange,
+    tokens: Vec<LuaTokenData>,
+) {
+    let mut pos = range.start_offset;
+    for token in tokens {
+        if pos < token.range.start_offset {
+            c.emit_range(
+                SourceRange::from_start_end(pos, token.range.start_offset),
+                DescItemKind::CodeBlock,
+            )
+        }
+        if !matches!(
+            token.kind,
+            LuaTokenKind::TkEof | LuaTokenKind::TkEndOfLine | LuaTokenKind::TkWhitespace
+        ) {
+            c.emit_range(token.range, DescItemKind::CodeBlockHl(token.kind));
+            pos = token.range.end_offset();
+        } else {
+            pos = token.range.start_offset;
+        }
+    }
+
+    if pos < range.end_offset() {
+        c.emit_range(
+            SourceRange::from_start_end(pos, range.end_offset()),
+            DescItemKind::CodeBlock,
+        )
+    }
+}
+
+pub fn sort_result(items: &mut Vec<DescItem>) {
+    items.sort_by_key(|r| {
+        let len: usize = r.range.len().into();
+
+        (
+            r.range.start(),               // Sort by start position,
+            usize::MAX - len,              // longer tokens first,
+            r.kind != DescItemKind::Scope, // scopes go first.
+        )
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use emmylua_parser::{LuaParser, ParserConfig};
+
+    fn get_desc(code: &str) -> LuaDocDescription {
+        LuaParser::parse(code, ParserConfig::default())
+            .get_chunk_node()
+            .descendants::<LuaDocDescription>()
+            .next()
+            .unwrap()
+    }
+
+    fn run_desc_to_lines(code: &str) -> Vec<&str> {
+        let desc = get_desc(code);
+        let lines = desc_to_lines(code, desc, None);
+        lines
+            .iter()
+            .map(|range| &code[range.start_offset..range.end_offset()])
+            .collect()
+    }
+
+    #[test]
+    fn test_desc_to_lines() {
+        assert_eq!(
+            run_desc_to_lines(
+                r#"
+                -- Desc
+            "#
+            ),
+            vec![""; 0]
+        );
+
+        assert_eq!(
+            run_desc_to_lines(
+                r#"
+                ----------
+                -- Desc --
+                ----------
+            "#
+            ),
+            vec![""; 0]
+        );
+
+        assert_eq!(
+            run_desc_to_lines(
+                r#"
+                ----------
+                -- Desc --
+                ----------
+                -- Desc --
+                ----------
+            "#
+            ),
+            vec![""; 0]
+        );
+
+        assert_eq!(
+            run_desc_to_lines(
+                r#"
+                --- Desc
+            "#
+            ),
+            vec!["Desc"]
+        );
+
+        assert_eq!(
+            run_desc_to_lines(
+                r#"
+                --------
+                --- Desc
+                --------
+            "#
+            ),
+            vec!["Desc"]
+        );
+
+        assert_eq!(
+            run_desc_to_lines(
+                r#"
+                --------
+                --- Desc
+                --------
+                --- Desc
+                --------
+            "#
+            ),
+            vec![" Desc", "-----", " Desc"]
+        );
+
+        assert_eq!(
+            run_desc_to_lines(
+                r#"
+                --- Desc
+                ---Desc 2
+            "#
+            ),
+            vec![" Desc", "Desc 2"]
+        );
+
+        assert_eq!(
+            run_desc_to_lines(
+                r#"
+                ---Desc
+                --- Desc 2
+            "#
+            ),
+            vec!["Desc", " Desc 2"]
+        );
+
+        assert_eq!(
+            run_desc_to_lines(
+                r#"
+                ---  Desc
+                ---  Desc 2
+            "#
+            ),
+            vec!["Desc", "Desc 2"]
+        );
+
+        assert_eq!(
+            run_desc_to_lines(
+                r#"
+                --- @param x int Desc
+            "#
+            ),
+            vec!["Desc"]
+        );
+    }
+}


### PR DESCRIPTION
This PR adds an optional feature that highlights Markdown, MySt (a Markdown extension used with Sphinx), and RST syntax in comments and provides Go To Definition implementation for cross-references. This feature is disabled by default; it can be enabled by specifying `doc.syntax` in `.emmyrc.json`.

<img width="1576" height="924" alt="image" src="https://github.com/user-attachments/assets/cb529517-06b4-4758-b1ee-d8f77dab2e18" />

# Caveats

- We use Semantic Tokens to provide syntax highlighting. Since there are no Semantic Tokens for bold and italic text, those are not highlighted.
