### PR TITLE
Warn and ignore variadic expansions that can't be handled properly

### DIFF
--- a/crates/emmylua_code_analysis/resources/schema.json
+++ b/crates/emmylua_code_analysis/resources/schema.json
@@ -417,6 +417,11 @@
           "description": "enum-value-mismatch",
           "type": "string",
           "const": "enum-value-mismatch"
+        },
+        {
+          "description": "Variadic operator (`T...`) used in a context where it's not allowed.",
+          "type": "string",
+          "const": "doc-type-unexpected-variadic"
         }
       ]
     },

--- a/crates/emmylua_code_analysis/src/compilation/test/mod.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/mod.rs
@@ -27,3 +27,4 @@ mod syntax_error_test;
 mod tuple_test;
 mod type_check_test;
 mod unpack_test;
+mod variadic_test;

--- a/crates/emmylua_code_analysis/src/compilation/test/variadic_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/variadic_test.rs
@@ -1,0 +1,224 @@
+#[cfg(test)]
+mod test {
+    use crate::{DiagnosticCode, VirtualWorkspace};
+
+    #[test]
+    fn test_unexpected_variadic_expansion() {
+        let mut ws = VirtualWorkspace::new();
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::DocTypeUnexpectedVariadic,
+            r#"
+                --- @type integer...
+                local _
+            "#,
+        ));
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::DocTypeUnexpectedVariadic,
+            r#"
+                --- @type (integer...)[]
+                local _
+            "#,
+        ));
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::DocTypeUnexpectedVariadic,
+            r#"
+                --- @type [integer..., integer]
+                local _
+            "#,
+        ));
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::DocTypeUnexpectedVariadic,
+            r#"
+                --- @class Foo
+                --- @operator add(Foo): Foo...
+            "#,
+        ));
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::DocTypeUnexpectedVariadic,
+            r#"
+                --- @class Foo
+                --- @operator add(Foo...): Foo
+            "#,
+        ));
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::DocTypeUnexpectedVariadic,
+            r#"
+                --- @class Foo
+                --- @operator call(Foo...): Foo
+            "#,
+        ));
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::DocTypeUnexpectedVariadic,
+            r#"
+                --- @return integer..., integer
+                function foo() end
+            "#,
+        ));
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::DocTypeUnexpectedVariadic,
+            r#"
+                --- @return integer...
+                --- @return integer
+                function foo() end
+            "#,
+        ));
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::DocTypeUnexpectedVariadic,
+            r#"
+                --- @param x any
+                --- @return boolean
+                --- @return_cast x integer...
+                function isInt(x) end
+            "#,
+        ));
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::DocTypeUnexpectedVariadic,
+            r#"
+                --- @param x integer...
+                function foo(x) end
+            "#,
+        ));
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::DocTypeUnexpectedVariadic,
+            r#"
+                --- @param x integer...
+                function foo(...) end
+            "#,
+        ));
+
+        assert!(ws.check_code_for(
+            DiagnosticCode::DocTypeUnexpectedVariadic,
+            r#"
+                --- @parameter x fun(): integer..., integer
+                function foo(x) end
+            "#,
+        ));
+    }
+
+    #[test]
+    fn test_expected_variadic_expansion() {
+        let mut ws = VirtualWorkspace::new();
+
+        assert!(ws.check_code_for(
+            DiagnosticCode::DocTypeUnexpectedVariadic,
+            r#"
+                --- @type [string, integer...]
+                local _
+            "#,
+        ));
+
+        assert!(ws.check_code_for(
+            DiagnosticCode::DocTypeUnexpectedVariadic,
+            r#"
+                --- @class Foo
+                --- @operator call(Foo): Foo...
+            "#,
+        ));
+
+        assert!(ws.check_code_for(
+            DiagnosticCode::DocTypeUnexpectedVariadic,
+            r#"
+                --- @parameter x fun(_: integer...)
+                function foo(x) end
+            "#,
+        ));
+
+        assert!(ws.check_code_for(
+            DiagnosticCode::DocTypeUnexpectedVariadic,
+            r#"
+                --- @parameter x fun(_: integer..., _: integer)
+                function foo(x) end
+            "#,
+        ));
+
+        assert!(ws.check_code_for(
+            DiagnosticCode::DocTypeUnexpectedVariadic,
+            r#"
+                --- @parameter x fun(_: integer..., _: integer...)
+                function foo(x) end
+            "#,
+        ));
+
+        assert!(ws.check_code_for(
+            DiagnosticCode::DocTypeUnexpectedVariadic,
+            r#"
+                --- @parameter x fun(): integer...
+                function foo(x) end
+            "#,
+        ));
+
+        assert!(ws.check_code_for(
+            DiagnosticCode::DocTypeUnexpectedVariadic,
+            r#"
+                --- @return integer...
+                function foo() end
+            "#,
+        ));
+
+        assert!(ws.check_code_for(
+            DiagnosticCode::DocTypeUnexpectedVariadic,
+            r#"
+                --- @type Foo<integer, integer...>
+                local _
+            "#,
+        ));
+
+        assert!(ws.check_code_for(
+            DiagnosticCode::DocTypeUnexpectedVariadic,
+            r#"
+                --- @type Foo<integer..., integer...>
+                local _
+            "#,
+        ));
+
+        assert!(ws.check_code_for(
+            DiagnosticCode::DocTypeUnexpectedVariadic,
+            r#"
+                --- @type Foo<integer..., integer>
+                local _
+            "#,
+        ));
+    }
+
+    #[test]
+    fn test_common_variadic_infer_errors() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            --- @return integer..., integer
+            function foo() end
+
+            a, b = foo()
+            a1, a2 = a
+        "#,
+        );
+
+        assert_eq!(ws.expr_ty("a"), ws.ty("integer"));
+        assert_eq!(ws.expr_ty("b"), ws.ty("integer"));
+        assert_eq!(ws.expr_ty("a1"), ws.ty("integer"));
+        assert_ne!(ws.expr_ty("a2"), ws.ty("integer"));
+
+        ws.def(
+            r#"
+            x = nil --- @type integer...
+            x1, x2 = x
+        "#,
+        );
+
+        assert_eq!(ws.expr_ty("x"), ws.ty("integer"));
+        assert_eq!(ws.expr_ty("x1"), ws.ty("integer"));
+        assert_ne!(ws.expr_ty("x2"), ws.ty("integer"));
+    }
+}

--- a/crates/emmylua_code_analysis/src/diagnostic/lua_diagnostic_code.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/lua_diagnostic_code.rs
@@ -101,6 +101,8 @@ pub enum DiagnosticCode {
     RequireModuleNotVisible,
     /// enum-value-mismatch
     EnumValueMismatch,
+    /// Variadic operator (`T...`) used in a context where it's not allowed.
+    DocTypeUnexpectedVariadic,
 
     #[serde(other)]
     None,


### PR DESCRIPTION
This PR checks for situation where variadic type expansion operator (`T...`) is used in an unexpected place, and can't be handled properly. Users will get a warning about such situations, and the operator will be ignored.

This prevents unexpected variadic types such as:

```lua
local x --- @type integer...
local x1, x2 = x
--             ^ EmmyLua thinks `x` is a result of a variadic expansion,
--    ^^  ^^     so it infers both `x1` and `x2` as integers.
```

Fix #701