### PR TITLE
Switch `emmylua_parser_desc` to gtest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,6 +677,7 @@ name = "emmylua_parser_desc"
 version = "0.13.0"
 dependencies = [
  "emmylua_parser",
+ "googletest",
  "rowan",
  "unicode-general-category",
 ]

--- a/crates/emmylua_parser_desc/Cargo.toml
+++ b/crates/emmylua_parser_desc/Cargo.toml
@@ -17,3 +17,6 @@ emmylua_parser.workspace = true
 # external
 rowan.workspace = true
 unicode-general-category.workspace = true
+
+[dev-dependencies]
+googletest.workspace = true

--- a/crates/emmylua_parser_desc/src/lang/json/json_lexer.rs
+++ b/crates/emmylua_parser_desc/src/lang/json/json_lexer.rs
@@ -198,8 +198,9 @@ impl<'a> JsonLexer<'a> {
 mod tests {
     use super::*;
     use emmylua_parser::Reader;
+    use googletest::prelude::*;
 
-    #[test]
+    #[gtest]
     fn test_json_lexer_basic() {
         let json = r#"
 {
@@ -235,11 +236,11 @@ mod tests {
             }
         }
 
-        assert!(string_count > 0, "Should find strings");
-        assert!(number_count > 0, "Should find numbers");
-        assert!(keyword_count > 0, "Should find keywords");
-        assert!(brace_count > 0, "Should find braces");
-        assert!(bracket_count > 0, "Should find brackets");
+        expect_gt!(string_count, 0, "Should find strings");
+        expect_gt!(number_count, 0, "Should find numbers");
+        expect_gt!(keyword_count, 0, "Should find keywords");
+        expect_gt!(brace_count, 0, "Should find braces");
+        expect_gt!(bracket_count, 0, "Should find brackets");
 
         println!(
             "Found {} strings, {} numbers, {} keywords, {} braces, {} brackets",
@@ -247,7 +248,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[gtest]
     fn test_json_lexer_keywords() {
         let json = "true false null";
 
@@ -260,10 +261,10 @@ mod tests {
             .filter(|t| t.kind == JsonTokenKind::TkKeyword)
             .collect();
 
-        assert_eq!(keywords.len(), 3, "Should find exactly 3 keywords");
+        expect_eq!(keywords.len(), 3, "Should find exactly 3 keywords");
     }
 
-    #[test]
+    #[gtest]
     fn test_json_lexer_numbers() {
         let json = "42 -17 3.14 -2.5 1e10 1E-5 -1.23e+4";
 
@@ -276,10 +277,10 @@ mod tests {
             .filter(|t| t.kind == JsonTokenKind::TkNumber)
             .collect();
 
-        assert_eq!(numbers.len(), 7, "Should find exactly 7 numbers");
+        expect_eq!(numbers.len(), 7, "Should find exactly 7 numbers");
     }
 
-    #[test]
+    #[gtest]
     fn test_json_lexer_strings() {
         let json = r#""hello" "world with spaces" "escaped\"quote" "unicode\u0041""#;
 
@@ -292,10 +293,10 @@ mod tests {
             .filter(|t| t.kind == JsonTokenKind::TkString)
             .collect();
 
-        assert_eq!(strings.len(), 4, "Should find exactly 4 strings");
+        expect_eq!(strings.len(), 4, "Should find exactly 4 strings");
     }
 
-    #[test]
+    #[gtest]
     fn test_json_lexer_structure() {
         let json = r#"{"key": ["value1", "value2"]}"#;
 
@@ -315,11 +316,11 @@ mod tests {
         let has_colon = tokens.iter().any(|t| t.kind == JsonTokenKind::TkColon);
         let has_comma = tokens.iter().any(|t| t.kind == JsonTokenKind::TkComma);
 
-        assert!(has_left_brace, "Should have left brace");
-        assert!(has_right_brace, "Should have right brace");
-        assert!(has_left_bracket, "Should have left bracket");
-        assert!(has_right_bracket, "Should have right bracket");
-        assert!(has_colon, "Should have colon");
-        assert!(has_comma, "Should have comma");
+        expect_true!(has_left_brace, "Should have left brace");
+        expect_true!(has_right_brace, "Should have right brace");
+        expect_true!(has_left_bracket, "Should have left bracket");
+        expect_true!(has_right_bracket, "Should have right bracket");
+        expect_true!(has_colon, "Should have colon");
+        expect_true!(has_comma, "Should have comma");
     }
 }

--- a/crates/emmylua_parser_desc/src/lang/vimscript/vim_lexer.rs
+++ b/crates/emmylua_parser_desc/src/lang/vimscript/vim_lexer.rs
@@ -448,8 +448,9 @@ impl<'a> VimscriptLexer<'a> {
 mod tests {
     use super::*;
     use emmylua_parser::Reader;
+    use googletest::prelude::*;
 
-    #[test]
+    #[gtest]
     fn test_vim_lexer_basic() {
         let code = r#"
 " This is a comment
@@ -483,10 +484,10 @@ endfunction
             }
         }
 
-        assert!(keyword_count > 0, "Should find keywords");
-        assert!(string_count > 0, "Should find strings");
-        assert!(comment_count > 0, "Should find comments");
-        assert!(number_count > 0, "Should find numbers");
+        expect_gt!(keyword_count, 0, "Should find keywords");
+        expect_gt!(string_count, 0, "Should find strings");
+        expect_gt!(comment_count, 0, "Should find comments");
+        expect_gt!(number_count, 0, "Should find numbers");
 
         println!(
             "Found {} keywords, {} strings, {} comments, {} numbers",
@@ -494,7 +495,7 @@ endfunction
         );
     }
 
-    #[test]
+    #[gtest]
     fn test_vim_lexer_keywords() {
         let code = "function! if else endif let echo return";
 
@@ -507,6 +508,6 @@ endfunction
             .filter(|t| t.kind == VimTokenKind::TkKeyword)
             .collect();
 
-        assert!(keywords.len() >= 5, "Should find multiple keywords");
+        expect_ge!(keywords.len(), 5, "Should find multiple keywords");
     }
 }

--- a/crates/emmylua_parser_desc/src/md.rs
+++ b/crates/emmylua_parser_desc/src/md.rs
@@ -1465,9 +1465,10 @@ mod tests {
     use super::*;
     #[allow(unused)]
     use crate::testlib::{print_result, test};
+    use googletest::prelude::*;
 
-    #[test]
-    fn test_md() {
+    #[gtest]
+    fn test_md() -> Result<()> {
         let code = r#"
 --- # Inline code
 ---
@@ -1728,11 +1729,12 @@ mod tests {
 "#;
 
         // print_result(&code, Box::new(MdParser::new(None)));
-        test(&code, Box::new(MdParser::new(None)), &expected);
+        test(&code, Box::new(MdParser::new(None)), &expected).or_fail()?;
+        Ok(())
     }
 
-    #[test]
-    fn test_myst() {
+    #[gtest]
+    fn test_myst() -> Result<()> {
         let code = r#"
 --- # Inline
 ---
@@ -1831,11 +1833,12 @@ mod tests {
 --- <Markup>$$</Markup> <Arg>(anchor)</Arg></Scope>
 "#;
 
-        test(&code, Box::new(MdParser::new_myst(None, None)), &expected);
+        test(&code, Box::new(MdParser::new_myst(None, None)), &expected).or_fail()?;
+        Ok(())
     }
 
-    #[test]
-    fn test_myst_primary_domain() {
+    #[gtest]
+    fn test_myst_primary_domain() -> Result<()> {
         let code = r#"--- See {obj}`ref`"#;
 
         let expected = r#"
@@ -1846,28 +1849,33 @@ mod tests {
             &code,
             Box::new(MdParser::new_myst(Some("lua".to_string()), None)),
             &expected,
-        );
+        )
+        .or_fail()?;
+        Ok(())
     }
 
-    #[test]
-    fn test_myst_search_at_offset() {
+    #[gtest]
+    fn test_myst_search_at_offset() -> Result<()> {
         let code = r#"--- See {lua:obj}`x` {lua:obj}`ref`"#;
         let expected = r#"--- See {lua:obj}`x` {lua:obj}`<Ref>ref</Ref>`"#;
         test(
             &code,
             Box::new(MdParser::new_myst(None, Some(31))),
             &expected,
-        );
+        )
+        .or_fail()?;
         test(
             &code,
             Box::new(MdParser::new_myst(None, Some(32))),
             &expected,
-        );
+        )
+        .or_fail()?;
         test(
             &code,
             Box::new(MdParser::new_myst(None, Some(34))),
             &expected,
-        );
+        )
+        .or_fail()?;
 
         let code = r#"--- See {lua:obj}`x` {lua:obj}`"#;
         let expected = r#"--- See {lua:obj}`x` {lua:obj}`<Ref></Ref>"#;
@@ -1875,7 +1883,8 @@ mod tests {
             &code,
             Box::new(MdParser::new_myst(None, Some(31))),
             &expected,
-        );
+        )
+        .or_fail()?;
 
         let code = r#"--- See {lua:obj}`x` {lua:obj}``..."#;
         let expected = r#"--- See {lua:obj}`x` {lua:obj}`<Ref>`...</Ref>"#;
@@ -1883,11 +1892,13 @@ mod tests {
             &code,
             Box::new(MdParser::new_myst(None, Some(31))),
             &expected,
-        );
+        )
+        .or_fail()?;
+        Ok(())
     }
 
-    #[test]
-    fn test_md_no_indent() {
+    #[gtest]
+    fn test_md_no_indent() -> Result<()> {
         let code = r#"
 ---```lua
 ---
@@ -1914,6 +1925,7 @@ local t = 123
 local t = 123
 "#;
 
-        test(&code, Box::new(MdParser::new(None)), &expected);
+        test(&code, Box::new(MdParser::new(None)), &expected).or_fail()?;
+        Ok(())
     }
 }

--- a/crates/emmylua_parser_desc/src/ref_target.rs
+++ b/crates/emmylua_parser_desc/src/ref_target.rs
@@ -203,11 +203,12 @@ fn eat_string(reader: &mut Reader) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use googletest::prelude::*;
 
-    #[test]
+    #[gtest]
     fn test_parse_ref_target_simple() {
         let res = parse_ref_target("a.b.c.d", TextRange::up_to(7.into()), 7.into());
-        assert_eq!(
+        expect_eq!(
             res,
             Some(vec![
                 (
@@ -230,10 +231,10 @@ mod tests {
         )
     }
 
-    #[test]
+    #[gtest]
     fn test_parse_ref_target_simple_partial() {
         let res = parse_ref_target("a.abc.d", TextRange::up_to(7.into()), 2.into());
-        assert_eq!(
+        expect_eq!(
             res,
             Some(vec![
                 (
@@ -248,7 +249,7 @@ mod tests {
         );
 
         let res = parse_ref_target("a.abc.d", TextRange::up_to(7.into()), 3.into());
-        assert_eq!(
+        expect_eq!(
             res,
             Some(vec![
                 (
@@ -263,7 +264,7 @@ mod tests {
         );
 
         let res = parse_ref_target("a.abc.d", TextRange::up_to(7.into()), 5.into());
-        assert_eq!(
+        expect_eq!(
             res,
             Some(vec![
                 (
@@ -278,10 +279,10 @@ mod tests {
         );
     }
 
-    #[test]
+    #[gtest]
     fn test_parse_ref_target_type() {
         let res = parse_ref_target("a.b.[c.d].e", TextRange::up_to(11.into()), 11.into());
-        assert_eq!(
+        expect_eq!(
             res,
             Some(vec![
                 (
@@ -304,10 +305,10 @@ mod tests {
         )
     }
 
-    #[test]
+    #[gtest]
     fn test_parse_ref_target_type_at_end() {
         let res = parse_ref_target("a.b.[c.d]", TextRange::up_to(9.into()), 9.into());
-        assert_eq!(
+        expect_eq!(
             res,
             Some(vec![
                 (
@@ -326,14 +327,14 @@ mod tests {
         )
     }
 
-    #[test]
+    #[gtest]
     fn test_parse_ref_target_type_braces_strings() {
         let res = parse_ref_target(
             "a.b.[fun(x: table<int, string>): { n: int, lit: \"}]\" }]",
             TextRange::up_to(55.into()),
             55.into(),
         );
-        assert_eq!(
+        expect_eq!(
             res,
             Some(vec![
                 (
@@ -354,10 +355,10 @@ mod tests {
         )
     }
 
-    #[test]
+    #[gtest]
     fn test_parse_ref_target_type_string_literal() {
         let res = parse_ref_target("a.b.['c']", TextRange::up_to(9.into()), 9.into());
-        assert_eq!(
+        expect_eq!(
             res,
             Some(vec![
                 (

--- a/crates/emmylua_parser_desc/src/rst.rs
+++ b/crates/emmylua_parser_desc/src/rst.rs
@@ -1728,9 +1728,10 @@ mod tests {
     use super::*;
     #[allow(unused)]
     use crate::testlib::{print_result, test};
+    use googletest::prelude::*;
 
-    #[test]
-    fn test_rst() {
+    #[gtest]
+    fn test_rst() -> Result<()> {
         let code = r#"
 --- Inline markup
 --- =============
@@ -2179,11 +2180,12 @@ mod tests {
 --- <Scope><Markup>-</Markup> And this is list.</Scope>
 "#;
 
-        test(&code, Box::new(RstParser::new(None, None, None)), &expected);
+        test(&code, Box::new(RstParser::new(None, None, None)), &expected).or_fail()?;
+        Ok(())
     }
 
-    #[test]
-    fn test_rst_no_indent() {
+    #[gtest]
+    fn test_rst_no_indent() -> Result<()> {
         let code = r#"
 ---```lua
 ---
@@ -2214,11 +2216,13 @@ local t = 123
             &code,
             Box::new(RstParser::new(None, Some("lua:obj".to_string()), None)),
             &expected,
-        );
+        )
+        .or_fail()?;
+        Ok(())
     }
 
-    #[test]
-    fn test_rst_default_role() {
+    #[gtest]
+    fn test_rst_default_role() -> Result<()> {
         let code = r#"--- See `ref`"#;
 
         let expected = r#"--- See <Markup>`</Markup><Ref>ref</Ref><Markup>`</Markup>"#;
@@ -2227,11 +2231,13 @@ local t = 123
             &code,
             Box::new(RstParser::new(None, Some("lua:obj".to_string()), None)),
             &expected,
-        );
+        )
+        .or_fail()?;
+        Ok(())
     }
 
-    #[test]
-    fn test_rst_primary_domain() {
+    #[gtest]
+    fn test_rst_primary_domain() -> Result<()> {
         let code = r#"--- See :obj:`ref`"#;
 
         let expected = r#"
@@ -2242,28 +2248,33 @@ local t = 123
             &code,
             Box::new(RstParser::new(Some("lua".to_string()), None, None)),
             &expected,
-        );
+        )
+        .or_fail()?;
+        Ok(())
     }
 
-    #[test]
-    fn test_rst_search_at_offset() {
+    #[gtest]
+    fn test_rst_search_at_offset() -> Result<()> {
         let code = r#"--- See :lua:obj:`x` :lua:obj:`ref`"#;
         let expected = r#"--- See :lua:obj:`x` :lua:obj:`<Ref>ref</Ref>`"#;
         test(
             &code,
             Box::new(RstParser::new(None, None, Some(31))),
             &expected,
-        );
+        )
+        .or_fail()?;
         test(
             &code,
             Box::new(RstParser::new(None, None, Some(32))),
             &expected,
-        );
+        )
+        .or_fail()?;
         test(
             &code,
             Box::new(RstParser::new(None, None, Some(34))),
             &expected,
-        );
+        )
+        .or_fail()?;
 
         let code = r#"--- See :lua:obj:`x` :lua:obj:`"#;
         let expected = r#"--- See :lua:obj:`x` :lua:obj:`<Ref></Ref>"#;
@@ -2271,7 +2282,8 @@ local t = 123
             &code,
             Box::new(RstParser::new(None, None, Some(31))),
             &expected,
-        );
+        )
+        .or_fail()?;
 
         let code = r#"--- See :lua:obj:`x` :lua:obj:``..."#;
         let expected = r#"--- See :lua:obj:`x` :lua:obj:`<Ref>`</Ref>..."#;
@@ -2279,28 +2291,33 @@ local t = 123
             &code,
             Box::new(RstParser::new(None, None, Some(31))),
             &expected,
-        );
+        )
+        .or_fail()?;
+        Ok(())
     }
 
