### PR TITLE
fix: don't add libraries in subdirectories to the main workspace

### DIFF
--- a/crates/emmylua_code_analysis/src/db_index/module/mod.rs
+++ b/crates/emmylua_code_analysis/src/db_index/module/mod.rs
@@ -316,12 +316,19 @@ impl LuaModuleIndex {
                     if matched_module_path.is_none() {
                         matched_module_path = Some((module_path, workspace.id));
                     } else {
-                        let (matched, _) = match matched_module_path.as_ref() {
+                        let (matched, matched_workspace_id) = match matched_module_path.as_ref() {
                             Some((matched, id)) => (matched, id),
                             None => continue,
                         };
                         if module_path.len() < matched.len() {
-                            matched_module_path = Some((module_path, workspace.id));
+                            // Libraries could be in a subdirectory of the main workspace
+                            // In case of a conflict, we prioritise the non-main workspace ID
+                            let workspace_id = if workspace.id.is_main() {
+                                *matched_workspace_id
+                            } else {
+                                workspace.id
+                            };
+                            matched_module_path = Some((module_path, workspace_id));
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #683.

note: I've also solved this in lux by not adding the project root to the workspaces, but instead adding the `lua` and `src` directories, if they exist.

Still, this fix could be useful in case someone else runs into this problem.