### PR TITLE
Don't add default fields when automatically editing `.emmyrc.json`

### DIFF
--- a/crates/emmylua_code_analysis/src/config/mod.rs
+++ b/crates/emmylua_code_analysis/src/config/mod.rs
@@ -7,15 +7,14 @@ use std::{
     path::{Path, PathBuf},
 };
 
-pub use config_loader::load_configs;
-pub use configs::EmmyrcFilenameConvention;
-pub use configs::EmmyrcLuaVersion;
-use configs::{EmmyrcCodeAction, EmmyrcDocumentColor};
+pub use config_loader::{load_configs, load_configs_raw};
 use configs::{
-    EmmyrcCodeLen, EmmyrcCompletion, EmmyrcDiagnostic, EmmyrcDoc, EmmyrcHover, EmmyrcInlayHint,
-    EmmyrcInlineValues, EmmyrcReference, EmmyrcResource, EmmyrcRuntime, EmmyrcSemanticToken,
-    EmmyrcSignature, EmmyrcStrict, EmmyrcWorkspace,
+    EmmyrcCodeAction, EmmyrcCodeLen, EmmyrcCompletion, EmmyrcDiagnostic, EmmyrcDoc,
+    EmmyrcDocumentColor, EmmyrcHover, EmmyrcInlayHint, EmmyrcInlineValues, EmmyrcReference,
+    EmmyrcResource, EmmyrcRuntime, EmmyrcSemanticToken, EmmyrcSignature, EmmyrcStrict,
+    EmmyrcWorkspace,
 };
+pub use configs::{EmmyrcFilenameConvention, EmmyrcLuaVersion};
 use emmylua_parser::{LuaLanguageLevel, ParserConfig, SpecialFunction};
 use regex::Regex;
 use rowan::NodeCache;


### PR DESCRIPTION
Right now, `disable_code` and `add_doc_tag` commands load `.emmyrc.json` into an `EmmyRc` object, change it, and then write it back. This results in serialization of all possible fields, even those that were missing in the
original JSON file.

This behaviour might cause an issue if these newly serialized fields shadow those configured in a global `.emmyrc.json`.

This PR changes edit logic to avoid creating full `EmmyRc` object. Instead, it parses `.emmyrc.json` into a `Value`, modifies it directly, and dumps it back. This way, only fields requested by the user are injected, and nothing else.