-    #[test]
-    fn test_rst_search_at_offset_default_role() {
+    #[gtest]
+    fn test_rst_search_at_offset_default_role() -> Result<()> {
         let code = r#"--- See `ab`"#;
         let expected = r#"--- See `<Ref>ab</Ref>`"#;
         test(
             &code,
             Box::new(RstParser::new(None, Some("lua:obj".to_string()), Some(9))),
             &expected,
-        );
+        )
+        .or_fail()?;
         test(
             &code,
             Box::new(RstParser::new(None, Some("lua:obj".to_string()), Some(10))),
             &expected,
-        );
+        )
+        .or_fail()?;
         test(
             &code,
             Box::new(RstParser::new(None, Some("lua:obj".to_string()), Some(11))),
             &expected,
-        );
+        )
+        .or_fail()?;
 
         let code = r#"--- See `"#;
         let expected = r#"--- See `<Ref></Ref>"#;
@@ -2308,7 +2325,8 @@ local t = 123
             &code,
             Box::new(RstParser::new(None, Some("lua:obj".to_string()), Some(9))),
             &expected,
-        );
+        )
+        .or_fail()?;
 
         let code = r#"--- See `..."#;
         let expected = r#"--- See `<Ref>...</Ref>"#;
@@ -2316,7 +2334,8 @@ local t = 123
             &code,
             Box::new(RstParser::new(None, Some("lua:obj".to_string()), Some(9))),
             &expected,
