### PR TITLE
Fix the new mismatched_lifetime_syntaxes warnings added in Rust 1.89

### DIFF
--- a/crates/emmylua_code_analysis/src/compilation/mod.rs
+++ b/crates/emmylua_code_analysis/src/compilation/mod.rs
@@ -24,7 +24,7 @@ impl LuaCompilation {
         compilation
     }
 
-    pub fn get_semantic_model(&self, file_id: FileId) -> Option<SemanticModel> {
+    pub fn get_semantic_model(&'_ self, file_id: FileId) -> Option<SemanticModel<'_>> {
         let cache = LuaInferCache::new(file_id, Default::default());
         let tree = self.db.get_vfs().get_syntax_tree(&file_id)?;
         Some(SemanticModel::new(

--- a/crates/emmylua_code_analysis/src/semantic/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/mod.rs
@@ -83,7 +83,7 @@ impl<'a> SemanticModel<'a> {
         }
     }
 
-    pub fn get_document(&self) -> LuaDocument {
+    pub fn get_document(&'_ self) -> LuaDocument<'_> {
         self.db.get_vfs().get_document(&self.file_id).unwrap()
     }
 
@@ -91,11 +91,11 @@ impl<'a> SemanticModel<'a> {
         self.db.get_module_index().get_module(self.file_id)
     }
 
-    pub fn get_document_by_file_id(&self, file_id: FileId) -> Option<LuaDocument> {
+    pub fn get_document_by_file_id(&'_ self, file_id: FileId) -> Option<LuaDocument<'_>> {
         self.db.get_vfs().get_document(&file_id)
     }
 
-    pub fn get_document_by_uri(&self, uri: &Uri) -> Option<LuaDocument> {
+    pub fn get_document_by_uri(&'_ self, uri: &Uri) -> Option<LuaDocument<'_>> {
         let file_id = self.db.get_vfs().get_file_id(&uri)?;
         self.db.get_vfs().get_document(&file_id)
     }

--- a/crates/emmylua_code_analysis/src/vfs/mod.rs
+++ b/crates/emmylua_code_analysis/src/vfs/mod.rs
@@ -121,7 +121,7 @@ impl Vfs {
         if let Some(s) = opt { Some(s) } else { None }
     }
 
-    pub fn get_document(&self, id: &FileId) -> Option<LuaDocument> {
+    pub fn get_document(&self, id: &FileId) -> Option<LuaDocument<'_>> {
         let path = self.file_path_map.get(&id.id)?;
         let text = self.get_file_content(id)?;
         let line_index = self.line_index_map.get(id)?;

--- a/crates/emmylua_ls/src/handlers/fold_range/builder.rs
+++ b/crates/emmylua_ls/src/handlers/fold_range/builder.rs
@@ -25,7 +25,7 @@ impl FoldingRangeBuilder<'_> {
         &self.root
     }
 
-    pub fn get_document(&self) -> &LuaDocument {
+    pub fn get_document(&'_ self) -> &'_ LuaDocument<'_> {
         self.document
     }
 


### PR DESCRIPTION
https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint/lifetime_syntax/static.MISMATCHED_LIFETIME_SYNTAXES.html