### PR TITLE
Prevent `TplRef`s from escaping into types of global variables

### DIFF
--- a/crates/emmylua_code_analysis/src/compilation/test/flow.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/flow.rs
@@ -1,6 +1,5 @@
 #[cfg(test)]
 mod test {
-
     use crate::{DiagnosticCode, LuaType, VirtualWorkspace};
 
     #[test]
@@ -1174,8 +1173,25 @@ end
             end
             "#,
         );
-        let a = ws.expr_ty("A");
-        assert_eq!(ws.humanize_type(a), "T");
+
+        // Note: we can't use `ws.ty_expr("A")` to get a true type of `A`
+        // because `infer_global_type` will not allow generic variables
+        // from `bindGC` to escape into global space.
+        let db = &ws.analysis.compilation.db;
+        let decl_id = db
+            .get_global_index()
+            .get_global_decl_ids("A")
+            .unwrap()
+            .first()
+            .unwrap()
+            .clone();
+        let typ = db
+            .get_type_index()
+            .get_type_cache(&decl_id.into())
+            .unwrap()
+            .as_type();
+
+        assert_eq!(ws.humanize_type(typ.clone()), "T");
     }
 
     #[test]

--- a/crates/emmylua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/generic_test.rs
@@ -120,4 +120,42 @@ mod test {
         let expected = ws.ty("string");
         assert_eq!(a_ty, expected);
     }
+
+    #[test]
+    fn test_local_generics_in_global_scope() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+                --- @generic T
+                --- @param x T
+                function foo(x)
+                    a = x
+                end
+            "#,
+        );
+        let a_ty = ws.expr_ty("a");
+        assert_eq!(a_ty, ws.ty("unknown"));
+    }
+
+    // Currently fails:
+    /*
+    #[test]
+    fn test_local_generics_in_global_scope_member() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+                t = {}
+
+                --- @generic T
+                --- @param x T
+                function foo(x)
+                    t.a = x
+                end
+                local b = t.a
+            "#,
+        );
+        let a_ty = ws.expr_ty("t.a");
+        assert_eq!(a_ty, LuaType::Unknown);
+    }
+    */
 }


### PR DESCRIPTION
If a global variable is not annotated, and there's an assignment to it in a generic function, there's a chance that references to generic parameters will end up in its type.

This commit fixes the situation by skipping a type from a particular assignment if it contains generic references.

This is a rather simplistic implementation. We could be smarter about it: it's possible to analyze generics that're referenced from a type and replace them with their bounds:

```lua
--- @generic T: Bound
--- @param x T
function foo(x)
   -- After this commit, `globalVar` will have type `undefined` in other files;
   -- instead, we can infer it as `Bound`.
   globalVar = x
end
```

However, this will require saving bounds to a global context, and lazily replacing them later. I've decided to leave it as is for now.