### PR TITLE
fix(progress): don't finish before update

### DIFF
--- a/crates/emmylua_ls/src/context/file_diagnostic.rs
+++ b/crates/emmylua_ls/src/context/file_diagnostic.rs
@@ -205,7 +205,7 @@ async fn workspace_diagnostic(
                     status_bar.finish_progress_task(
                         client_id,
                         ProgressTask::DiagnoseWorkspace,
-                        None,
+                        Some("Diagnosis complete".to_string()),
                     );
                     break;
                 }

--- a/crates/emmylua_ls/src/handlers/initialized/mod.rs
+++ b/crates/emmylua_ls/src/handlers/initialized/mod.rs
@@ -163,15 +163,15 @@ pub async fn init_analysis(
         mut_analysis.update_files_by_path(files);
     }
 
-    status_bar.finish_progress_task(
-        client_id,
-        ProgressTask::LoadWorkspace,
-        Some(String::from("Finished loading workspace files")),
-    );
     status_bar.update_progress_task(
         client_id,
         ProgressTask::LoadWorkspace,
-        Some(100),
+        None,
+        Some(String::from("Finished loading workspace files")),
+    );
+    status_bar.finish_progress_task(
+        client_id,
+        ProgressTask::LoadWorkspace,
         Some("Indexing complete".to_string()),
     );
 


### PR DESCRIPTION
Problem: "Load workspace" progress is updated after finishing,
triggering errors in clients (e.g. Neovim).
(Regression introduced in f7b400c71b80d69873d3286554b2e7fb9180b3b4)

Solution: Correct sequencing of `update_progress` and `finish_progress`.

Also make `finish_progress` message for diagnostics consistent.
