### PR TITLE
Reuse doc completion, hover, and definition for `@see`

### DIFF
--- a/crates/emmylua_code_analysis/src/compilation/analyzer/doc/type_ref_tags.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/doc/type_ref_tags.rs
@@ -389,11 +389,16 @@ pub fn analyze_see(analyzer: &mut DocAnalyzer, tag: LuaDocTagSee) -> Option<()> 
     let owner = get_owner_id_or_report(analyzer, &tag)?;
     let content = tag.get_see_content()?;
     let text = content.get_text();
+    let descriptions = tag
+        .get_description()
+        .map(|description| description.get_description_text());
 
-    analyzer
-        .db
-        .get_property_index_mut()
-        .add_see(analyzer.file_id, owner, text.to_string());
+    analyzer.db.get_property_index_mut().add_see(
+        analyzer.file_id,
+        owner,
+        text.to_string(),
+        descriptions,
+    );
 
     Some(())
 }

--- a/crates/emmylua_code_analysis/src/db_index/property/mod.rs
+++ b/crates/emmylua_code_analysis/src/db_index/property/mod.rs
@@ -160,12 +160,18 @@ impl LuaPropertyIndex {
         &mut self,
         file_id: FileId,
         owner_id: LuaSemanticDeclId,
-        see_content: String,
+        mut see_content: String,
+        see_description: Option<String>,
     ) -> Option<()> {
         let property = self.get_or_create_property(owner_id.clone())?;
         let tag_content = property
             .tag_content
             .get_or_insert_with(|| Box::new(LuaTagContent::new()));
+
+        if let Some(see_description) = see_description {
+            see_content += " ";
+            see_content += &see_description;
+        }
 
         tag_content.add_tag("see".into(), see_content);
 

--- a/crates/emmylua_ls/src/handlers/completion/providers/doc_type_provider.rs
+++ b/crates/emmylua_ls/src/handlers/completion/providers/doc_type_provider.rs
@@ -63,7 +63,7 @@ fn check_can_add_type_completion(builder: &CompletionBuilder) -> Option<()> {
         LuaTokenKind::TkWhitespace => {
             let left_token = builder.trigger_token.prev_token()?;
             match left_token.kind().into() {
-                LuaTokenKind::TkTagReturn | LuaTokenKind::TkTagType | LuaTokenKind::TkTagSee => {
+                LuaTokenKind::TkTagReturn | LuaTokenKind::TkTagType => {
                     return Some(());
                 }
                 LuaTokenKind::TkName => {

--- a/crates/emmylua_ls/src/handlers/definition/goto_doc_see.rs
+++ b/crates/emmylua_ls/src/handlers/definition/goto_doc_see.rs
@@ -1,45 +1,41 @@
-use emmylua_code_analysis::{LuaMemberKey, LuaSemanticDeclId, LuaType, SemanticModel};
+use crate::handlers::definition::goto_path::goto_path;
+use emmylua_code_analysis::{
+    LuaCompilation, LuaMemberKey, LuaSemanticDeclId, LuaType, SemanticModel,
+};
 use emmylua_parser::{LuaAstToken, LuaGeneralToken};
+use emmylua_parser_desc::parse_ref_target;
 use lsp_types::GotoDefinitionResponse;
+use rowan::TextSize;
 
 pub fn goto_doc_see(
     semantic_model: &SemanticModel,
+    compilation: &LuaCompilation,
     content_token: LuaGeneralToken,
+    position_offset: TextSize,
 ) -> Option<GotoDefinitionResponse> {
     let text = content_token.get_text();
     let name_parts = text.split('#').collect::<Vec<_>>();
 
     match name_parts.len() {
-        1 => {
-            let name = &name_parts[0];
-            return goto_type(semantic_model, &name);
-        }
-        2 => {
+        0 => {}
+        // Legacy handler for format like `@see type#member`
+        2 if !name_parts[1].is_empty() && !name_parts[1].starts_with([' ', '\t']) => {
             let type_name = &name_parts[0];
             let member_name = &name_parts[1];
             return goto_type_member(semantic_model, &type_name, &member_name);
         }
-        _ => {}
+        _ => {
+            let path = parse_ref_target(
+                semantic_model.get_document().get_text(),
+                content_token.get_range(),
+                position_offset,
+            )?;
+
+            return goto_path(semantic_model, compilation, &path, content_token.syntax());
+        }
     }
 
     None
-}
-
-fn goto_type(semantic_model: &SemanticModel, type_name: &str) -> Option<GotoDefinitionResponse> {
-    let file_id = semantic_model.get_file_id();
-    let type_decl = semantic_model
-        .get_db()
-        .get_type_index()
-        .find_type_decl(file_id, type_name)?;
-    let locations = type_decl.get_locations();
-    let mut result = Vec::new();
-    for location in locations {
-        let document = semantic_model.get_document_by_file_id(location.file_id)?;
-        let lsp_location = document.to_lsp_location(location.range)?;
-        result.push(lsp_location);
-    }
-
-    Some(GotoDefinitionResponse::Array(result))
 }
 
 fn goto_type_member(

--- a/crates/emmylua_ls/src/handlers/definition/mod.rs
+++ b/crates/emmylua_ls/src/handlers/definition/mod.rs
@@ -94,7 +94,12 @@ pub fn definition(
     } else if token.kind() == LuaTokenKind::TkDocSeeContent.into() {
         let general_token = LuaGeneralToken::cast(token.clone())?;
         if let Some(_) = general_token.get_parent::<LuaDocTagSee>() {
-            return goto_doc_see(&semantic_model, general_token);
+            return goto_doc_see(
+                &semantic_model,
+                &analysis.compilation,
+                general_token,
+                position_offset,
+            );
         }
     } else if token.kind() == LuaTokenKind::TkDocDetail.into() {
         let parent = token.parent()?;

--- a/crates/emmylua_ls/src/handlers/hover/hover_builder.rs
+++ b/crates/emmylua_ls/src/handlers/hover/hover_builder.rs
@@ -23,7 +23,7 @@ pub struct HoverBuilder<'a> {
     pub annotation_description: Vec<MarkedString>,
     /// Type expansion, often used for alias types
     pub type_expansion: Option<Vec<String>>,
-    /// see
+    /// For `@see` and unknown tags tags
     tag_content: Option<Vec<(String, String)>>,
 
     pub is_completion: bool,
@@ -239,6 +239,9 @@ impl<'a> HoverBuilder<'a> {
             }
 
             if let Some(tag_content) = &self.tag_content {
+                if !tag_content.is_empty() {
+                    content.push_str("\n---\n");
+                }
                 for (tag_name, description) in tag_content {
                     content.push_str(&format!("\n@*{}* {}\n", tag_name, description));
                 }

--- a/crates/emmylua_ls/src/handlers/test/completion_test.rs
+++ b/crates/emmylua_ls/src/handlers/test/completion_test.rs
@@ -2082,4 +2082,37 @@ mod tests {
         ));
         Ok(())
     }
+
+    #[gtest]
+    fn test_see_completion() -> Result<()> {
+        let mut ws = ProviderVirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@class Meep
+            "#,
+        );
+        check!(ws.check_completion(
+            r#"
+            --- @see M<??>
+            "#,
+            vec![
+                VirtualCompletionItem {
+                    label: "Meep".to_string(),
+                    kind: CompletionItemKind::CLASS,
+                    ..Default::default()
+                },
+                VirtualCompletionItem {
+                    label: "virtual_0".to_string(),
+                    kind: CompletionItemKind::FILE,
+                    ..Default::default()
+                },
+                VirtualCompletionItem {
+                    label: "virtual_1".to_string(),
+                    kind: CompletionItemKind::FILE,
+                    ..Default::default()
+                },
+            ],
+        ));
+        Ok(())
+    }
 }

--- a/crates/emmylua_ls/src/handlers/test/definition_test.rs
+++ b/crates/emmylua_ls/src/handlers/test/definition_test.rs
@@ -466,4 +466,46 @@ mod tests {
         ));
         Ok(())
     }
+
+    #[gtest]
+    fn test_goto_see() -> Result<()> {
+        let mut ws = ProviderVirtualWorkspace::new();
+        let mut emmyrc = Emmyrc::default();
+        emmyrc.doc.syntax = DocSyntax::Myst;
+        ws.analysis.update_config(emmyrc.into());
+
+        ws.def_file(
+            "a.lua",
+            r#"
+                ---@class Meep
+            "#,
+        );
+
+        check!(ws.check_definition(
+            r#"
+                --- @see Mee<??>p
+            "#,
+            vec![Expected {
+                file: "a.lua".to_string(),
+                line: 1,
+            }],
+        ));
+
+        check!(ws.check_definition(
+            r#"
+                --- @class Foo
+                --- @field bar int
+                local Foo = {}
+
+                --- @see b<??>ar
+                Foo.xxx = 0
+            "#,
+            vec![Expected {
+                file: "".to_string(),
+                line: 2,
+            }],
+        ));
+
+        Ok(())
+    }
 }

--- a/crates/emmylua_ls/src/handlers/test/hover_test.rs
+++ b/crates/emmylua_ls/src/handlers/test/hover_test.rs
@@ -365,4 +365,52 @@ mod tests {
 
         Ok(())
     }
+
+    #[gtest]
+    fn test_see_tag() -> Result<()> {
+        let mut ws = ProviderVirtualWorkspace::new();
+        check!(ws.check_hover(
+            r#"
+                --- Description
+                ---
+                --- @see a.b.c
+                local function te<??>st() end
+            "#,
+            VirtualHoverResult {
+                value: "```lua\nlocal function test()\n```\n\n---\n\nDescription\n\n---\n\n@*see* a.b.c".to_string(),
+            },
+        ));
+
+        check!(ws.check_hover(
+            r#"
+                --- Description
+                ---
+                --- @see a.b.c see description
+                local function te<??>st() end
+            "#,
+            VirtualHoverResult {
+                value: "```lua\nlocal function test()\n```\n\n---\n\nDescription\n\n---\n\n@*see* a.b.c see description".to_string(),
+            },
+        ));
+
+        Ok(())
+    }
+
+    #[gtest]
+    fn test_other_tag() -> Result<()> {
+        let mut ws = ProviderVirtualWorkspace::new();
+        check!(ws.check_hover(
+            r#"
+                --- Description
+                ---
+                --- @xyz content
+                local function te<??>st() end
+            "#,
+            VirtualHoverResult {
+                value: "```lua\nlocal function test()\n```\n\n---\n\nDescription\n\n---\n\n@*xyz* content".to_string(),
+            },
+        ));
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
This PR improves handling of `@see` contents by reusing machinery introduced for parsing documentation comments. The behavior is backwards-compatible with the old syntax (`@see class#member`).

Fix #671