-        );
+        )
+        .or_fail()?;
 
         let code = r#"--- See ``"#;
         let expected = r#"--- See `<Ref>`</Ref>"#;
@@ -2324,6 +2343,8 @@ local t = 123
             &code,
             Box::new(RstParser::new(None, Some("lua:obj".to_string()), Some(9))),
             &expected,
-        );
+        )
+        .or_fail()?;
+        Ok(())
     }
 }

--- a/crates/emmylua_parser_desc/src/util.rs
+++ b/crates/emmylua_parser_desc/src/util.rs
@@ -358,6 +358,7 @@ pub fn sort_result(items: &mut Vec<DescItem>) {
 mod tests {
     use super::*;
     use emmylua_parser::{LuaParser, ParserConfig};
+    use googletest::prelude::*;
 
     fn get_desc(code: &str) -> LuaDocDescription {
         LuaParser::parse(code, ParserConfig::default())
@@ -376,9 +377,9 @@ mod tests {
             .collect()
     }
 
-    #[test]
+    #[gtest]
     fn test_desc_to_lines() {
-        assert_eq!(
+        expect_eq!(
             run_desc_to_lines(
                 r#"
                 -- Desc
@@ -387,7 +388,7 @@ mod tests {
             vec![""; 0]
         );
 
-        assert_eq!(
+        expect_eq!(
             run_desc_to_lines(
                 r#"
                 ----------
@@ -398,7 +399,7 @@ mod tests {
             vec![""; 0]
         );
 
-        assert_eq!(
+        expect_eq!(
             run_desc_to_lines(
                 r#"
                 ----------
@@ -411,7 +412,7 @@ mod tests {
             vec![""; 0]
         );
 
-        assert_eq!(
+        expect_eq!(
             run_desc_to_lines(
                 r#"
                 --- Desc
@@ -420,7 +421,7 @@ mod tests {
             vec!["Desc"]
         );
 
-        assert_eq!(
+        expect_eq!(
             run_desc_to_lines(
                 r#"
                 --------
@@ -431,7 +432,7 @@ mod tests {
             vec!["Desc"]
         );
 
-        assert_eq!(
+        expect_eq!(
             run_desc_to_lines(
                 r#"
                 --------
@@ -444,7 +445,7 @@ mod tests {
             vec![" Desc", "-----", " Desc"]
         );
 
-        assert_eq!(
+        expect_eq!(
             run_desc_to_lines(
                 r#"
                 --- Desc
@@ -454,7 +455,7 @@ mod tests {
             vec![" Desc", "Desc 2"]
         );
 
-        assert_eq!(
+        expect_eq!(
             run_desc_to_lines(
                 r#"
                 ---Desc
@@ -464,7 +465,7 @@ mod tests {
             vec!["Desc", " Desc 2"]
         );
 
-        assert_eq!(
+        expect_eq!(
             run_desc_to_lines(
                 r#"
                 ---  Desc
@@ -474,7 +475,7 @@ mod tests {
             vec!["Desc", "Desc 2"]
         );
 
-        assert_eq!(
+        expect_eq!(
             run_desc_to_lines(
                 r#"
                 --- @param x int Desc


### PR DESCRIPTION
GTest prints nice diffs, which is useful for debugging. It also allows continuing test even if assertion fails, so you see all failures if several test cases are crammed in a single `#[test]`.

<img width="1008" height="604" alt="image" src="https://github.com/user-attachments/assets/f7d763bc-8394-4719-9d66-6ebf3990f79f" />
