### PR TITLE
fix: remove `unwrap`s

### DIFF
--- a/crates/emmylua_code_analysis/src/compilation/analyzer/flow/bind_analyze/mod.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/flow/bind_analyze/mod.rs
@@ -101,7 +101,7 @@ fn bind_node(binder: &mut FlowBinder, node: LuaAst, current: FlowId) -> FlowId {
         | LuaAst::LuaLiteralExpr(_)
         | LuaAst::LuaClosureExpr(_) => bind_expr(
             binder,
-            LuaExpr::cast(node.syntax().clone()).unwrap(),
+            LuaExpr::cast(node.syntax().clone()).expect("cast always succeedss"),
             current,
         ),
 

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/lua/for_range_stat.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/lua/for_range_stat.rs
@@ -146,9 +146,9 @@ pub fn infer_for_range_iter_expr_func(
         _ => return Err(InferFailReason::None),
     };
 
-    if status_param.is_none() {
+    let Some(status_param) = status_param else {
         return Ok(doc_function.get_variadic_ret());
-    }
+    };
     let mut substitutor = TypeSubstitutor::new();
     let mut context = TplContext {
         db,
@@ -163,7 +163,7 @@ pub fn infer_for_range_iter_expr_func(
         .map(|(_, opt_ty)| opt_ty.clone().unwrap_or(LuaType::Any))
         .collect::<Vec<_>>();
 
-    tpl_pattern_match_args(&mut context, &params, &vec![status_param.clone().unwrap()])?;
+    tpl_pattern_match_args(&mut context, &params, &[status_param])?;
 
     let instantiate_func = if let LuaType::DocFunction(f) =
         instantiate_doc_function(db, &doc_function, &substitutor)

--- a/crates/emmylua_code_analysis/src/config/flatten_config/mod.rs
+++ b/crates/emmylua_code_analysis/src/config/flatten_config/mod.rs
@@ -51,7 +51,7 @@ fn to_emmyrc_json(config: &FlattenConfigObject) -> Value {
             } else {
                 current = current
                     .as_object_mut()
-                    .unwrap()
+                    .expect("always an object")
                     .entry(key.to_string())
                     .or_insert(Value::Object(Default::default()));
             }

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/cast_type_mismatch.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/cast_type_mismatch.rs
@@ -272,7 +272,13 @@ fn expand_type_recursive(
                         Some(LuaType::Unknown)
                     }
                 }
-                1 => Some(expanded_types.iter().cloned().next().unwrap().into()),
+                1 => Some(
+                    expanded_types
+                        .iter()
+                        .next()
+                        .cloned()
+                        .expect("always one element"),
+                ),
                 _ => Some(LuaType::Union(
                     LuaUnionType::from_set(expanded_types).into(),
                 )),

--- a/crates/emmylua_code_analysis/src/lib.rs
+++ b/crates/emmylua_code_analysis/src/lib.rs
@@ -1,8 +1,11 @@
-#![deny(
-    clippy::unwrap_used,
-    clippy::unwrap_in_result,
-    clippy::panic,
-    clippy::panic_in_result_fn
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::unwrap_in_result,
+        clippy::panic,
+        clippy::panic_in_result_fn
+    )
 )]
 
 mod compilation;

--- a/crates/emmylua_code_analysis/src/resources/best_resource_path.rs
+++ b/crates/emmylua_code_analysis/src/resources/best_resource_path.rs
@@ -2,9 +2,7 @@ use std::path::PathBuf;
 
 pub fn get_best_resources_dir() -> PathBuf {
     if cfg!(debug_assertions) {
-        let exe_path = std::env::current_exe().unwrap();
-        let exe_dir = exe_path.parent().unwrap();
-        return exe_dir.join("resources");
+        return exe_dir().join("resources");
     }
 
     if cfg!(target_os = "windows") {
@@ -15,9 +13,7 @@ pub fn get_best_resources_dir() -> PathBuf {
                 .join("resources")
         } else {
             // Fall back to the directory next to the executable
-            let exe_path = std::env::current_exe().unwrap();
-            let exe_dir = exe_path.parent().unwrap();
-            exe_dir.join("resources")
+            exe_dir().join("resources")
         }
     } else {
         // On non-Windows platforms, try XDG_DATA_HOME first
@@ -35,10 +31,14 @@ pub fn get_best_resources_dir() -> PathBuf {
                     .join("resources")
             } else {
                 // Fall back to the directory next to the executable
-                let exe_path = std::env::current_exe().unwrap();
-                let exe_dir = exe_path.parent().unwrap();
-                exe_dir.join("resources")
+                exe_dir().join("resources")
             }
         }
     }
