### PR TITLE
Clarify the option --mixin of the doc generation cli

### DIFF
--- a/crates/emmylua_doc_cli/src/cmd_args.rs
+++ b/crates/emmylua_doc_cli/src/cmd_args.rs
@@ -48,7 +48,9 @@ pub struct CmdArgs {
     #[arg(long, default_value = "Docs")]
     pub site_name: Option<String>,
 
-    /// The path of the mixin md file
+    /// A directory whose contents are merged with the generated Markdown files.
+    /// For example, to override docs/index.md, create a folder called "docs" in
+    /// your mixin folder and create a file called "index.md" inside it.
     #[arg(long)]
     pub mixin: Option<PathBuf>,
 


### PR DESCRIPTION
As stated in the issue https://github.com/EmmyLuaLs/emmylua-analyzer-rust/issues/36#issuecomment-2641984188, a folder must be specified, not a single Markdown file.