### PR TITLE
fix(hover): use left token when cursor is before '.', ':', '[', ']'

### DIFF
--- a/crates/emmylua_ls/src/handlers/test/hover_test.rs
+++ b/crates/emmylua_ls/src/handlers/test/hover_test.rs
@@ -310,4 +310,59 @@ mod tests {
         ));
         Ok(())
     }
+
+    #[gtest]
+    fn test_before_dot_returns_object_info() -> Result<()> {
+        let mut ws = ProviderVirtualWorkspace::new();
+        ws.def(
+            r#"
+                ---@class Node
+                ---@field field number?
+                ---@field method fun(self: Node)
+
+                ---@type Node
+                node = {}
+
+                function node.method() end
+            "#,
+        );
+
+        check!(ws.check_hover(
+            r#"
+                node<??>.field = nil
+            "#,
+            VirtualHoverResult {
+                value: "```lua\n(global) node: Node {\n    field: number?,\n    method: function,\n}\n```".to_string(),
+            },
+        ));
+
+        check!(ws.check_hover(
+            r#"
+                node<??>:method()
+            "#,
+            VirtualHoverResult {
+                value: "```lua\n(global) node: Node {\n    field: number?,\n    method: function,\n}\n```".to_string(),
+            },
+        ));
+
+        check!(ws.check_hover(
+            r#"
+                node<??>["key"] = "value"
+            "#,
+            VirtualHoverResult {
+                value: "```lua\n(global) node: Node {\n    field: number?,\n    method: function,\n}\n```".to_string(),
+            },
+        ));
+
+        check!(ws.check_hover(
+            r#"
+                node["key"<??>] = "value"
+            "#,
+            VirtualHoverResult {
+                value: "\"key\"".to_string(),
+            },
+        ));
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
Fixes an issue with hover behavior on dot selectors. When the cursor was placed to the left of the dot (e.g., `struct|.field`), the hover would incorrectly show information for the field and highlight the dot token.

Before/After:
<img width="933" height="310" alt="1754560858_screenshot" src="https://github.com/user-attachments/assets/9c6dd3d7-c235-4396-beaa-f6bc5f6a7e11" />
<img width="874" height="307" alt="1754560904_screenshot" src="https://github.com/user-attachments/assets/65b15a07-7b72-4d4f-b694-64964eaede8c" />