+}
+
+fn exe_dir() -> PathBuf {
+    let mut exe = std::env::current_exe().expect("executable available");
+    exe.pop();
+    exe
 }

--- a/crates/emmylua_code_analysis/src/resources/mod.rs
+++ b/crates/emmylua_code_analysis/src/resources/mod.rs
@@ -40,7 +40,11 @@ pub fn load_resource_std(
         .into_iter()
         .filter_map(|file| {
             if file.path.ends_with(".lua") {
-                let path = resoucres_dir.join(&file.path).to_str().unwrap().to_string();
+                let path = resoucres_dir
+                    .join(&file.path)
+                    .to_str()
+                    .expect("UTF-8 paths")
+                    .to_string();
                 Some(LuaFileInfo {
                     path,
                     content: file.content,
@@ -77,7 +81,7 @@ fn load_resource_from_file_system(resources_dir: &Path) -> Option<Vec<LuaFileInf
         let files = load_resource_from_include_dir();
         for file in &files {
             let path = resources_dir.join(&file.path);
-            let parent = path.parent().unwrap();
+            let parent = path.parent().expect("resources not top-level dir");
             if !parent.exists() {
                 match std::fs::create_dir_all(parent) {
                     Ok(_) => {}
@@ -134,7 +138,9 @@ fn check_need_dump_to_file_system() -> bool {
         return true;
     }
 
-    let content = std::fs::read_to_string(&version_path).unwrap();
+    let Ok(content) = std::fs::read_to_string(&version_path) else {
+        return true;
+    };
     let version = content.trim();
     if version != VERSION {
         return true;
@@ -154,10 +160,10 @@ fn walk_resource_dir(dir: &Dir, files: &mut Vec<LuaFileInfo>) {
         match entry {
             DirEntry::File(file) => {
                 let path = file.path();
-                let content = file.contents_utf8().unwrap();
+                let content = file.contents_utf8().expect("UTF-8 paths");
 
                 files.push(LuaFileInfo {
-                    path: path.to_str().unwrap().to_string(),
+                    path: path.to_str().expect("UTF-8 paths").to_string(),
                     content: content.to_string(),
                 });
             }

--- a/crates/emmylua_code_analysis/src/semantic/generic/instantiate_special_generic.rs
+++ b/crates/emmylua_code_analysis/src/semantic/generic/instantiate_special_generic.rs
@@ -131,12 +131,10 @@ fn instantiate_select_call(source: &LuaType, index: &LuaType) -> LuaType {
         NumOrLen::Num(i) => match multi_return {
             VariadicType::Base(_) => LuaType::Variadic(multi_return.clone().into()),
             VariadicType::Multi(_) => {
-                let total_len = multi_return.get_min_len();
-                if total_len.is_none() {
+                let Some(total_len) = multi_return.get_min_len() else {
                     return source.clone();
-                }
+                };
 
-                let total_len = total_len.unwrap();
                 let start = if i < 0 { total_len as i64 + i } else { i - 1 };
                 if start < 0 || start >= (total_len as i64) {
                     return source.clone();

--- a/crates/emmylua_code_analysis/src/semantic/generic/tpl_pattern.rs
+++ b/crates/emmylua_code_analysis/src/semantic/generic/tpl_pattern.rs
@@ -80,10 +80,9 @@ pub fn multi_param_tpl_pattern_match_multi_return(
         VariadicType::Multi(_) => {
             let mut call_arg_types = Vec::new();
             for (i, param) in func_param_types.iter().enumerate() {
-                let return_type = multi_return.get_type(i);
-                if return_type.is_none() {
+                let Some(return_type) = multi_return.get_type(i) else {
                     break;
-                }
+                };
 
                 if param.is_variadic() {
                     call_arg_types.push(LuaType::Variadic(
@@ -91,7 +90,7 @@ pub fn multi_param_tpl_pattern_match_multi_return(
                     ));
                     break;
                 } else {
-                    call_arg_types.push(return_type.unwrap().clone());
+                    call_arg_types.push(return_type.clone());
                 }
             }
 
@@ -485,13 +484,13 @@ fn table_generic_tpl_pattern_member_owner_match(
             });
     }
 
-    let key_type = match keys.len() {
-        0 => return Err(InferFailReason::None),
-        1 => keys.iter().next().cloned().unwrap(),
+    let key_type = match &keys[..] {
+        [] => return Err(InferFailReason::None),
+        [first] => first.clone(),
         _ => LuaType::Union(LuaUnionType::from_vec(keys).into()),
     };
-    let value_type = match values.len() {
-        1 => values.iter().next().cloned().unwrap(),
+    let value_type = match &values[..] {
+        [first] => first.clone(),
         _ => LuaType::Union(LuaUnionType::from_vec(values).into()),
     };
 

--- a/crates/emmylua_code_analysis/src/semantic/infer/infer_index.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/infer_index.rs
@@ -432,9 +432,9 @@ fn infer_custom_type_member(
                     }
                 }
             }
-            match result_types.len() {
-                0 => {}
-                1 => return Ok(result_types.iter().next().cloned().unwrap()),
+            match &result_types[..] {
+                [] => {}
+                [first] => return Ok(first.clone()),
                 _ => return Ok(LuaType::from_vec(result_types)),
             }
         }

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/binary_flow.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/binary_flow.rs
@@ -282,11 +282,14 @@ fn maybe_type_guard_binary(
         }
     }
 
-    if type_guard_expr.is_none() || literal_string.is_empty() {
+    let Some(type_guard_expr) = type_guard_expr else {
+        return Ok(ResultTypeOrContinue::Continue);
+    };
+    if literal_string.is_empty() {
         return Ok(ResultTypeOrContinue::Continue);
     }
 
-    let Some(arg_list) = type_guard_expr.unwrap().get_args_list() else {
+    let Some(arg_list) = type_guard_expr.get_args_list() else {
         return Ok(ResultTypeOrContinue::Continue);
     };
 

--- a/crates/emmylua_code_analysis/src/semantic/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/mod.rs
@@ -84,7 +84,10 @@ impl<'a> SemanticModel<'a> {
     }
 
     pub fn get_document(&'_ self) -> LuaDocument<'_> {
-        self.db.get_vfs().get_document(&self.file_id).unwrap()
+        self.db
+            .get_vfs()
+            .get_document(&self.file_id)
+            .expect("always exists")
     }
 
     pub fn get_module(&self) -> Option<&ModuleInfo> {

--- a/crates/emmylua_code_analysis/src/test_lib/mod.rs
+++ b/crates/emmylua_code_analysis/src/test_lib/mod.rs
@@ -18,7 +18,7 @@ pub struct VirtualWorkspace {
     id_counter: u32,
 }
 
-#[allow(unused)]
+#[allow(unused, clippy::unwrap_used)]
 impl VirtualWorkspace {
     pub fn new() -> Self {
         let generator = VirtualUrlGenerator::new();

--- a/crates/emmylua_code_analysis/src/vfs/document.rs
+++ b/crates/emmylua_code_analysis/src/vfs/document.rs
@@ -38,7 +38,7 @@ impl<'a> LuaDocument<'a> {
     }
 
     pub fn get_uri(&self) -> Uri {
-        file_path_to_uri(self.path).unwrap()
+        file_path_to_uri(self.path).expect("path is always absolute")
     }
 
     pub fn get_file_path(&self) -> &PathBuf {

--- a/crates/emmylua_code_analysis/src/vfs/loader.rs
+++ b/crates/emmylua_code_analysis/src/vfs/loader.rs
@@ -62,7 +62,7 @@ pub fn load_workspace_files(
         .filter(|e| e.file_type().is_file())
     {
         let path = entry.path();
-        let relative_path = path.strip_prefix(root).unwrap();
+        let relative_path = path.strip_prefix(root).expect("paths are descendants");
         if exclude_set.is_match(relative_path) {
             continue;
         }

--- a/crates/emmylua_code_analysis/src/vfs/mod.rs
+++ b/crates/emmylua_code_analysis/src/vfs/mod.rs
@@ -86,7 +86,7 @@ impl Vfs {
             let parse_config = self
                 .emmyrc
                 .as_ref()
-                .unwrap()
+                .expect("emmyrc set")
                 .get_parse_config(&mut self.node_cache);
             let tree = LuaParser::parse(&data, parse_config);
             self.tree_map.insert(fid, tree);


### PR DESCRIPTION
`unwrap` calls are set to `deny` in `emmylua_code_analysis` due to [`clippy::unwrap_used`](https://rust-lang.github.io/rust-clippy/master/index.html#unwrap_used). `expect` calls are preferred and ideally, the `unwrap` can be avoided.

So, in cases where `unwrap`/`expect` can't be avoided, I used expect. In some cases, the code could be rewritten to avoid unwrapping (e.g. with `let-else`). For the tests, the unwrap/panic checks are now disabled.