### PR TITLE
refactor: address all lint warnings in `emmylua_code_analysis`

### DIFF
--- a/crates/emmylua_check/src/output/json_output_writer.rs
+++ b/crates/emmylua_check/src/output/json_output_writer.rs
@@ -20,11 +20,10 @@ impl JsonOutputWriter {
         let output = match output {
             OutputDestination::Stdout => None,
             OutputDestination::File(path) => {
-                if let Some(parent) = path.parent() {
-                    if !parent.exists() {
+                if let Some(parent) = path.parent()
+                    && !parent.exists() {
                         std::fs::create_dir_all(parent).unwrap();
                     }
-                }
 
                 Some(std::fs::File::create(path).unwrap())
             }

--- a/crates/emmylua_check/src/output/json_output_writer.rs
+++ b/crates/emmylua_check/src/output/json_output_writer.rs
@@ -21,9 +21,10 @@ impl JsonOutputWriter {
             OutputDestination::Stdout => None,
             OutputDestination::File(path) => {
                 if let Some(parent) = path.parent()
-                    && !parent.exists() {
-                        std::fs::create_dir_all(parent).unwrap();
-                    }
+                    && !parent.exists()
+                {
+                    std::fs::create_dir_all(parent).unwrap();
+                }
 
                 Some(std::fs::File::create(path).unwrap())
             }

--- a/crates/emmylua_check/src/output/sarif_output_writer.rs
+++ b/crates/emmylua_check/src/output/sarif_output_writer.rs
@@ -24,9 +24,10 @@ impl SarifOutputWriter {
             OutputDestination::Stdout => None,
             OutputDestination::File(path) => {
                 if let Some(parent) = path.parent()
-                    && !parent.exists() {
-                        std::fs::create_dir_all(parent).unwrap();
-                    }
+                    && !parent.exists()
+                {
+                    std::fs::create_dir_all(parent).unwrap();
+                }
                 Some(std::fs::File::create(path).unwrap())
             }
         };

--- a/crates/emmylua_check/src/output/sarif_output_writer.rs
+++ b/crates/emmylua_check/src/output/sarif_output_writer.rs
@@ -23,11 +23,10 @@ impl SarifOutputWriter {
         let output = match output {
             OutputDestination::Stdout => None,
             OutputDestination::File(path) => {
-                if let Some(parent) = path.parent() {
-                    if !parent.exists() {
+                if let Some(parent) = path.parent()
+                    && !parent.exists() {
                         std::fs::create_dir_all(parent).unwrap();
                     }
-                }
                 Some(std::fs::File::create(path).unwrap())
             }
         };
@@ -115,7 +114,7 @@ impl OutputWriter for SarifOutputWriter {
         }
 
         let file_path = db.get_vfs().get_file_path(&file_id).unwrap();
-        let file_uri = file_path_to_uri(&file_path).unwrap().as_str().to_string();
+        let file_uri = file_path_to_uri(file_path).unwrap().as_str().to_string();
         self.ensure_tool();
 
         for diagnostic in diagnostics {

--- a/crates/emmylua_check/src/terminal_display/display.rs
+++ b/crates/emmylua_check/src/terminal_display/display.rs
@@ -395,12 +395,10 @@ impl TerminalDisplay {
             } else {
                 println!("\nCheck completed with warnings");
             }
+        } else if self.supports_color {
+            println!("\n{}", Color::Green.bold().paint("Check successful"));
         } else {
-            if self.supports_color {
-                println!("\n{}", Color::Green.bold().paint("Check successful"));
-            } else {
-                println!("\nCheck successful");
-            }
+            println!("\nCheck successful");
         }
     }
 }

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/common/migrate_global_member.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/common/migrate_global_member.rs
@@ -24,10 +24,10 @@ fn migrate_global_member_to_decl(db: &mut DbIndex, decl_id: LuaDeclId) -> Option
         return None;
     }
 
-    let owner_id = get_owner_id(db, &decl_id.clone().into())?;
+    let owner_id = get_owner_id(db, &decl_id.into())?;
 
     let name = decl.get_name();
-    let global_id = GlobalId::new(name.into());
+    let global_id = GlobalId::new(name);
     let members = db
         .get_member_index()
         .get_members(&LuaMemberOwner::GlobalPath(global_id))?
@@ -47,7 +47,7 @@ fn migrate_global_member_to_decl(db: &mut DbIndex, decl_id: LuaDeclId) -> Option
 fn migrate_global_member_to_member(db: &mut DbIndex, member_id: LuaMemberId) -> Option<()> {
     let member = db.get_member_index().get_member(&member_id)?;
     let global_id = member.get_global_id()?;
-    let owner_id = get_owner_id(db, &member_id.clone().into())?;
+    let owner_id = get_owner_id(db, &member_id.into())?;
 
     let members = db
         .get_member_index()

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/decl/exprs.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/decl/exprs.rs
@@ -327,16 +327,17 @@ pub fn analyze_call_expr(analyzer: &mut DeclAnalyzer, expr: LuaCallExpr) -> Opti
     if expr.is_require() {
         let args = expr.get_args_list()?;
         if let Some(LuaExpr::LiteralExpr(literal_expr)) = args.get_args().next()
-            && let Some(LuaLiteralToken::String(string_token)) = literal_expr.get_literal() {
-                let module_path = string_token.get_value();
-                let file_id = analyzer.get_file_id();
-                let module_info = analyzer.db.get_module_index().find_module(&module_path)?;
-                let module_file_id = module_info.file_id;
-                analyzer
-                    .db
-                    .get_file_dependencies_index_mut()
-                    .add_required_file(file_id, module_file_id);
-            }
+            && let Some(LuaLiteralToken::String(string_token)) = literal_expr.get_literal()
+        {
+            let module_path = string_token.get_value();
+            let file_id = analyzer.get_file_id();
+            let module_info = analyzer.db.get_module_index().find_module(&module_path)?;
+            let module_file_id = module_info.file_id;
+            analyzer
+                .db
+                .get_file_dependencies_index_mut()
+                .add_required_file(file_id, module_file_id);
+        }
     }
 
     Some(())

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/decl/exprs.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/decl/exprs.rs
@@ -22,7 +22,7 @@ pub fn analyze_name_expr(analyzer: &mut DeclAnalyzer, expr: LuaNameExpr) -> Opti
     let decl_id = LuaDeclId::new(file_id, position);
     let (decl_id, is_local) = if analyzer.decl.get_decl(&decl_id).is_some() {
         (Some(decl_id), false)
-    } else if let Some(decl) = analyzer.find_decl(&name, position) {
+    } else if let Some(decl) = analyzer.find_decl(name, position) {
         if decl.is_local() {
             // reference local variable
             (Some(decl.get_id()), true)
@@ -197,7 +197,7 @@ fn analyze_closure_params(
     let signature = analyzer
         .db
         .get_signature_index_mut()
-        .get_or_create(signature_id.clone());
+        .get_or_create(*signature_id);
     let params = closure.get_params_list()?.get_params();
     for param in params {
         let name = if let Some(name_token) = param.get_name_token() {
@@ -306,7 +306,7 @@ pub fn analyze_literal_expr(analyzer: &mut DeclAnalyzer, expr: LuaLiteralExpr) -
                 .map(|_| decl_id)
                 .or_else(|| {
                     analyzer
-                        .find_decl(&dots_token.get_text(), position)
+                        .find_decl(dots_token.get_text(), position)
                         .and_then(|decl| decl.is_local().then(|| decl.get_id()))
                 });
 
@@ -326,8 +326,8 @@ pub fn analyze_literal_expr(analyzer: &mut DeclAnalyzer, expr: LuaLiteralExpr) -
 pub fn analyze_call_expr(analyzer: &mut DeclAnalyzer, expr: LuaCallExpr) -> Option<()> {
     if expr.is_require() {
         let args = expr.get_args_list()?;
-        if let Some(LuaExpr::LiteralExpr(literal_expr)) = args.get_args().next() {
-            if let Some(LuaLiteralToken::String(string_token)) = literal_expr.get_literal() {
+        if let Some(LuaExpr::LiteralExpr(literal_expr)) = args.get_args().next()
+            && let Some(LuaLiteralToken::String(string_token)) = literal_expr.get_literal() {
                 let module_path = string_token.get_value();
                 let file_id = analyzer.get_file_id();
                 let module_info = analyzer.db.get_module_index().find_module(&module_path)?;
@@ -337,7 +337,6 @@ pub fn analyze_call_expr(analyzer: &mut DeclAnalyzer, expr: LuaCallExpr) -> Opti
                     .get_file_dependencies_index_mut()
                     .add_required_file(file_id, module_file_id);
             }
-        }
     }
 
     Some(())

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/decl/members.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/decl/members.rs
@@ -54,13 +54,11 @@ pub fn find_index_owner(
                 }
                 _ => {}
             }
-        } else {
-            if let Some(access_path) = index_expr.get_access_path() {
-                return (
-                    LuaMemberOwner::LocalUnresolve,
-                    Some(GlobalId(SmolStr::new(access_path).into())),
-                );
-            }
+        } else if let Some(access_path) = index_expr.get_access_path() {
+            return (
+                LuaMemberOwner::LocalUnresolve,
+                Some(GlobalId(SmolStr::new(access_path).into())),
+            );
         }
     }
 

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/decl/stats.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/decl/stats.rs
@@ -37,18 +37,14 @@ pub fn analyze_local_stat(analyzer: &mut DeclAnalyzer, stat: LuaLocalStat) -> Op
 
         let file_id = analyzer.get_file_id();
         let range = local_name.get_range();
-        let expr_id = if let Some(expr) = value_expr_list.get(index) {
-            Some(expr.get_syntax_id())
-        } else {
-            None
-        };
+        let expr_id = value_expr_list.get(index).map(|expr| expr.get_syntax_id());
 
         let decl = LuaDecl::new(
             &name,
             file_id,
             range,
             LuaDeclExtra::Local {
-                kind: local_name.syntax().kind().into(),
+                kind: local_name.syntax().kind(),
                 attrib,
             },
             expr_id,
@@ -62,11 +58,7 @@ pub fn analyze_local_stat(analyzer: &mut DeclAnalyzer, stat: LuaLocalStat) -> Op
 pub fn analyze_assign_stat(analyzer: &mut DeclAnalyzer, stat: LuaAssignStat) -> Option<()> {
     let (vars, value_exprs) = stat.get_var_and_expr_list();
     for (idx, var) in vars.iter().enumerate() {
-        let value_expr_id = if let Some(expr) = value_exprs.get(idx) {
-            Some(expr.get_syntax_id())
-        } else {
-            None
-        };
+        let value_expr_id = value_exprs.get(idx).map(|expr| expr.get_syntax_id());
 
         match &var {
             LuaVarExpr::NameExpr(name_expr) => {
@@ -91,7 +83,7 @@ pub fn analyze_assign_stat(analyzer: &mut DeclAnalyzer, stat: LuaAssignStat) -> 
                     continue;
                 }
 
-                if let Some(decl) = analyzer.find_decl(&name, position) {
+                if let Some(decl) = analyzer.find_decl(name, position) {
                     let decl_id = decl.get_id();
                     analyzer
                         .db
@@ -136,7 +128,7 @@ pub fn analyze_assign_stat(analyzer: &mut DeclAnalyzer, stat: LuaAssignStat) -> 
 
                 analyzer.db.get_member_index_mut().add_member(owner, member);
                 if let LuaMemberKey::Name(name) = &key {
-                    analyze_maybe_global_index_expr(analyzer, index_expr, &name, value_expr_id);
+                    analyze_maybe_global_index_expr(analyzer, index_expr, name, value_expr_id);
                 }
             }
         }
@@ -160,7 +152,7 @@ fn analyze_maybe_global_index_expr(
             let position = index_expr.get_position();
             let name = name_token.get_name_text();
             let range = index_expr.get_range();
-            if let Some(decl) = analyzer.find_decl(&name, position) {
+            if let Some(decl) = analyzer.find_decl(name, position) {
                 let decl_id = decl.get_id();
                 analyzer
                     .db
@@ -195,7 +187,7 @@ pub fn analyze_for_stat(analyzer: &mut DeclAnalyzer, stat: LuaForStat) -> Option
         file_id,
         range,
         LuaDeclExtra::Local {
-            kind: it_var.syntax().kind().into(),
+            kind: it_var.syntax().kind(),
             attrib: Some(LocalAttribute::IterConst),
         },
         None,
@@ -223,7 +215,7 @@ pub fn analyze_for_range_stat(analyzer: &mut DeclAnalyzer, stat: LuaForRangeStat
             file_id,
             range,
             LuaDeclExtra::Local {
-                kind: var.syntax().kind().into(),
+                kind: var.syntax().kind(),
                 attrib: Some(LocalAttribute::IterConst),
             },
             None,
@@ -242,7 +234,7 @@ pub fn analyze_func_stat(analyzer: &mut DeclAnalyzer, stat: LuaFuncStat) -> Opti
             let position = name_token.get_position();
             let name = name_token.get_name_text();
             let range = name_token.get_range();
-            if analyzer.find_decl(&name, position).is_none() {
+            if analyzer.find_decl(name, position).is_none() {
                 let decl = LuaDecl::new(
                     name,
                     file_id,
@@ -287,7 +279,7 @@ pub fn analyze_func_stat(analyzer: &mut DeclAnalyzer, stat: LuaFuncStat) -> Opti
                 .add_member(owner_id, member);
 
             if let LuaMemberKey::Name(name) = &key {
-                analyze_maybe_global_index_expr(analyzer, &index_expr, &name, None);
+                analyze_maybe_global_index_expr(analyzer, &index_expr, name, None);
             }
             LuaSemanticDeclId::Member(member_id)
         }
@@ -317,7 +309,7 @@ pub fn analyze_local_func_stat(analyzer: &mut DeclAnalyzer, stat: LuaLocalFuncSt
         file_id,
         range,
         LuaDeclExtra::Local {
-            kind: local_name.syntax().kind().into(),
+            kind: local_name.syntax().kind(),
             attrib: None,
         },
         None,

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/doc/diagnostic_tags.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/doc/diagnostic_tags.rs
@@ -34,17 +34,13 @@ fn analyze_diagnostic_disable(
     let comment = analyzer.comment.clone();
     let owner_block = comment.ancestors::<LuaBlock>().next()?;
     let owner_block_range = owner_block.get_range();
-    let is_file_disable = if let Some(_) = owner_block.get_parent::<LuaChunk>() {
-        true
-    } else {
-        false
-    };
+    let is_file_disable = owner_block.get_parent::<LuaChunk>().is_some();
 
     let diagnostic_index = analyzer.db.get_diagnostic_index_mut();
     if let Some(diagnostic_code_list) = diagnostic.get_code_list() {
         for code in diagnostic_code_list.get_codes() {
             let name = code.get_name_text();
-            let diagnostic_code = if let Some(code) = DiagnosticCode::from_str(name).ok() {
+            let diagnostic_code = if let Ok(code) = DiagnosticCode::from_str(name) {
                 code
             } else {
                 continue;
@@ -79,7 +75,7 @@ fn analyze_diagnostic_disable_next_line(
     let comment = analyzer.comment.clone();
     let comment_range = comment.get_range();
     let document = analyzer.db.get_vfs().get_document(&analyzer.file_id)?;
-    let comment_end_line = document.get_line(comment_range.end().into())?;
+    let comment_end_line = document.get_line(comment_range.end())?;
     let line_range = document.get_line_range(comment_end_line + 1)?;
     let valid_range = TextRange::new(comment_range.start(), line_range.end());
 
@@ -87,7 +83,7 @@ fn analyze_diagnostic_disable_next_line(
     if let Some(diagnostic_code_list) = diagnostic.get_code_list() {
         for code in diagnostic_code_list.get_codes() {
             let name = code.get_name_text();
-            let diagnostic_code = if let Some(code) = DiagnosticCode::from_str(name).ok() {
+            let diagnostic_code = if let Ok(code) = DiagnosticCode::from_str(name) {
                 code
             } else {
                 continue;
@@ -115,14 +111,14 @@ fn analyze_diagnostic_disable_line(
     let comment = analyzer.comment.clone();
     let comment_range = comment.get_range();
     let document = analyzer.db.get_vfs().get_document(&analyzer.file_id)?;
-    let comment_end_line = document.get_line(comment_range.end().into())?;
+    let comment_end_line = document.get_line(comment_range.end())?;
     let valid_range = document.get_line_range(comment_end_line)?;
 
     let diagnostic_index = analyzer.db.get_diagnostic_index_mut();
     if let Some(diagnostic_code_list) = diagnostic.get_code_list() {
         for code in diagnostic_code_list.get_codes() {
             let name = code.get_name_text();
-            let diagnostic_code = if let Some(code) = DiagnosticCode::from_str(name).ok() {
+            let diagnostic_code = if let Ok(code) = DiagnosticCode::from_str(name) {
                 code
             } else {
                 continue;
@@ -151,7 +147,7 @@ fn analyze_diagnostic_enable(
     let diagnostic_code_list = diagnostic.get_code_list()?;
     for code in diagnostic_code_list.get_codes() {
         let name = code.get_name_text();
-        let diagnostic_code = if let Some(code) = DiagnosticCode::from_str(name).ok() {
+        let diagnostic_code = if let Ok(code) = DiagnosticCode::from_str(name) {
             code
         } else {
             continue;

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/doc/file_generic_index.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/doc/file_generic_index.rs
@@ -100,13 +100,14 @@ impl FileGenericIndex {
 
         for params_id in params_ids.iter().rev() {
             if let Some(params) = self.generic_params.get(*params_id)
-                && let Some((id, is_variadic)) = params.params.get(name) {
-                    if params.is_func {
-                        return Some((GenericTplId::Func(*id as u32), *is_variadic));
-                    } else {
-                        return Some((GenericTplId::Type(*id as u32), *is_variadic));
-                    }
+                && let Some((id, is_variadic)) = params.params.get(name)
+            {
+                if params.is_func {
+                    return Some((GenericTplId::Func(*id as u32), *is_variadic));
+                } else {
+                    return Some((GenericTplId::Type(*id as u32), *is_variadic));
                 }
+            }
         }
 
         None

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/doc/file_generic_index.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/doc/file_generic_index.rs
@@ -99,15 +99,14 @@ impl FileGenericIndex {
         let params_ids = self.find_generic_params(position)?;
 
         for params_id in params_ids.iter().rev() {
-            if let Some(params) = self.generic_params.get(*params_id) {
-                if let Some((id, is_variadic)) = params.params.get(name) {
+            if let Some(params) = self.generic_params.get(*params_id)
+                && let Some((id, is_variadic)) = params.params.get(name) {
                     if params.is_func {
                         return Some((GenericTplId::Func(*id as u32), *is_variadic));
                     } else {
                         return Some((GenericTplId::Type(*id as u32), *is_variadic));
                     }
                 }
-            }
         }
 
         None

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/doc/infer_type.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/doc/infer_type.rs
@@ -205,49 +205,50 @@ fn infer_special_table_type(
 
 fn infer_generic_type(analyzer: &mut DocAnalyzer, generic_type: &LuaDocGenericType) -> LuaType {
     if let Some(name_type) = generic_type.get_name_type()
-        && let Some(name) = name_type.get_name_text() {
-            if let Some(typ) = infer_special_generic_type(analyzer, &name, generic_type) {
-                return typ;
-            }
-
-            let id = if let Some(name_type_decl) = analyzer
-                .db
-                .get_type_index_mut()
-                .find_type_decl(analyzer.file_id, &name)
-            {
-                name_type_decl.get_id()
-            } else {
-                analyzer.db.get_diagnostic_index_mut().add_diagnostic(
-                    analyzer.file_id,
-                    AnalyzeError::new(
-                        DiagnosticCode::TypeNotFound,
-                        &t!("Type '%{name}' not found", name = name),
-                        generic_type.get_range(),
-                    ),
-                );
-                return LuaType::Unknown;
-            };
-
-            let mut generic_params = Vec::new();
-            if let Some(generic_decl_list) = generic_type.get_generic_types() {
-                for param in generic_decl_list.get_types() {
-                    let param_type = infer_type(analyzer, param);
-                    if param_type.is_unknown() {
-                        return LuaType::Unknown;
-                    }
-                    generic_params.push(param_type);
-                }
-            }
-            if let Some(name_type) = generic_type.get_name_type() {
-                analyzer.db.get_reference_index_mut().add_type_reference(
-                    analyzer.file_id,
-                    id.clone(),
-                    name_type.get_range(),
-                );
-            }
-
-            return LuaType::Generic(LuaGenericType::new(id, generic_params).into());
+        && let Some(name) = name_type.get_name_text()
+    {
+        if let Some(typ) = infer_special_generic_type(analyzer, &name, generic_type) {
+            return typ;
         }
+
+        let id = if let Some(name_type_decl) = analyzer
+            .db
+            .get_type_index_mut()
+            .find_type_decl(analyzer.file_id, &name)
+        {
+            name_type_decl.get_id()
+        } else {
+            analyzer.db.get_diagnostic_index_mut().add_diagnostic(
+                analyzer.file_id,
+                AnalyzeError::new(
+                    DiagnosticCode::TypeNotFound,
+                    &t!("Type '%{name}' not found", name = name),
+                    generic_type.get_range(),
+                ),
+            );
+            return LuaType::Unknown;
+        };
+
+        let mut generic_params = Vec::new();
+        if let Some(generic_decl_list) = generic_type.get_generic_types() {
+            for param in generic_decl_list.get_types() {
+                let param_type = infer_type(analyzer, param);
+                if param_type.is_unknown() {
+                    return LuaType::Unknown;
+                }
+                generic_params.push(param_type);
+            }
+        }
+        if let Some(name_type) = generic_type.get_name_type() {
+            analyzer.db.get_reference_index_mut().add_type_reference(
+                analyzer.file_id,
+                id.clone(),
+                name_type.get_range(),
+            );
+        }
+
+        return LuaType::Generic(LuaGenericType::new(id, generic_params).into());
+    }
 
     LuaType::Unknown
 }
@@ -505,9 +506,10 @@ fn infer_func_type(analyzer: &mut DocAnalyzer, func: &LuaDocFuncType) -> LuaType
     // compact luals
     if is_colon
         && let Some(first_param) = params_result.first()
-            && first_param.0 == "self" {
-                is_colon = false
-            }
+        && first_param.0 == "self"
+    {
+        is_colon = false
+    }
 
     let return_type = if return_types.len() == 1 {
         return_types[0].clone()

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/doc/infer_type.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/doc/infer_type.rs
@@ -204,9 +204,9 @@ fn infer_special_table_type(
 }
 
 fn infer_generic_type(analyzer: &mut DocAnalyzer, generic_type: &LuaDocGenericType) -> LuaType {
-    if let Some(name_type) = generic_type.get_name_type() {
-        if let Some(name) = name_type.get_name_text() {
-            if let Some(typ) = infer_special_generic_type(analyzer, &name, &generic_type) {
+    if let Some(name_type) = generic_type.get_name_type()
+        && let Some(name) = name_type.get_name_text() {
+            if let Some(typ) = infer_special_generic_type(analyzer, &name, generic_type) {
                 return typ;
             }
 
@@ -248,7 +248,6 @@ fn infer_generic_type(analyzer: &mut DocAnalyzer, generic_type: &LuaDocGenericTy
 
             return LuaType::Generic(LuaGenericType::new(id, generic_params).into());
         }
-    }
 
     LuaType::Unknown
 }
@@ -504,13 +503,11 @@ fn infer_func_type(analyzer: &mut DocAnalyzer, func: &LuaDocFuncType) -> LuaType
     }
 
     // compact luals
-    if is_colon {
-        if let Some(first_param) = params_result.first() {
-            if first_param.0 == "self" {
+    if is_colon
+        && let Some(first_param) = params_result.first()
+            && first_param.0 == "self" {
                 is_colon = false
             }
-        }
-    }
 
     let return_type = if return_types.len() == 1 {
         return_types[0].clone()
@@ -527,14 +524,11 @@ fn infer_func_type(analyzer: &mut DocAnalyzer, func: &LuaDocFuncType) -> LuaType
 
 fn get_colon_define(analyzer: &mut DocAnalyzer) -> Option<bool> {
     let owner = analyzer.comment.get_owner()?;
-    match owner {
-        LuaAst::LuaFuncStat(func_stat) => {
-            let func_name = func_stat.get_func_name()?;
-            if let LuaVarExpr::IndexExpr(index_expr) = func_name {
-                return Some(index_expr.get_index_token()?.is_colon());
-            }
+    if let LuaAst::LuaFuncStat(func_stat) = owner {
+        let func_name = func_stat.get_func_name()?;
+        if let LuaVarExpr::IndexExpr(index_expr) = func_name {
+            return Some(index_expr.get_index_token()?.is_colon());
         }
-        _ => {}
     }
 
     None
@@ -589,7 +583,7 @@ fn infer_str_tpl(
             let prefix = prefix.unwrap_or("".to_string());
             let suffix = suffix.unwrap_or("".to_string());
             if tpl_id.is_func() {
-                let str_tpl_type = LuaStringTplType::new(&prefix, &tpl.get_name(), tpl_id, &suffix);
+                let str_tpl_type = LuaStringTplType::new(&prefix, tpl.get_name(), tpl_id, &suffix);
                 return LuaType::StrTplRef(str_tpl_type.into());
             }
         }

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/doc/mod.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/doc/mod.rs
@@ -103,11 +103,10 @@ pub fn preprocess_description(mut description: &str, owner: Option<&LuaSemanticD
     } else {
         true
     };
-    if need_remove_start_char {
-        if description.starts_with(['#', '@']) {
-            description = description.trim_start_matches(|c| c == '#' || c == '@');
+    if need_remove_start_char
+        && description.starts_with(['#', '@']) {
+            description = description.trim_start_matches(['#', '@']);
         }
-    }
 
     let mut result = String::new();
     let lines = description.lines();

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/doc/mod.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/doc/mod.rs
@@ -103,10 +103,9 @@ pub fn preprocess_description(mut description: &str, owner: Option<&LuaSemanticD
     } else {
         true
     };
-    if need_remove_start_char
-        && description.starts_with(['#', '@']) {
-            description = description.trim_start_matches(['#', '@']);
-        }
+    if need_remove_start_char && description.starts_with(['#', '@']) {
+        description = description.trim_start_matches(['#', '@']);
+    }
 
     let mut result = String::new();
     let lines = description.lines();

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/doc/property_tags.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/doc/property_tags.rs
@@ -70,7 +70,9 @@ pub fn analyze_nodiscard(analyzer: &mut DocAnalyzer, nodiscard: LuaDocTagNodisca
 }
 
 pub fn analyze_deprecated(analyzer: &mut DocAnalyzer, tag: LuaDocTagDeprecated) -> Option<()> {
-    let message = tag.get_description().map(|desc| desc.get_description_text().to_string());
+    let message = tag
+        .get_description()
+        .map(|desc| desc.get_description_text().to_string());
     let owner_id = get_owner_id_or_report(analyzer, &tag)?;
 
     analyzer

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/doc/property_tags.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/doc/property_tags.rs
@@ -70,11 +70,7 @@ pub fn analyze_nodiscard(analyzer: &mut DocAnalyzer, nodiscard: LuaDocTagNodisca
 }
 
 pub fn analyze_deprecated(analyzer: &mut DocAnalyzer, tag: LuaDocTagDeprecated) -> Option<()> {
-    let message = if let Some(desc) = tag.get_description() {
-        Some(desc.get_description_text().to_string())
-    } else {
-        None
-    };
+    let message = tag.get_description().map(|desc| desc.get_description_text().to_string());
     let owner_id = get_owner_id_or_report(analyzer, &tag)?;
 
     analyzer

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/doc/tags.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/doc/tags.rs
@@ -160,22 +160,22 @@ pub fn get_owner_id(analyzer: &mut DocAnalyzer) -> Option<LuaSemanticDeclId> {
                 LuaVarExpr::NameExpr(name_expr) => {
                     let decl_id = LuaDeclId::new(analyzer.file_id, name_expr.get_position());
                     let _ = analyzer.db.get_decl_index_mut().get_decl_mut(&decl_id)?;
-                    return Some(LuaSemanticDeclId::LuaDecl(decl_id));
+                    Some(LuaSemanticDeclId::LuaDecl(decl_id))
                 }
                 LuaVarExpr::IndexExpr(index_expr) => {
                     let member_id = LuaMemberId::new(index_expr.get_syntax_id(), analyzer.file_id);
-                    return Some(LuaSemanticDeclId::Member(member_id));
+                    Some(LuaSemanticDeclId::Member(member_id))
                 } // _ => None,
             }
         }
         LuaAst::LuaLocalStat(local_stat) => {
             let local_name = local_stat.child::<LuaLocalName>()?;
             let decl_id = LuaDeclId::new(analyzer.file_id, local_name.get_position());
-            return Some(LuaSemanticDeclId::LuaDecl(decl_id));
+            Some(LuaSemanticDeclId::LuaDecl(decl_id))
         }
         LuaAst::LuaTableField(field) => {
             let member_id = LuaMemberId::new(field.get_syntax_id(), analyzer.file_id);
-            return Some(LuaSemanticDeclId::Member(member_id));
+            Some(LuaSemanticDeclId::Member(member_id))
         }
         LuaAst::LuaCallExprStat(call_expr_stat) => {
             let call_expr = call_expr_stat.get_call_expr()?;

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/doc/type_def_tags.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/doc/type_def_tags.rs
@@ -186,7 +186,9 @@ fn get_generic_params(
             continue;
         };
 
-        let type_ref = param.get_type().map(|type_ref| infer_type(analyzer, type_ref));
+        let type_ref = param
+            .get_type()
+            .map(|type_ref| infer_type(analyzer, type_ref));
 
         let is_variadic = param.is_variadic();
         params_result.push(GenericParam::new(name, type_ref, is_variadic));
@@ -239,24 +241,26 @@ fn get_local_stat_reference_ranges(
         let name_node = syntax_id.to_node_from_root(&analyzer.root)?;
         if let Some(parent1) = name_node.parent()
             && parent1.kind() == LuaSyntaxKind::IndexExpr.into()
-                && let Some(parent2) = parent1.parent() {
-                    if parent2.kind() == LuaSyntaxKind::FuncStat.into() {
-                        ranges.push(parent2.text_range());
-                        let stat = LuaFuncStat::cast(parent2)?;
-                        for comment in stat.get_comments() {
-                            ranges.push(comment.get_range());
-                        }
-                    } else if parent2.kind() == LuaSyntaxKind::AssignStat.into() {
-                        let stat = LuaAssignStat::cast(parent2)?;
-                        if let Some(assign_token) = stat.get_assign_op()
-                            && assign_token.get_position() > decl_ref.range.start() {
-                                ranges.push(stat.get_range());
-                                for comment in stat.get_comments() {
-                                    ranges.push(comment.get_range());
-                                }
-                            }
+            && let Some(parent2) = parent1.parent()
+        {
+            if parent2.kind() == LuaSyntaxKind::FuncStat.into() {
+                ranges.push(parent2.text_range());
+                let stat = LuaFuncStat::cast(parent2)?;
+                for comment in stat.get_comments() {
+                    ranges.push(comment.get_range());
+                }
+            } else if parent2.kind() == LuaSyntaxKind::AssignStat.into() {
+                let stat = LuaAssignStat::cast(parent2)?;
+                if let Some(assign_token) = stat.get_assign_op()
+                    && assign_token.get_position() > decl_ref.range.start()
+                {
+                    ranges.push(stat.get_range());
+                    for comment in stat.get_comments() {
+                        ranges.push(comment.get_range());
                     }
                 }
+            }
+        }
     }
 
     Some(ranges)
@@ -279,24 +283,26 @@ fn get_global_reference_ranges(
         let name_node = syntax_id.to_node_from_root(&analyzer.root)?;
         if let Some(parent1) = name_node.parent()
             && parent1.kind() == LuaSyntaxKind::IndexExpr.into()
-                && let Some(parent2) = parent1.parent() {
-                    if parent2.kind() == LuaSyntaxKind::FuncStat.into() {
-                        ranges.push(parent2.text_range());
-                        let stat = LuaFuncStat::cast(parent2)?;
-                        for comment in stat.get_comments() {
-                            ranges.push(comment.get_range());
-                        }
-                    } else if parent2.kind() == LuaSyntaxKind::AssignStat.into() {
-                        let stat = LuaAssignStat::cast(parent2)?;
-                        if let Some(assign_token) = stat.token_by_kind(LuaTokenKind::TkAssign)
-                            && assign_token.get_position() > syntax_id.get_range().start() {
-                                ranges.push(stat.get_range());
-                                for comment in stat.get_comments() {
-                                    ranges.push(comment.get_range());
-                                }
-                            }
+            && let Some(parent2) = parent1.parent()
+        {
+            if parent2.kind() == LuaSyntaxKind::FuncStat.into() {
+                ranges.push(parent2.text_range());
+                let stat = LuaFuncStat::cast(parent2)?;
+                for comment in stat.get_comments() {
+                    ranges.push(comment.get_range());
+                }
+            } else if parent2.kind() == LuaSyntaxKind::AssignStat.into() {
+                let stat = LuaAssignStat::cast(parent2)?;
+                if let Some(assign_token) = stat.token_by_kind(LuaTokenKind::TkAssign)
+                    && assign_token.get_position() > syntax_id.get_range().start()
+                {
+                    ranges.push(stat.get_range());
+                    for comment in stat.get_comments() {
+                        ranges.push(comment.get_range());
                     }
                 }
+            }
+        }
     }
 
     Some(ranges)
@@ -317,7 +323,9 @@ pub fn analyze_func_generic(analyzer: &mut DocAnalyzer, tag: LuaDocTagGeneric) -
                 continue;
             };
 
-            let type_ref = param.get_type().map(|type_ref| infer_type(analyzer, type_ref));
+            let type_ref = param
+                .get_type()
+                .map(|type_ref| infer_type(analyzer, type_ref));
 
             params_result.push(GenericParam::new(
                 SmolStr::new(name.as_str()),

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/doc/type_ref_tags.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/doc/type_ref_tags.rs
@@ -25,7 +25,9 @@ use crate::{
 };
 
 pub fn analyze_type(analyzer: &mut DocAnalyzer, tag: LuaDocTagType) -> Option<()> {
-    let description = tag.get_description().map(|des| preprocess_description(&des.get_description_text(), None));
+    let description = tag
+        .get_description()
+        .map(|des| preprocess_description(&des.get_description_text(), None));
 
     let mut type_list = Vec::new();
     for lua_doc_type in tag.get_type_list() {
@@ -58,13 +60,14 @@ pub fn analyze_type(analyzer: &mut DocAnalyzer, tag: LuaDocTagType) -> Option<()
 
                         // bind description
                         if let Some(ref desc) = description
-                            && !desc.is_empty() {
-                                analyzer.db.get_property_index_mut().add_description(
-                                    analyzer.file_id,
-                                    LuaSemanticDeclId::LuaDecl(decl_id),
-                                    desc.clone(),
-                                );
-                            }
+                            && !desc.is_empty()
+                        {
+                            analyzer.db.get_property_index_mut().add_description(
+                                analyzer.file_id,
+                                LuaSemanticDeclId::LuaDecl(decl_id),
+                                desc.clone(),
+                            );
+                        }
                     }
                     LuaVarExpr::IndexExpr(index_expr) => {
                         let member_id =
@@ -76,13 +79,14 @@ pub fn analyze_type(analyzer: &mut DocAnalyzer, tag: LuaDocTagType) -> Option<()
 
                         // bind description
                         if let Some(ref desc) = description
-                            && !desc.is_empty() {
-                                analyzer.db.get_property_index_mut().add_description(
-                                    analyzer.file_id,
-                                    LuaSemanticDeclId::Member(member_id),
-                                    desc.clone(),
-                                );
-                            }
+                            && !desc.is_empty()
+                        {
+                            analyzer.db.get_property_index_mut().add_description(
+                                analyzer.file_id,
+                                LuaSemanticDeclId::Member(member_id),
+                                desc.clone(),
+                            );
+                        }
                     }
                 }
             }
@@ -105,13 +109,14 @@ pub fn analyze_type(analyzer: &mut DocAnalyzer, tag: LuaDocTagType) -> Option<()
 
                 // bind description
                 if let Some(ref desc) = description
-                    && !desc.is_empty() {
-                        analyzer.db.get_property_index_mut().add_description(
-                            analyzer.file_id,
-                            LuaSemanticDeclId::LuaDecl(decl_id),
-                            desc.clone(),
-                        );
-                    }
+                    && !desc.is_empty()
+                {
+                    analyzer.db.get_property_index_mut().add_description(
+                        analyzer.file_id,
+                        LuaSemanticDeclId::LuaDecl(decl_id),
+                        desc.clone(),
+                    );
+                }
             }
         }
         LuaAst::LuaTableField(table_field) => {
@@ -125,13 +130,14 @@ pub fn analyze_type(analyzer: &mut DocAnalyzer, tag: LuaDocTagType) -> Option<()
 
                 // bind description
                 if let Some(ref desc) = description
-                    && !desc.is_empty() {
-                        analyzer.db.get_property_index_mut().add_description(
-                            analyzer.file_id,
-                            LuaSemanticDeclId::Member(member_id),
-                            desc.clone(),
-                        );
-                    }
+                    && !desc.is_empty()
+                {
+                    analyzer.db.get_property_index_mut().add_description(
+                        analyzer.file_id,
+                        LuaSemanticDeclId::Member(member_id),
+                        desc.clone(),
+                    );
+                }
             }
         }
         LuaAst::LuaReturnStat(return_stat) => {
@@ -173,7 +179,9 @@ pub fn analyze_param(analyzer: &mut DocAnalyzer, tag: LuaDocTagParam) -> Option<
         type_ref = TypeOps::Union.apply(analyzer.db, &type_ref, &LuaType::Nil);
     }
 
-    let description = tag.get_description().map(|des| preprocess_description(&des.get_description_text(), None));
+    let description = tag
+        .get_description()
+        .map(|des| preprocess_description(&des.get_description_text(), None));
 
     // bind type ref to signature and param
     if let Some(closure) = find_owner_closure(analyzer) {
@@ -210,7 +218,9 @@ pub fn analyze_param(analyzer: &mut DocAnalyzer, tag: LuaDocTagParam) -> Option<
 }
 
 pub fn analyze_return(analyzer: &mut DocAnalyzer, tag: LuaDocTagReturn) -> Option<()> {
-    let description = tag.get_description().map(|des| preprocess_description(&des.get_description_text(), None));
+    let description = tag
+        .get_description()
+        .map(|des| preprocess_description(&des.get_description_text(), None));
 
     if let Some(closure) = find_owner_closure_or_report(analyzer, &tag) {
         let signature_id = LuaSignatureId::from_closure(analyzer.file_id, &closure);
@@ -389,7 +399,6 @@ pub fn analyze_other(analyzer: &mut DocAnalyzer, other: LuaDocTagOther) -> Optio
     let owner = get_owner_id(analyzer)?;
     let tag_name = other.get_tag_name()?;
     let description = if let Some(des) = other.get_description() {
-        
         preprocess_description(&des.get_description_text(), None)
     } else {
         "".to_string()

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/doc/type_ref_tags.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/doc/type_ref_tags.rs
@@ -25,11 +25,7 @@ use crate::{
 };
 
 pub fn analyze_type(analyzer: &mut DocAnalyzer, tag: LuaDocTagType) -> Option<()> {
-    let description = if let Some(des) = tag.get_description() {
-        Some(preprocess_description(&des.get_description_text(), None))
-    } else {
-        None
-    };
+    let description = tag.get_description().map(|des| preprocess_description(&des.get_description_text(), None));
 
     let mut type_list = Vec::new();
     for lua_doc_type in tag.get_type_list() {
@@ -61,15 +57,14 @@ pub fn analyze_type(analyzer: &mut DocAnalyzer, tag: LuaDocTagType) -> Option<()
                             .bind_type(decl_id.into(), LuaTypeCache::DocType(type_ref.clone()));
 
                         // bind description
-                        if let Some(ref desc) = description {
-                            if !desc.is_empty() {
+                        if let Some(ref desc) = description
+                            && !desc.is_empty() {
                                 analyzer.db.get_property_index_mut().add_description(
                                     analyzer.file_id,
                                     LuaSemanticDeclId::LuaDecl(decl_id),
                                     desc.clone(),
                                 );
                             }
-                        }
                     }
                     LuaVarExpr::IndexExpr(index_expr) => {
                         let member_id =
@@ -80,15 +75,14 @@ pub fn analyze_type(analyzer: &mut DocAnalyzer, tag: LuaDocTagType) -> Option<()
                             .bind_type(member_id.into(), LuaTypeCache::DocType(type_ref.clone()));
 
                         // bind description
-                        if let Some(ref desc) = description {
-                            if !desc.is_empty() {
+                        if let Some(ref desc) = description
+                            && !desc.is_empty() {
                                 analyzer.db.get_property_index_mut().add_description(
                                     analyzer.file_id,
                                     LuaSemanticDeclId::Member(member_id),
                                     desc.clone(),
                                 );
                             }
-                        }
                     }
                 }
             }
@@ -110,19 +104,18 @@ pub fn analyze_type(analyzer: &mut DocAnalyzer, tag: LuaDocTagType) -> Option<()
                     .bind_type(decl_id.into(), LuaTypeCache::DocType(type_ref.clone()));
 
                 // bind description
-                if let Some(ref desc) = description {
-                    if !desc.is_empty() {
+                if let Some(ref desc) = description
+                    && !desc.is_empty() {
                         analyzer.db.get_property_index_mut().add_description(
                             analyzer.file_id,
                             LuaSemanticDeclId::LuaDecl(decl_id),
                             desc.clone(),
                         );
                     }
-                }
             }
         }
         LuaAst::LuaTableField(table_field) => {
-            if let Some(first_type) = type_list.get(0) {
+            if let Some(first_type) = type_list.first() {
                 let member_id = LuaMemberId::new(table_field.get_syntax_id(), analyzer.file_id);
 
                 analyzer
@@ -131,19 +124,18 @@ pub fn analyze_type(analyzer: &mut DocAnalyzer, tag: LuaDocTagType) -> Option<()
                     .bind_type(member_id.into(), LuaTypeCache::DocType(first_type.clone()));
 
                 // bind description
-                if let Some(ref desc) = description {
-                    if !desc.is_empty() {
+                if let Some(ref desc) = description
+                    && !desc.is_empty() {
                         analyzer.db.get_property_index_mut().add_description(
                             analyzer.file_id,
                             LuaSemanticDeclId::Member(member_id),
                             desc.clone(),
                         );
                     }
-                }
             }
         }
         LuaAst::LuaReturnStat(return_stat) => {
-            if let Some(first_type) = type_list.get(0) {
+            if let Some(first_type) = type_list.first() {
                 let file_id = analyzer.file_id;
                 let syntax_id = return_stat.get_syntax_id();
                 let in_file_syntax_id = InFiled::new(file_id, syntax_id);
@@ -181,11 +173,7 @@ pub fn analyze_param(analyzer: &mut DocAnalyzer, tag: LuaDocTagParam) -> Option<
         type_ref = TypeOps::Union.apply(analyzer.db, &type_ref, &LuaType::Nil);
     }
 
-    let description = if let Some(des) = tag.get_description() {
-        Some(preprocess_description(&des.get_description_text(), None))
-    } else {
-        None
-    };
+    let description = tag.get_description().map(|des| preprocess_description(&des.get_description_text(), None));
 
     // bind type ref to signature and param
     if let Some(closure) = find_owner_closure(analyzer) {
@@ -222,21 +210,13 @@ pub fn analyze_param(analyzer: &mut DocAnalyzer, tag: LuaDocTagParam) -> Option<
 }
 
 pub fn analyze_return(analyzer: &mut DocAnalyzer, tag: LuaDocTagReturn) -> Option<()> {
-    let description = if let Some(des) = tag.get_description() {
-        Some(preprocess_description(&des.get_description_text(), None))
-    } else {
-        None
-    };
+    let description = tag.get_description().map(|des| preprocess_description(&des.get_description_text(), None));
 
     if let Some(closure) = find_owner_closure_or_report(analyzer, &tag) {
         let signature_id = LuaSignatureId::from_closure(analyzer.file_id, &closure);
         let returns = tag.get_type_and_name_list();
         for (doc_type, name_token) in returns {
-            let name = if let Some(name) = name_token {
-                Some(name.get_name_text().to_string())
-            } else {
-                None
-            };
+            let name = name_token.map(|name| name.get_name_text().to_string());
 
             let type_ref = infer_type(analyzer, doc_type);
             let return_info = LuaDocReturnInfo {
@@ -284,28 +264,22 @@ pub fn analyze_return_cast(analyzer: &mut DocAnalyzer, tag: LuaDocTagReturnCast)
 pub fn analyze_overload(analyzer: &mut DocAnalyzer, tag: LuaDocTagOverload) -> Option<()> {
     if let Some(decl_id) = analyzer.current_type_id.clone() {
         let type_ref = infer_type(analyzer, tag.get_type()?);
-        match type_ref {
-            LuaType::DocFunction(func) => {
-                let operator = LuaOperator::new(
-                    decl_id.clone().into(),
-                    LuaOperatorMetaMethod::Call,
-                    analyzer.file_id,
-                    tag.get_range(),
-                    OperatorFunction::Func(func.clone()),
-                );
-                analyzer.db.get_operator_index_mut().add_operator(operator);
-            }
-            _ => {}
+        if let LuaType::DocFunction(func) = type_ref {
+            let operator = LuaOperator::new(
+                decl_id.clone().into(),
+                LuaOperatorMetaMethod::Call,
+                analyzer.file_id,
+                tag.get_range(),
+                OperatorFunction::Func(func.clone()),
+            );
+            analyzer.db.get_operator_index_mut().add_operator(operator);
         }
     } else if let Some(closure) = find_owner_closure_or_report(analyzer, &tag) {
         let type_ref = infer_type(analyzer, tag.get_type()?);
-        match type_ref {
-            LuaType::DocFunction(func) => {
-                let id = LuaSignatureId::from_closure(analyzer.file_id, &closure);
-                let signature = analyzer.db.get_signature_index_mut().get_or_create(id);
-                signature.overloads.push(func);
-            }
-            _ => {}
+        if let LuaType::DocFunction(func) = type_ref {
+            let id = LuaSignatureId::from_closure(analyzer.file_id, &closure);
+            let signature = analyzer.db.get_signature_index_mut().get_or_create(id);
+            signature.overloads.push(func);
         }
     }
     Some(())
@@ -321,13 +295,13 @@ pub fn analyze_module(analyzer: &mut DocAnalyzer, tag: LuaDocTagModule) -> Optio
         match &owner_id {
             LuaSemanticDeclId::LuaDecl(decl_id) => {
                 analyzer.db.get_type_index_mut().bind_type(
-                    decl_id.clone().into(),
+                    (*decl_id).into(),
                     LuaTypeCache::DocType(export_type.clone()),
                 );
             }
             LuaSemanticDeclId::Member(member_id) => {
                 analyzer.db.get_type_index_mut().bind_type(
-                    member_id.clone().into(),
+                    (*member_id).into(),
                     LuaTypeCache::DocType(export_type.clone()),
                 );
             }
@@ -415,8 +389,8 @@ pub fn analyze_other(analyzer: &mut DocAnalyzer, other: LuaDocTagOther) -> Optio
     let owner = get_owner_id(analyzer)?;
     let tag_name = other.get_tag_name()?;
     let description = if let Some(des) = other.get_description() {
-        let description = preprocess_description(&des.get_description_text(), None);
-        description
+        
+        preprocess_description(&des.get_description_text(), None)
     } else {
         "".to_string()
     };

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/flow/bind_analyze/exprs/mod.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/flow/bind_analyze/exprs/mod.rs
@@ -101,9 +101,7 @@ pub fn bind_paren_expr(
     paren_expr: emmylua_parser::LuaParenExpr,
     current: FlowId,
 ) -> Option<()> {
-    let Some(inner_expr) = paren_expr.get_expr() else {
-        return None;
-    };
+    let inner_expr = paren_expr.get_expr()?;
 
     bind_expr(binder, inner_expr, current);
     Some(())
@@ -114,9 +112,7 @@ pub fn bind_unary_expr(
     unary_expr: LuaUnaryExpr,
     current: FlowId,
 ) -> Option<()> {
-    let Some(inner_expr) = unary_expr.get_expr() else {
-        return None;
-    };
+    let inner_expr = unary_expr.get_expr()?;
     bind_expr(binder, inner_expr, current);
     Some(())
 }

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/flow/bind_analyze/stats.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/flow/bind_analyze/stats.rs
@@ -161,8 +161,8 @@ pub fn bind_break_stat(
     current: FlowId,
 ) -> FlowId {
     let break_flow_id = binder.create_break();
-    if let Some(loop_flow) = binder.get_flow(binder.loop_label) {
-        if loop_flow.kind.is_unreachable() {
+    if let Some(loop_flow) = binder.get_flow(binder.loop_label)
+        && loop_flow.kind.is_unreachable() {
             // report a error if we are trying to break outside a loop
             binder.report_error(AnalyzeError::new(
                 DiagnosticCode::SyntaxError,
@@ -171,7 +171,6 @@ pub fn bind_break_stat(
             ));
             return current;
         }
-    }
 
     binder.add_antecedent(break_flow_id, current);
     binder.add_antecedent(binder.break_target_label, break_flow_id);

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/flow/bind_analyze/stats.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/flow/bind_analyze/stats.rs
@@ -162,15 +162,16 @@ pub fn bind_break_stat(
 ) -> FlowId {
     let break_flow_id = binder.create_break();
     if let Some(loop_flow) = binder.get_flow(binder.loop_label)
-        && loop_flow.kind.is_unreachable() {
-            // report a error if we are trying to break outside a loop
-            binder.report_error(AnalyzeError::new(
-                DiagnosticCode::SyntaxError,
-                &t!("Break outside loop"),
-                break_stat.get_range(),
-            ));
-            return current;
-        }
+        && loop_flow.kind.is_unreachable()
+    {
+        // report a error if we are trying to break outside a loop
+        binder.report_error(AnalyzeError::new(
+            DiagnosticCode::SyntaxError,
+            &t!("Break outside loop"),
+            break_stat.get_range(),
+        ));
+        return current;
+    }
 
     binder.add_antecedent(break_flow_id, current);
     binder.add_antecedent(binder.break_target_label, break_flow_id);

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/lua/for_range_stat.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/lua/for_range_stat.rs
@@ -23,8 +23,7 @@ pub fn analyze_for_range_stat(
 
     match iter_var_types {
         Ok(iter_var_types) => {
-            let mut idx = 0;
-            for var_name in var_name_list {
+            for (idx, var_name) in var_name_list.enumerate() {
                 let position = var_name.get_position();
                 let decl_id = LuaDeclId::new(analyzer.file_id, position);
                 let ret_type = iter_var_types
@@ -36,9 +35,7 @@ pub fn analyze_for_range_stat(
                     .db
                     .get_type_index_mut()
                     .bind_type(decl_id.into(), LuaTypeCache::InferType(ret_type));
-                idx += 1;
             }
-            return Some(());
         }
         Err(InferFailReason::None) => {
             for var_name in var_name_list {
@@ -49,7 +46,6 @@ pub fn analyze_for_range_stat(
                     .get_type_index_mut()
                     .bind_type(decl_id.into(), LuaTypeCache::InferType(LuaType::Unknown));
             }
-            return Some(());
         }
         Err(reason) => {
             let unresolved = UnResolveIterVar {
@@ -125,7 +121,7 @@ pub fn infer_for_range_iter_expr_func(
                             _ => None,
                         }
                     })
-                    .nth(0)
+                    .next()
                     .ok_or(InferFailReason::None)?
             } else {
                 return Err(InferFailReason::None);
@@ -154,7 +150,7 @@ pub fn infer_for_range_iter_expr_func(
         db,
         cache,
         substitutor: &mut substitutor,
-        root: root,
+        root,
         call_expr: None,
     };
     let params = doc_function

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/lua/func_body.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/lua/func_body.rs
@@ -60,7 +60,9 @@ fn analyze_block_returns(block: LuaBlock, returns: &mut Vec<LuaReturnPoint>) -> 
             }
             LuaStat::CallExprStat(call_expr) => {
                 let flow = analyze_call_expr_stat_returns(call_expr, returns);
-                if let Some(ChangeFlow::Error) = flow { return Some(ChangeFlow::Error) }
+                if let Some(ChangeFlow::Error) = flow {
+                    return Some(ChangeFlow::Error);
+                }
             }
             LuaStat::BreakStat(_) => {
                 return Some(ChangeFlow::Break);

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/lua/func_body.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/lua/func_body.rs
@@ -60,10 +60,7 @@ fn analyze_block_returns(block: LuaBlock, returns: &mut Vec<LuaReturnPoint>) -> 
             }
             LuaStat::CallExprStat(call_expr) => {
                 let flow = analyze_call_expr_stat_returns(call_expr, returns);
-                match flow {
-                    Some(ChangeFlow::Error) => return Some(ChangeFlow::Error),
-                    _ => {}
-                }
+                if let Some(ChangeFlow::Error) = flow { return Some(ChangeFlow::Error) }
             }
             LuaStat::BreakStat(_) => {
                 return Some(ChangeFlow::Break);

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/unresolve/check_reason.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/unresolve/check_reason.rs
@@ -64,10 +64,8 @@ pub fn resolve_as_any(db: &mut DbIndex, reason: &InferFailReason, loop_count: us
             return Some(());
         }
         InferFailReason::UnResolveDeclType(decl_id) => {
-            db.get_type_index_mut().bind_type(
-                (*decl_id).into(),
-                LuaTypeCache::InferType(LuaType::Any),
-            );
+            db.get_type_index_mut()
+                .bind_type((*decl_id).into(), LuaTypeCache::InferType(LuaType::Any));
         }
         InferFailReason::UnResolveMemberType(member_id) => {
             // 第一次循环不处理, 或许需要判断`unresolves`是否全为取值再跳过?

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/unresolve/check_reason.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/unresolve/check_reason.rs
@@ -21,7 +21,7 @@ pub fn check_reach_reason(
         | InferFailReason::RecursiveInfer => Some(true),
         InferFailReason::UnResolveDeclType(decl_id) => {
             let decl = db.get_decl_index().get_decl(decl_id)?;
-            let typ = db.get_type_index().get_type_cache(&decl_id.clone().into());
+            let typ = db.get_type_index().get_type_cache(&(*decl_id).into());
             if typ.is_none() && decl.is_param() {
                 return Some(infer_param(db, decl).is_ok());
             }
@@ -32,7 +32,7 @@ pub fn check_reach_reason(
             let member = db.get_member_index().get_member(member_id)?;
             let key = member.get_key();
             let owner = db.get_member_index().get_current_owner(member_id)?;
-            let member_item = db.get_member_index().get_member_item(&owner, key)?;
+            let member_item = db.get_member_index().get_member_item(owner, key)?;
             Some(member_item.resolve_type(db).is_ok())
         }
         InferFailReason::UnResolveExpr(expr) => {
@@ -65,7 +65,7 @@ pub fn resolve_as_any(db: &mut DbIndex, reason: &InferFailReason, loop_count: us
         }
         InferFailReason::UnResolveDeclType(decl_id) => {
             db.get_type_index_mut().bind_type(
-                decl_id.clone().into(),
+                (*decl_id).into(),
                 LuaTypeCache::InferType(LuaType::Any),
             );
         }
@@ -76,8 +76,8 @@ pub fn resolve_as_any(db: &mut DbIndex, reason: &InferFailReason, loop_count: us
             }
             let member = db.get_member_index().get_member(member_id)?;
             let key = member.get_key();
-            let owner = db.get_member_index().get_current_owner(&member_id)?;
-            let member_item = db.get_member_index().get_member_item(&owner, key)?;
+            let owner = db.get_member_index().get_current_owner(member_id)?;
+            let member_item = db.get_member_index().get_member_item(owner, key)?;
             let opt_type = member_item.resolve_type(db).ok();
             if opt_type.is_none() {
                 let semantic_member_id = member_item.resolve_semantic_decl(db)?;

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/unresolve/mod.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/unresolve/mod.rs
@@ -38,7 +38,7 @@ impl AnalysisPipeline for UnResolveAnalysisPipeline {
         for (unresolve, reason) in context.unresolves.drain(..) {
             reason_resolve
                 .entry(reason.clone())
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(unresolve);
         }
 
@@ -232,7 +232,7 @@ fn try_resolve(
         for (unresolve, reason) in retain_unresolve {
             reason_reasolve
                 .entry(reason.clone())
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(unresolve);
         }
 
@@ -388,6 +388,7 @@ impl From<UnResolveModuleRef> for UnResolve {
     }
 }
 
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug)]
 pub enum UnResolveParentAst {
     LuaFuncStat(LuaFuncStat),

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/unresolve/resolve_closure.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/unresolve/resolve_closure.rs
@@ -21,7 +21,7 @@ pub fn try_resolve_call_closure_params(
 ) -> ResolveResult {
     let call_expr = closure_params.call_expr.clone();
     let prefix_expr = call_expr.get_prefix_expr().ok_or(InferFailReason::None)?;
-    let call_expr_type = infer_expr(db, cache, prefix_expr.into())?;
+    let call_expr_type = infer_expr(db, cache, prefix_expr)?;
 
     let call_doc_func = infer_call_expr_func(
         db,
@@ -53,7 +53,7 @@ pub fn try_resolve_call_closure_params(
     let (async_state, params_to_insert) = if let Some(param_type) =
         call_doc_func.get_params().get(param_idx)
     {
-        let Some(param_type) = get_real_type(db, &param_type.1.as_ref().unwrap_or(&LuaType::Any))
+        let Some(param_type) = get_real_type(db, param_type.1.as_ref().unwrap_or(&LuaType::Any))
         else {
             return Ok(());
         };
@@ -110,7 +110,7 @@ pub fn try_resolve_closure_return(
 ) -> ResolveResult {
     let call_expr = closure_return.call_expr.clone();
     let prefix_expr = call_expr.get_prefix_expr().ok_or(InferFailReason::None)?;
-    let call_expr_type = infer_expr(db, cache, prefix_expr.into())?;
+    let call_expr_type = infer_expr(db, cache, prefix_expr)?;
     let mut param_idx = closure_return.param_idx;
     let call_doc_func = infer_call_expr_func(
         db,
@@ -137,7 +137,7 @@ pub fn try_resolve_closure_return(
     }
 
     let ret_type = if let Some(param_type) = call_doc_func.get_params().get(param_idx) {
-        let Some(param_type) = get_real_type(db, &param_type.1.as_ref().unwrap_or(&LuaType::Any))
+        let Some(param_type) = get_real_type(db, param_type.1.as_ref().unwrap_or(&LuaType::Any))
         else {
             return Ok(());
         };
@@ -322,11 +322,10 @@ fn resolve_closure_member_type(
                             .get_type_decl(&ref_id)
                             .ok_or(InferFailReason::None)?;
 
-                        if let Some(origin) = type_decl.get_alias_origin(&db, None) {
-                            if let LuaType::DocFunction(f) = origin {
+                        if let Some(origin) = type_decl.get_alias_origin(db, None)
+                            && let LuaType::DocFunction(f) = origin {
                                 multi_function_type.push(f);
                             }
-                        }
                     }
                     _ => {}
                 };
@@ -342,7 +341,7 @@ fn resolve_closure_member_type(
                     }
                     (false, true) => {
                         // 原始签名不是冒号定义, 但未解析的签名是冒号定义, 即要删除第一个参数
-                        if doc_params.len() > 0 {
+                        if !doc_params.is_empty() {
                             doc_params.remove(0);
                         }
                     }
@@ -354,18 +353,14 @@ fn resolve_closure_member_type(
                         if final_param.0 == "..." {
                             // 如果`doc_params`当前与之后的参数的类型不一致, 那么`variadic_type`为`Any`
                             for i in idx..doc_params.len() {
-                                if let Some(param) = doc_params.get(i) {
-                                    match &param.1 {
-                                        Some(typ) => {
-                                            if variadic_type == LuaType::Unknown {
-                                                variadic_type = typ.clone();
-                                            } else if variadic_type != *typ {
-                                                variadic_type = LuaType::Any;
-                                            }
+                                if let Some(param) = doc_params.get(i)
+                                    && let Some(typ) = &param.1 {
+                                        if variadic_type == LuaType::Unknown {
+                                            variadic_type = typ.clone();
+                                        } else if variadic_type != *typ {
+                                            variadic_type = LuaType::Any;
                                         }
-                                        None => {}
                                     }
-                                }
                             }
 
                             break;
@@ -384,11 +379,10 @@ fn resolve_closure_member_type(
                 final_ret = TypeOps::Union.apply(db, &final_ret, doc_func.get_ret());
             }
 
-            if !variadic_type.is_unknown() {
-                if let Some(param) = final_params.last_mut() {
+            if !variadic_type.is_unknown()
+                && let Some(param) = final_params.last_mut() {
                     param.1 = Some(variadic_type);
                 }
-            }
 
             resolve_doc_function(
                 db,
@@ -409,8 +403,8 @@ fn resolve_closure_member_type(
                 .get_type_decl(ref_id)
                 .ok_or(InferFailReason::None)?;
 
-            if type_decl.is_alias() {
-                if let Some(origin) = type_decl.get_alias_origin(&db, None) {
+            if type_decl.is_alias()
+                && let Some(origin) = type_decl.get_alias_origin(db, None) {
                     return resolve_closure_member_type(
                         db,
                         closure_params,
@@ -419,7 +413,6 @@ fn resolve_closure_member_type(
                         infer_guard,
                     );
                 }
-            }
             Ok(())
         }
         _ => Ok(()),
@@ -447,20 +440,18 @@ fn resolve_doc_function(
             doc_params.insert(0, ("self".to_string(), Some(LuaType::SelfInfer)));
         }
         (false, true) => {
-            if doc_params.len() > 0 {
+            if !doc_params.is_empty() {
                 doc_params.remove(0);
             }
         }
         _ => {}
     }
 
-    if let Some(self_type) = self_type {
-        if let Some((_, Some(typ))) = doc_params.get(0) {
-            if typ.is_self_infer() {
+    if let Some(self_type) = self_type
+        && let Some((_, Some(typ))) = doc_params.first()
+            && typ.is_self_infer() {
                 doc_params[0].1 = Some(self_type);
             }
-        }
-    }
 
     for (index, param) in doc_params.iter().enumerate() {
         let name = signature.params.get(index).unwrap_or(&param.0);
@@ -523,50 +514,47 @@ fn find_best_function_type(
     origin_signature: &LuaSignature,
 ) -> Option<LuaType> {
     // 寻找非自身定义的签名
-    match find_decl_function_type(db, cache, prefix_type, index_member_expr) {
-        Ok(result) => {
-            if result.is_current_owner {
-                // 对应当前类型下的声明, 我们需要过滤掉所有`signature`类型
-                if let Some(filtered_types) = filter_signature_type(&result.typ) {
-                    match filtered_types.len() {
-                        0 => {}
-                        1 => return Some(LuaType::DocFunction(filtered_types[0].clone())),
-                        _ => {
-                            return Some(LuaType::from_vec(
-                                filtered_types
-                                    .into_iter()
-                                    .map(|func| LuaType::DocFunction(func.clone()))
-                                    .collect(),
-                            ));
-                        }
+    if let Ok(result) = find_decl_function_type(db, cache, prefix_type, index_member_expr) {
+        if result.is_current_owner {
+            // 对应当前类型下的声明, 我们需要过滤掉所有`signature`类型
+            if let Some(filtered_types) = filter_signature_type(&result.typ) {
+                match filtered_types.len() {
+                    0 => {}
+                    1 => return Some(LuaType::DocFunction(filtered_types[0].clone())),
+                    _ => {
+                        return Some(LuaType::from_vec(
+                            filtered_types
+                                .into_iter()
+                                .map(|func| LuaType::DocFunction(func.clone()))
+                                .collect(),
+                        ));
                     }
                 }
-            } else {
-                return Some(result.typ);
             }
+        } else {
+            return Some(result.typ);
         }
-        _ => {}
     }
 
     match origin_signature.overloads.len() {
-        0 => return None,
+        0 => None,
         1 => {
-            return origin_signature
+            origin_signature
                 .overloads
                 .clone()
                 .into_iter()
                 .next()
-                .map(LuaType::DocFunction);
+                .map(LuaType::DocFunction)
         }
         _ => {
-            return Some(LuaType::from_vec(
+            Some(LuaType::from_vec(
                 origin_signature
                     .overloads
                     .clone()
                     .into_iter()
                     .map(LuaType::DocFunction)
                     .collect(),
-            ));
+            ))
         }
     }
 }

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/unresolve/resolve_closure.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/unresolve/resolve_closure.rs
@@ -323,9 +323,10 @@ fn resolve_closure_member_type(
                             .ok_or(InferFailReason::None)?;
 
                         if let Some(origin) = type_decl.get_alias_origin(db, None)
-                            && let LuaType::DocFunction(f) = origin {
-                                multi_function_type.push(f);
-                            }
+                            && let LuaType::DocFunction(f) = origin
+                        {
+                            multi_function_type.push(f);
+                        }
                     }
                     _ => {}
                 };
@@ -354,13 +355,14 @@ fn resolve_closure_member_type(
                             // 如果`doc_params`当前与之后的参数的类型不一致, 那么`variadic_type`为`Any`
                             for i in idx..doc_params.len() {
                                 if let Some(param) = doc_params.get(i)
-                                    && let Some(typ) = &param.1 {
-                                        if variadic_type == LuaType::Unknown {
-                                            variadic_type = typ.clone();
-                                        } else if variadic_type != *typ {
-                                            variadic_type = LuaType::Any;
-                                        }
+                                    && let Some(typ) = &param.1
+                                {
+                                    if variadic_type == LuaType::Unknown {
+                                        variadic_type = typ.clone();
+                                    } else if variadic_type != *typ {
+                                        variadic_type = LuaType::Any;
                                     }
+                                }
                             }
 
                             break;
@@ -380,9 +382,10 @@ fn resolve_closure_member_type(
             }
 
             if !variadic_type.is_unknown()
-                && let Some(param) = final_params.last_mut() {
-                    param.1 = Some(variadic_type);
-                }
+                && let Some(param) = final_params.last_mut()
+            {
+                param.1 = Some(variadic_type);
+            }
 
             resolve_doc_function(
                 db,
@@ -404,15 +407,16 @@ fn resolve_closure_member_type(
                 .ok_or(InferFailReason::None)?;
 
             if type_decl.is_alias()
-                && let Some(origin) = type_decl.get_alias_origin(db, None) {
-                    return resolve_closure_member_type(
-                        db,
-                        closure_params,
-                        &origin,
-                        self_type,
-                        infer_guard,
-                    );
-                }
+                && let Some(origin) = type_decl.get_alias_origin(db, None)
+            {
+                return resolve_closure_member_type(
+                    db,
+                    closure_params,
+                    &origin,
+                    self_type,
+                    infer_guard,
+                );
+            }
             Ok(())
         }
         _ => Ok(()),
@@ -449,9 +453,10 @@ fn resolve_doc_function(
 
     if let Some(self_type) = self_type
         && let Some((_, Some(typ))) = doc_params.first()
-            && typ.is_self_infer() {
-                doc_params[0].1 = Some(self_type);
-            }
+        && typ.is_self_infer()
+    {
+        doc_params[0].1 = Some(self_type);
+    }
 
     for (index, param) in doc_params.iter().enumerate() {
         let name = signature.params.get(index).unwrap_or(&param.0);
@@ -538,23 +543,19 @@ fn find_best_function_type(
 
     match origin_signature.overloads.len() {
         0 => None,
-        1 => {
+        1 => origin_signature
+            .overloads
+            .clone()
+            .into_iter()
+            .next()
+            .map(LuaType::DocFunction),
+        _ => Some(LuaType::from_vec(
             origin_signature
                 .overloads
                 .clone()
                 .into_iter()
-                .next()
                 .map(LuaType::DocFunction)
-        }
-        _ => {
-            Some(LuaType::from_vec(
-                origin_signature
-                    .overloads
-                    .clone()
-                    .into_iter()
-                    .map(LuaType::DocFunction)
-                    .collect(),
-            ))
-        }
+                .collect(),
+        )),
     }
 }

--- a/crates/emmylua_code_analysis/src/config/configs/completion.rs
+++ b/crates/emmylua_code_analysis/src/config/configs/completion.rs
@@ -78,8 +78,10 @@ fn default_auto_require_separator() -> String {
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, Copy)]
 #[serde(rename_all = "kebab-case")]
+#[derive(Default)]
 pub enum EmmyrcFilenameConvention {
     /// Keep the original filename.
+    #[default]
     Keep,
     /// Convert the filename to snake_case.
     SnakeCase,
@@ -91,8 +93,3 @@ pub enum EmmyrcFilenameConvention {
     KeepClass,
 }
 
-impl Default for EmmyrcFilenameConvention {
-    fn default() -> Self {
-        EmmyrcFilenameConvention::Keep
-    }
-}

--- a/crates/emmylua_code_analysis/src/config/configs/completion.rs
+++ b/crates/emmylua_code_analysis/src/config/configs/completion.rs
@@ -92,4 +92,3 @@ pub enum EmmyrcFilenameConvention {
     /// When returning class definition, use class name, otherwise keep original name.
     KeepClass,
 }
-

--- a/crates/emmylua_code_analysis/src/config/configs/doc.rs
+++ b/crates/emmylua_code_analysis/src/config/configs/doc.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase")]
+#[derive(Default)]
 pub struct EmmyrcDoc {
     /// Treat specific field names as private, e.g. `m_*` means `XXX.m_id` and `XXX.m_type` are private, witch can only be accessed in the class where the definition is located.
     #[serde(default)]
@@ -27,29 +28,15 @@ pub struct EmmyrcDoc {
     pub rst_default_role: Option<String>,
 }
 
-impl Default for EmmyrcDoc {
-    fn default() -> Self {
-        Self {
-            private_name: Default::default(),
-            known_tags: Default::default(),
-            syntax: Default::default(),
-            rst_primary_domain: None,
-            rst_default_role: None,
-        }
-    }
-}
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "kebab-case")]
+#[derive(Default)]
 pub enum DocSyntax {
     None,
+    #[default]
     Md,
     Myst,
     Rst,
 }
 
-impl Default for DocSyntax {
-    fn default() -> Self {
-        DocSyntax::Md
-    }
-}

--- a/crates/emmylua_code_analysis/src/config/configs/doc.rs
+++ b/crates/emmylua_code_analysis/src/config/configs/doc.rs
@@ -28,7 +28,6 @@ pub struct EmmyrcDoc {
     pub rst_default_role: Option<String>,
 }
 
-
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "kebab-case")]
 #[derive(Default)]
@@ -39,4 +38,3 @@ pub enum DocSyntax {
     Myst,
     Rst,
 }
-

--- a/crates/emmylua_code_analysis/src/config/configs/runtime.rs
+++ b/crates/emmylua_code_analysis/src/config/configs/runtime.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase")]
+#[derive(Default)]
 pub struct EmmyrcRuntime {
     /// Lua version.
     #[serde(default)]
@@ -34,22 +35,9 @@ pub struct EmmyrcRuntime {
     pub special: HashMap<String, EmmyrcSpecialSymbol>,
 }
 
-impl Default for EmmyrcRuntime {
-    fn default() -> Self {
-        Self {
-            version: Default::default(),
-            require_like_function: Default::default(),
-            framework_versions: Default::default(),
-            extensions: Default::default(),
-            require_pattern: Default::default(),
-            class_default_call: Default::default(),
-            nonstandard_symbol: Default::default(),
-            special: Default::default(),
-        }
-    }
-}
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, Copy, PartialEq, Eq)]
+#[derive(Default)]
 pub enum EmmyrcLuaVersion {
     /// Lua 5.1
     #[serde(rename = "Lua5.1", alias = "Lua 5.1")]
@@ -71,14 +59,10 @@ pub enum EmmyrcLuaVersion {
     Lua55,
     /// Lua Latest
     #[serde(rename = "LuaLatest", alias = "Lua Latest")]
+    #[default]
     LuaLatest,
 }
 
-impl Default for EmmyrcLuaVersion {
-    fn default() -> Self {
-        EmmyrcLuaVersion::LuaLatest
-    }
-}
 
 impl EmmyrcLuaVersion {
     pub fn to_lua_version_number(&self) -> LuaVersionNumber {

--- a/crates/emmylua_code_analysis/src/config/configs/runtime.rs
+++ b/crates/emmylua_code_analysis/src/config/configs/runtime.rs
@@ -35,9 +35,7 @@ pub struct EmmyrcRuntime {
     pub special: HashMap<String, EmmyrcSpecialSymbol>,
 }
 
-
-#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, Copy, PartialEq, Eq)]
-#[derive(Default)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, Copy, PartialEq, Eq, Default)]
 pub enum EmmyrcLuaVersion {
     /// Lua 5.1
     #[serde(rename = "Lua5.1", alias = "Lua 5.1")]
@@ -62,7 +60,6 @@ pub enum EmmyrcLuaVersion {
     #[default]
     LuaLatest,
 }
-
 
 impl EmmyrcLuaVersion {
     pub fn to_lua_version_number(&self) -> LuaVersionNumber {

--- a/crates/emmylua_code_analysis/src/config/mod.rs
+++ b/crates/emmylua_code_analysis/src/config/mod.rs
@@ -71,7 +71,7 @@ impl Emmyrc {
         let lua_language_level = self.get_language_level();
         let mut special_like = HashMap::new();
         for (name, func) in self.runtime.special.iter() {
-            if let Some(func) = func.clone().into() {
+            if let Some(func) = (*func).into() {
                 special_like.insert(name.clone(), func);
             }
         }
@@ -80,7 +80,7 @@ impl Emmyrc {
         }
         let mut non_std_symbols = LuaNonStdSymbolSet::new();
         for symbol in self.runtime.nonstandard_symbol.iter() {
-            non_std_symbols.add(symbol.clone().into());
+            non_std_symbols.add((*symbol).into());
         }
 
         ParserConfig::new(

--- a/crates/emmylua_code_analysis/src/db_index/declaration/decl_tree.rs
+++ b/crates/emmylua_code_analysis/src/db_index/declaration/decl_tree.rs
@@ -56,9 +56,10 @@ impl LuaDeclarationTree {
             match decl_id {
                 ScopeOrDeclId::Decl(decl_id) => {
                     if let Some(decl) = self.get_decl(&decl_id)
-                        && !decl.is_implicit_self() {
-                            result.push(decl.get_id());
-                        }
+                        && !decl.is_implicit_self()
+                    {
+                        result.push(decl.get_id());
+                    }
                 }
                 ScopeOrDeclId::Scope(_) => {}
             }
@@ -161,14 +162,15 @@ impl LuaDeclarationTree {
             }
             LuaScopeKind::Repeat => {
                 if level == 0
-                    && let Some(ScopeOrDeclId::Scope(scope_id)) = scope.get_children().first() {
-                        let scope = match self.scopes.get(scope_id.id as usize) {
-                            Some(scope) => scope,
-                            None => return,
-                        };
-                        self.walk_up(scope, start_pos, level, f);
-                        return;
-                    }
+                    && let Some(ScopeOrDeclId::Scope(scope_id)) = scope.get_children().first()
+                {
+                    let scope = match self.scopes.get(scope_id.id as usize) {
+                        Some(scope) => scope,
+                        None => return,
+                    };
+                    self.walk_up(scope, start_pos, level, f);
+                    return;
+                }
 
                 self.base_walk_up(scope, start_pos, level, f);
             }
@@ -200,9 +202,10 @@ impl LuaDeclarationTree {
             LuaScopeKind::LocalOrAssignStat | LuaScopeKind::FuncStat | LuaScopeKind::MethodStat => {
                 for child in scope.get_children() {
                     if let ScopeOrDeclId::Decl(decl_id) = child
-                        && f(decl_id.into()) {
-                            return true;
-                        }
+                        && f(decl_id.into())
+                    {
+                        return true;
+                    }
                 }
             }
             _ => {}

--- a/crates/emmylua_code_analysis/src/db_index/declaration/mod.rs
+++ b/crates/emmylua_code_analysis/src/db_index/declaration/mod.rs
@@ -19,6 +19,12 @@ pub struct LuaDeclIndex {
     decl_trees: HashMap<FileId, LuaDeclarationTree>,
 }
 
+impl Default for LuaDeclIndex {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl LuaDeclIndex {
     pub fn new() -> Self {
         Self {

--- a/crates/emmylua_code_analysis/src/db_index/dependency/mod.rs
+++ b/crates/emmylua_code_analysis/src/db_index/dependency/mod.rs
@@ -13,6 +13,12 @@ pub struct LuaDependencyIndex {
     dependencies: HashMap<FileId, HashSet<FileId>>,
 }
 
+impl Default for LuaDependencyIndex {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl LuaDependencyIndex {
     pub fn new() -> Self {
         Self {
@@ -23,7 +29,7 @@ impl LuaDependencyIndex {
     pub fn add_required_file(&mut self, file_id: FileId, dependency_id: FileId) {
         self.dependencies
             .entry(file_id)
-            .or_insert_with(HashSet::new)
+            .or_default()
             .insert(dependency_id);
     }
 

--- a/crates/emmylua_code_analysis/src/db_index/diagnostic/mod.rs
+++ b/crates/emmylua_code_analysis/src/db_index/diagnostic/mod.rs
@@ -19,6 +19,12 @@ pub struct DiagnosticIndex {
     file_diagnostic_enabled: HashMap<FileId, HashSet<DiagnosticCode>>,
 }
 
+impl Default for DiagnosticIndex {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl DiagnosticIndex {
     pub fn new() -> Self {
         Self {

--- a/crates/emmylua_code_analysis/src/db_index/flow/mod.rs
+++ b/crates/emmylua_code_analysis/src/db_index/flow/mod.rs
@@ -18,6 +18,12 @@ pub struct LuaFlowIndex {
     signature_cast_cache: HashMap<FileId, HashMap<LuaSignatureId, LuaSignatureCast>>,
 }
 
+impl Default for LuaFlowIndex {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl LuaFlowIndex {
     pub fn new() -> Self {
         Self {
@@ -49,7 +55,7 @@ impl LuaFlowIndex {
     ) {
         self.signature_cast_cache
             .entry(file_id)
-            .or_insert_with(HashMap::new)
+            .or_default()
             .insert(signature_id, LuaSignatureCast { name, cast });
     }
 }

--- a/crates/emmylua_code_analysis/src/db_index/global/mod.rs
+++ b/crates/emmylua_code_analysis/src/db_index/global/mod.rs
@@ -28,10 +28,7 @@ impl LuaGlobalIndex {
 
     pub fn add_global_decl(&mut self, name: &str, decl_id: LuaDeclId) {
         let id = GlobalId::new(name);
-        self.global_decl
-            .entry(id)
-            .or_default()
-            .push(decl_id);
+        self.global_decl.entry(id).or_default().push(decl_id);
     }
 
     pub fn get_all_global_decl_ids(&self) -> Vec<LuaDeclId> {

--- a/crates/emmylua_code_analysis/src/db_index/member/lua_member.rs
+++ b/crates/emmylua_code_analysis/src/db_index/member/lua_member.rs
@@ -58,7 +58,7 @@ impl LuaMember {
     }
 
     pub fn is_field(&self) -> bool {
-        LuaSyntaxKind::DocTagField == self.member_id.get_syntax_id().get_kind().into()
+        LuaSyntaxKind::DocTagField == self.member_id.get_syntax_id().get_kind()
     }
 
     pub fn get_feature(&self) -> LuaMemberFeature {

--- a/crates/emmylua_code_analysis/src/db_index/member/lua_member_item.rs
+++ b/crates/emmylua_code_analysis/src/db_index/member/lua_member_item.rs
@@ -40,9 +40,7 @@ fn resolve_member_type(
 ) -> Result<LuaType, InferFailReason> {
     match member_item {
         LuaMemberIndexItem::One(member_id) => {
-            let member_type_cache = db
-                .get_type_index()
-                .get_type_cache(&(*member_id).into());
+            let member_type_cache = db.get_type_index().get_type_cache(&(*member_id).into());
             match member_type_cache {
                 Some(cache) => Ok(cache.as_type().clone()),
                 None => Err(InferFailReason::UnResolveMemberType(*member_id)),

--- a/crates/emmylua_code_analysis/src/db_index/member/lua_member_item.rs
+++ b/crates/emmylua_code_analysis/src/db_index/member/lua_member_item.rs
@@ -10,16 +10,16 @@ pub enum LuaMemberIndexItem {
 
 impl LuaMemberIndexItem {
     pub fn resolve_type(&self, db: &DbIndex) -> Result<LuaType, InferFailReason> {
-        resolve_member_type(db, &self)
+        resolve_member_type(db, self)
     }
 
     pub fn resolve_semantic_decl(&self, db: &DbIndex) -> Option<LuaSemanticDeclId> {
-        resolve_member_semantic_id(db, &self)
+        resolve_member_semantic_id(db, self)
     }
 
     #[allow(unused)]
     pub fn resolve_type_owner_member_id(&self, db: &DbIndex) -> Option<LuaMemberId> {
-        resolve_type_owner_member_id(db, &self)
+        resolve_type_owner_member_id(db, self)
     }
 
     pub fn is_one(&self) -> bool {
@@ -42,11 +42,11 @@ fn resolve_member_type(
         LuaMemberIndexItem::One(member_id) => {
             let member_type_cache = db
                 .get_type_index()
-                .get_type_cache(&member_id.clone().into());
-            return match member_type_cache {
+                .get_type_cache(&(*member_id).into());
+            match member_type_cache {
                 Some(cache) => Ok(cache.as_type().clone()),
                 None => Err(InferFailReason::UnResolveMemberType(*member_id)),
-            };
+            }
         }
         LuaMemberIndexItem::Many(member_ids) => {
             let mut resolve_state = MemberTypeResolveState::All;
@@ -77,7 +77,7 @@ fn resolve_member_type(
                         typ = TypeOps::Union.apply(
                             db,
                             &typ,
-                            &db.get_type_index()
+                            db.get_type_index()
                                 .get_type_cache(&member.get_id().into())
                                 .ok_or(InferFailReason::UnResolveMemberType(member.get_id()))?
                                 .as_type(),
@@ -93,7 +93,7 @@ fn resolve_member_type(
                             typ = TypeOps::Union.apply(
                                 db,
                                 &typ,
-                                &db.get_type_index()
+                                db.get_type_index()
                                     .get_type_cache(&member.get_id().into())
                                     .ok_or(InferFailReason::UnResolveMemberType(member.get_id()))?
                                     .as_type(),
@@ -110,7 +110,7 @@ fn resolve_member_type(
                             typ = TypeOps::Union.apply(
                                 db,
                                 &typ,
-                                &db.get_type_index()
+                                db.get_type_index()
                                     .get_type_cache(&member.get_id().into())
                                     .ok_or(InferFailReason::UnResolveMemberType(member.get_id()))?
                                     .as_type(),

--- a/crates/emmylua_code_analysis/src/db_index/member/mod.rs
+++ b/crates/emmylua_code_analysis/src/db_index/member/mod.rs
@@ -136,9 +136,10 @@ impl LuaMemberIndex {
             LuaMemberIndexItem::Many(ids) => {
                 for id in ids {
                     if let Some(member) = self.get_member(id)
-                        && !member.get_feature().is_meta_decl() {
-                            return false;
-                        }
+                        && !member.get_feature().is_meta_decl()
+                    {
+                        return false;
+                    }
                 }
                 return true;
             }

--- a/crates/emmylua_code_analysis/src/db_index/member/mod.rs
+++ b/crates/emmylua_code_analysis/src/db_index/member/mod.rs
@@ -27,6 +27,12 @@ enum MemberOrOwner {
     Owner(LuaMemberOwner),
 }
 
+impl Default for LuaMemberIndex {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl LuaMemberIndex {
     pub fn new() -> Self {
         Self {
@@ -53,7 +59,7 @@ impl LuaMemberIndex {
     fn add_in_file_object(&mut self, file_id: FileId, member_or_owner: MemberOrOwner) {
         self.in_filed
             .entry(file_id)
-            .or_insert_with(HashSet::new)
+            .or_default()
             .insert(member_or_owner);
     }
 
@@ -70,7 +76,7 @@ impl LuaMemberIndex {
                 match item {
                     LuaMemberIndexItem::One(old_id) => {
                         if old_id != &id {
-                            let ids = vec![old_id.clone(), id];
+                            let ids = vec![*old_id, id];
                             *item = LuaMemberIndexItem::Many(ids);
                         }
                     }
@@ -129,11 +135,10 @@ impl LuaMemberIndex {
             }
             LuaMemberIndexItem::Many(ids) => {
                 for id in ids {
-                    if let Some(member) = self.get_member(id) {
-                        if !member.get_feature().is_meta_decl() {
+                    if let Some(member) = self.get_member(id)
+                        && !member.get_feature().is_meta_decl() {
                             return false;
                         }
-                    }
                 }
                 return true;
             }

--- a/crates/emmylua_code_analysis/src/db_index/metatable/mod.rs
+++ b/crates/emmylua_code_analysis/src/db_index/metatable/mod.rs
@@ -11,6 +11,12 @@ pub struct LuaMetatableIndex {
     pub metatables: HashMap<InFiled<TextRange>, InFiled<TextRange>>,
 }
 
+impl Default for LuaMetatableIndex {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl LuaMetatableIndex {
     pub fn new() -> Self {
         Self {

--- a/crates/emmylua_code_analysis/src/db_index/mod.rs
+++ b/crates/emmylua_code_analysis/src/db_index/mod.rs
@@ -53,6 +53,12 @@ pub struct DbIndex {
 }
 
 #[allow(unused)]
+impl Default for DbIndex {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl DbIndex {
     pub fn new() -> Self {
         Self {

--- a/crates/emmylua_code_analysis/src/db_index/module/workspace.rs
+++ b/crates/emmylua_code_analysis/src/db_index/module/workspace.rs
@@ -12,7 +12,7 @@ impl Workspace {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WorkspaceId {
     pub id: u32,
 }
@@ -37,11 +37,13 @@ impl WorkspaceId {
 
 impl PartialOrd for WorkspaceId {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        match self.id.cmp(&other.id) {
-            std::cmp::Ordering::Less => Some(std::cmp::Ordering::Less),
-            std::cmp::Ordering::Greater => Some(std::cmp::Ordering::Greater),
-            std::cmp::Ordering::Equal => Some(std::cmp::Ordering::Equal),
-        }
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for WorkspaceId {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.id.cmp(&other.id)
     }
 }
 

--- a/crates/emmylua_code_analysis/src/db_index/operators/lua_operator.rs
+++ b/crates/emmylua_code_analysis/src/db_index/operators/lua_operator.rs
@@ -84,9 +84,7 @@ impl LuaOperator {
                 let signature = db.get_signature_index().get(signature_id);
                 if let Some(signature) = signature {
                     if signature.resolve_return == SignatureReturnStatus::UnResolve {
-                        return Err(InferFailReason::UnResolveSignatureReturn(
-                            *signature_id,
-                        ));
+                        return Err(InferFailReason::UnResolveSignatureReturn(*signature_id));
                     }
 
                     let return_type = signature.return_docs.first();
@@ -105,9 +103,7 @@ impl LuaOperator {
 
                 if let Some(signature) = db.get_signature_index().get(signature_id) {
                     if signature.resolve_return == SignatureReturnStatus::UnResolve {
-                        return Err(InferFailReason::UnResolveSignatureReturn(
-                            *signature_id,
-                        ));
+                        return Err(InferFailReason::UnResolveSignatureReturn(*signature_id));
                     }
 
                     let return_type = signature.return_docs.first();

--- a/crates/emmylua_code_analysis/src/db_index/operators/lua_operator.rs
+++ b/crates/emmylua_code_analysis/src/db_index/operators/lua_operator.rs
@@ -85,11 +85,11 @@ impl LuaOperator {
                 if let Some(signature) = signature {
                     if signature.resolve_return == SignatureReturnStatus::UnResolve {
                         return Err(InferFailReason::UnResolveSignatureReturn(
-                            signature_id.clone(),
+                            *signature_id,
                         ));
                     }
 
-                    let return_type = signature.return_docs.get(0);
+                    let return_type = signature.return_docs.first();
                     if let Some(return_type) = return_type {
                         return Ok(return_type.type_ref.clone());
                     }
@@ -106,11 +106,11 @@ impl LuaOperator {
                 if let Some(signature) = db.get_signature_index().get(signature_id) {
                     if signature.resolve_return == SignatureReturnStatus::UnResolve {
                         return Err(InferFailReason::UnResolveSignatureReturn(
-                            signature_id.clone(),
+                            *signature_id,
                         ));
                     }
 
-                    let return_type = signature.return_docs.get(0);
+                    let return_type = signature.return_docs.first();
                     if let Some(return_type) = return_type {
                         return Ok(return_type.type_ref.clone());
                     }

--- a/crates/emmylua_code_analysis/src/db_index/operators/mod.rs
+++ b/crates/emmylua_code_analysis/src/db_index/operators/mod.rs
@@ -17,6 +17,12 @@ pub struct LuaOperatorIndex {
     in_filed_operator_map: HashMap<FileId, Vec<LuaOperatorId>>,
 }
 
+impl Default for LuaOperatorIndex {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl LuaOperatorIndex {
     pub fn new() -> Self {
         Self {
@@ -33,13 +39,13 @@ impl LuaOperatorIndex {
         self.operators.insert(id, operator);
         self.type_operators_map
             .entry(owner)
-            .or_insert_with(HashMap::new)
+            .or_default()
             .entry(op)
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(id);
         self.in_filed_operator_map
             .entry(id.file_id)
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(id);
     }
 

--- a/crates/emmylua_code_analysis/src/db_index/property/mod.rs
+++ b/crates/emmylua_code_analysis/src/db_index/property/mod.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::module_inception)]
 mod property;
 
 use std::collections::{HashMap, HashSet};
@@ -17,6 +18,12 @@ pub struct LuaPropertyIndex {
 
     id_count: u32,
     in_filed_owner: HashMap<FileId, HashSet<LuaSemanticDeclId>>,
+}
+
+impl Default for LuaPropertyIndex {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl LuaPropertyIndex {
@@ -54,11 +61,11 @@ impl LuaPropertyIndex {
     ) -> Option<()> {
         let (_, property_id) = self.get_or_create_property(source_owner_id.clone())?;
         self.property_owners_map
-            .insert(same_property_owner_id, property_id.clone());
+            .insert(same_property_owner_id, property_id);
 
         self.in_filed_owner
             .entry(file_id)
-            .or_insert_with(HashSet::new)
+            .or_default()
             .insert(source_owner_id);
 
         Some(())
@@ -75,7 +82,7 @@ impl LuaPropertyIndex {
 
         self.in_filed_owner
             .entry(file_id)
-            .or_insert_with(HashSet::new)
+            .or_default()
             .insert(owner_id);
 
         Some(())
@@ -92,7 +99,7 @@ impl LuaPropertyIndex {
 
         self.in_filed_owner
             .entry(file_id)
-            .or_insert_with(HashSet::new)
+            .or_default()
             .insert(owner_id);
 
         Some(())
@@ -109,7 +116,7 @@ impl LuaPropertyIndex {
 
         self.in_filed_owner
             .entry(file_id)
-            .or_insert_with(HashSet::new)
+            .or_default()
             .insert(owner_id);
 
         Some(())
@@ -126,7 +133,7 @@ impl LuaPropertyIndex {
 
         self.in_filed_owner
             .entry(file_id)
-            .or_insert_with(HashSet::new)
+            .or_default()
             .insert(owner_id);
 
         Some(())
@@ -143,7 +150,7 @@ impl LuaPropertyIndex {
 
         self.in_filed_owner
             .entry(file_id)
-            .or_insert_with(HashSet::new)
+            .or_default()
             .insert(owner_id);
 
         Some(())
@@ -167,7 +174,7 @@ impl LuaPropertyIndex {
 
         self.in_filed_owner
             .entry(file_id)
-            .or_insert_with(HashSet::new)
+            .or_default()
             .insert(owner_id);
 
         Some(())
@@ -185,7 +192,7 @@ impl LuaPropertyIndex {
 
         self.in_filed_owner
             .entry(file_id)
-            .or_insert_with(HashSet::new)
+            .or_default()
             .insert(owner_id);
 
         Some(())
@@ -202,7 +209,7 @@ impl LuaPropertyIndex {
 
         self.in_filed_owner
             .entry(file_id)
-            .or_insert_with(HashSet::new)
+            .or_default()
             .insert(owner_id);
 
         Some(())
@@ -210,7 +217,7 @@ impl LuaPropertyIndex {
 
     pub fn get_property(&self, owner_id: &LuaSemanticDeclId) -> Option<&LuaCommonProperty> {
         self.property_owners_map
-            .get(&owner_id)
+            .get(owner_id)
             .and_then(|id| self.properties.get(id))
     }
 }
@@ -259,7 +266,7 @@ pub fn try_extract_signature_id_from_field(
     match &type_node {
         LuaDocType::Func(doc_func) => Some(LuaSignatureId::from_doc_func(
             member.get_file_id(),
-            &doc_func,
+            doc_func,
         )),
         _ => None,
     }

--- a/crates/emmylua_code_analysis/src/db_index/property/property.rs
+++ b/crates/emmylua_code_analysis/src/db_index/property/property.rs
@@ -11,6 +11,12 @@ pub struct LuaCommonProperty {
     pub export: Option<LuaExport>,
 }
 
+impl Default for LuaCommonProperty {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl LuaCommonProperty {
     pub fn new() -> Self {
         Self {
@@ -93,6 +99,12 @@ pub enum LuaExportScope {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LuaTagContent {
     pub tags: Vec<(String, String)>,
+}
+
+impl Default for LuaTagContent {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl LuaTagContent {

--- a/crates/emmylua_code_analysis/src/db_index/reference/file_reference.rs
+++ b/crates/emmylua_code_analysis/src/db_index/reference/file_reference.rs
@@ -9,6 +9,12 @@ pub struct FileReference {
     references_to_decl: HashMap<TextRange, LuaDeclId>,
 }
 
+impl Default for FileReference {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl FileReference {
     pub fn new() -> Self {
         Self {
@@ -27,7 +33,7 @@ impl FileReference {
 
         self.decl_references
             .entry(decl_id)
-            .or_insert_with(DeclReference::new)
+            .or_default()
             .add_cell(decl_ref);
     }
 
@@ -54,6 +60,12 @@ pub struct DeclReferenceCell {
 pub struct DeclReference {
     pub cells: Vec<DeclReferenceCell>,
     pub mutable: bool,
+}
+
+impl Default for DeclReference {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl DeclReference {

--- a/crates/emmylua_code_analysis/src/db_index/reference/mod.rs
+++ b/crates/emmylua_code_analysis/src/db_index/reference/mod.rs
@@ -21,6 +21,12 @@ pub struct LuaReferenceIndex {
     type_references: HashMap<FileId, HashMap<LuaTypeDeclId, HashSet<TextRange>>>,
 }
 
+impl Default for LuaReferenceIndex {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl LuaReferenceIndex {
     pub fn new() -> Self {
         Self {
@@ -41,7 +47,7 @@ impl LuaReferenceIndex {
     ) {
         self.file_references
             .entry(file_id)
-            .or_insert_with(FileReference::new)
+            .or_default()
             .add_decl_reference(decl_id, range, is_write);
     }
 
@@ -49,9 +55,9 @@ impl LuaReferenceIndex {
         let key = SmolStr::new(name);
         self.global_references
             .entry(key)
-            .or_insert_with(HashMap::new)
+            .or_default()
             .entry(file_id)
-            .or_insert_with(HashSet::new)
+            .or_default()
             .insert(syntax_id);
     }
 
@@ -63,9 +69,9 @@ impl LuaReferenceIndex {
     ) {
         self.index_reference
             .entry(key)
-            .or_insert_with(HashMap::new)
+            .or_default()
             .entry(file_id)
-            .or_insert_with(HashSet::new)
+            .or_default()
             .insert(syntax_id);
     }
 
@@ -84,9 +90,9 @@ impl LuaReferenceIndex {
     ) {
         self.type_references
             .entry(file_id)
-            .or_insert_with(HashMap::new)
+            .or_default()
             .entry(type_decl_id)
-            .or_insert_with(HashSet::new)
+            .or_default()
             .insert(range);
     }
 
@@ -97,7 +103,7 @@ impl LuaReferenceIndex {
     pub fn create_local_reference(&mut self, file_id: FileId) {
         self.file_references
             .entry(file_id)
-            .or_insert_with(FileReference::new);
+            .or_default();
     }
 
     pub fn get_decl_references(
@@ -151,12 +157,11 @@ impl LuaReferenceIndex {
             .global_references
             .get(name)?
             .iter()
-            .map(|(file_id, syntax_ids)| {
+            .flat_map(|(file_id, syntax_ids)| {
                 syntax_ids
                     .iter()
                     .map(|syntax_id| InFiled::new(*file_id, *syntax_id))
             })
-            .flatten()
             .collect();
 
         Some(results)
@@ -165,33 +170,31 @@ impl LuaReferenceIndex {
     pub fn get_index_references(&self, key: &LuaMemberKey) -> Option<Vec<InFiled<LuaSyntaxId>>> {
         let results = self
             .index_reference
-            .get(&key)?
+            .get(key)?
             .iter()
-            .map(|(file_id, syntax_ids)| {
+            .flat_map(|(file_id, syntax_ids)| {
                 syntax_ids
                     .iter()
                     .map(|syntax_id| InFiled::new(*file_id, *syntax_id))
             })
-            .flatten()
             .collect();
 
         Some(results)
     }
 
     pub fn get_string_references(&self, string_value: &str) -> Vec<InFiled<TextRange>> {
-        let results = self
+        
+
+        self
             .string_references
             .iter()
-            .map(|(file_id, string_reference)| {
+            .flat_map(|(file_id, string_reference)| {
                 string_reference
-                    .get_string_references(&string_value)
+                    .get_string_references(string_value)
                     .into_iter()
                     .map(|range| InFiled::new(*file_id, range))
             })
-            .flatten()
-            .collect();
-
-        results
+            .collect()
     }
 
     pub fn get_type_references(
@@ -201,14 +204,13 @@ impl LuaReferenceIndex {
         let results = self
             .type_references
             .iter()
-            .map(|(file_id, type_references)| {
+            .flat_map(|(file_id, type_references)| {
                 type_references
                     .get(type_decl_id)
                     .into_iter()
                     .flatten()
-                    .map(|range| InFiled::new(*file_id, range.clone()))
+                    .map(|range| InFiled::new(*file_id, *range))
             })
-            .flatten()
             .collect();
 
         Some(results)

--- a/crates/emmylua_code_analysis/src/db_index/reference/mod.rs
+++ b/crates/emmylua_code_analysis/src/db_index/reference/mod.rs
@@ -101,9 +101,7 @@ impl LuaReferenceIndex {
     }
 
     pub fn create_local_reference(&mut self, file_id: FileId) {
-        self.file_references
-            .entry(file_id)
-            .or_default();
+        self.file_references.entry(file_id).or_default();
     }
 
     pub fn get_decl_references(
@@ -183,10 +181,7 @@ impl LuaReferenceIndex {
     }
 
     pub fn get_string_references(&self, string_value: &str) -> Vec<InFiled<TextRange>> {
-        
-
-        self
-            .string_references
+        self.string_references
             .iter()
             .flat_map(|(file_id, string_reference)| {
                 string_reference

--- a/crates/emmylua_code_analysis/src/db_index/reference/string_reference.rs
+++ b/crates/emmylua_code_analysis/src/db_index/reference/string_reference.rs
@@ -17,7 +17,7 @@ impl StringReference {
     pub fn add_string_reference(&mut self, string: &str, range: TextRange) {
         self.string_references
             .entry(SmolStr::new(string))
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(range);
     }
 

--- a/crates/emmylua_code_analysis/src/db_index/signature/mod.rs
+++ b/crates/emmylua_code_analysis/src/db_index/signature/mod.rs
@@ -1,4 +1,5 @@
 mod async_state;
+#[allow(clippy::module_inception)]
 mod signature;
 
 use std::collections::{HashMap, HashSet};
@@ -19,6 +20,12 @@ pub struct LuaSignatureIndex {
     in_file_signatures: HashMap<FileId, HashSet<LuaSignatureId>>,
 }
 
+impl Default for LuaSignatureIndex {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl LuaSignatureIndex {
     pub fn new() -> Self {
         Self {
@@ -32,9 +39,7 @@ impl LuaSignatureIndex {
             .entry(signature_id.get_file_id())
             .or_default()
             .insert(signature_id);
-        self.signatures
-            .entry(signature_id)
-            .or_insert_with(LuaSignature::new)
+        self.signatures.entry(signature_id).or_default()
     }
 
     pub fn get(&self, signature_id: &LuaSignatureId) -> Option<&LuaSignature> {

--- a/crates/emmylua_code_analysis/src/db_index/signature/signature.rs
+++ b/crates/emmylua_code_analysis/src/db_index/signature/signature.rs
@@ -88,9 +88,10 @@ impl LuaSignature {
         if idx < self.params.len() {
             return Some(self.params[idx].clone());
         } else if let Some(name) = self.params.last()
-            && name == "..." {
-                return Some(name.clone());
-            }
+            && name == "..."
+        {
+            return Some(name.clone());
+        }
 
         None
     }
@@ -99,9 +100,10 @@ impl LuaSignature {
         if idx < self.params.len() {
             return self.param_docs.get(&idx);
         } else if let Some(name) = self.params.last()
-            && name == "..." {
-                return self.param_docs.get(&(self.params.len() - 1));
-            }
+            && name == "..."
+        {
+            return self.param_docs.get(&(self.params.len() - 1));
+        }
 
         None
     }
@@ -139,9 +141,9 @@ impl LuaSignature {
                         && (param_type.is_any()
                             || param_type.is_table()
                             || param_type.is_class_tpl())
-                        {
-                            return false;
-                        }
+                    {
+                        return false;
+                    }
 
                     semantic_model
                         .type_check(owner_type, &param_info.type_ref)

--- a/crates/emmylua_code_analysis/src/db_index/signature/signature.rs
+++ b/crates/emmylua_code_analysis/src/db_index/signature/signature.rs
@@ -32,6 +32,12 @@ pub enum LuaNoDiscard {
     NoDiscardWithMessage(Box<String>),
 }
 
+impl Default for LuaSignature {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl LuaSignature {
     pub fn new() -> Self {
         Self {
@@ -81,11 +87,10 @@ impl LuaSignature {
     pub fn get_param_name_by_id(&self, idx: usize) -> Option<String> {
         if idx < self.params.len() {
             return Some(self.params[idx].clone());
-        } else if let Some(name) = self.params.last() {
-            if name == "..." {
+        } else if let Some(name) = self.params.last()
+            && name == "..." {
                 return Some(name.clone());
             }
-        }
 
         None
     }
@@ -93,11 +98,10 @@ impl LuaSignature {
     pub fn get_param_info_by_id(&self, idx: usize) -> Option<&LuaDocParamInfo> {
         if idx < self.params.len() {
             return self.param_docs.get(&idx);
-        } else if let Some(name) = self.params.last() {
-            if name == "..." {
+        } else if let Some(name) = self.params.last()
+            && name == "..." {
                 return self.param_docs.get(&(self.params.len() - 1));
             }
-        }
 
         None
     }
@@ -131,17 +135,13 @@ impl LuaSignature {
             match owner_type {
                 Some(owner_type) => {
                     // 一些类型不应该被视为 method
-                    match (owner_type, param_type) {
-                        (LuaType::Ref(_) | LuaType::Def(_), _) => {
-                            if param_type.is_any()
-                                || param_type.is_table()
-                                || param_type.is_class_tpl()
-                            {
-                                return false;
-                            }
+                    if let (LuaType::Ref(_) | LuaType::Def(_), _) = (owner_type, param_type)
+                        && (param_type.is_any()
+                            || param_type.is_table()
+                            || param_type.is_class_tpl())
+                        {
+                            return false;
                         }
-                        _ => {}
-                    }
 
                     semantic_model
                         .type_check(owner_type, &param_info.type_ref)
@@ -164,7 +164,7 @@ impl LuaSignature {
 
     pub fn to_call_operator_func_type(&self) -> Arc<LuaFunctionType> {
         let mut params = self.get_type_params();
-        if params.len() > 0 && !self.is_colon_define {
+        if !params.is_empty() && !self.is_colon_define {
             params.remove(0);
         }
 

--- a/crates/emmylua_code_analysis/src/db_index/type/humanize_type.rs
+++ b/crates/emmylua_code_analysis/src/db_index/type/humanize_type.rs
@@ -121,8 +121,7 @@ fn humanize_def_type(db: &DbIndex, id: &LuaTypeDeclId, level: RenderLevel) -> St
     let generic = match db.get_type_index().get_generic_params(id) {
         Some(generic) => generic,
         None => {
-            return humanize_simple_type(db, id, &full_name, level)
-                .unwrap_or(full_name.to_string());
+            return humanize_simple_type(db, id, full_name, level).unwrap_or(full_name.to_string());
         }
     };
 
@@ -300,9 +299,9 @@ fn humanize_multi_line_union_type(
         return text;
     }
 
-    text.push_str("\n");
+    text.push('\n');
     for (typ, description) in members {
-        let type_humanize_text = humanize_type(db, &typ, RenderLevel::Minimal);
+        let type_humanize_text = humanize_type(db, typ, RenderLevel::Minimal);
         if let Some(description) = description {
             text.push_str(&format!(
                 "    | {} -- {}\n",
@@ -396,10 +395,7 @@ fn humanize_doc_function_type(
 
     let ret_type = lua_func.get_ret();
     let return_nil = match ret_type {
-        LuaType::Variadic(variadic) => match variadic.get_type(0) {
-            Some(LuaType::Nil) => true,
-            _ => false,
-        },
+        LuaType::Variadic(variadic) => matches!(variadic.get_type(0), Some(LuaType::Nil)),
         _ => ret_type.is_nil(),
     };
 
@@ -434,7 +430,7 @@ fn humanize_object_type(db: &DbIndex, object: &LuaObjectType, level: RenderLevel
     let fields = object
         .get_fields()
         .iter()
-        .sorted_by(|a, b| a.0.cmp(&b.0))
+        .sorted_by(|a, b| a.0.cmp(b.0))
         .take(num)
         .map(|field| {
             let name = field.0.clone();
@@ -548,8 +544,8 @@ fn humanize_table_const_type_detail_and_simple(
         };
         let member_string = build_table_member_string(
             key,
-            &type_cache.as_type(),
-            humanize_type(db, &type_cache.as_type(), level.next_level()),
+            type_cache.as_type(),
+            humanize_type(db, type_cache.as_type(), level.next_level()),
             level,
         );
 
@@ -603,7 +599,7 @@ fn humanize_table_const_type(
 
 fn humanize_table_generic_type(
     db: &DbIndex,
-    table_generic_params: &Vec<LuaType>,
+    table_generic_params: &[LuaType],
     level: RenderLevel,
 ) -> String {
     let num = match level {
@@ -730,10 +726,7 @@ fn humanize_signature_type(
     let ret_str = {
         let ret_type = signature.get_return_type();
         let return_nil = match ret_type {
-            LuaType::Variadic(variadic) => match variadic.get_type(0) {
-                Some(LuaType::Nil) => true,
-                _ => false,
-            },
+            LuaType::Variadic(variadic) => matches!(variadic.get_type(0), Some(LuaType::Nil)),
             _ => ret_type.is_nil(),
         };
 

--- a/crates/emmylua_code_analysis/src/db_index/type/mod.rs
+++ b/crates/emmylua_code_analysis/src/db_index/type/mod.rs
@@ -73,10 +73,7 @@ impl LuaTypeIndex {
 
     pub fn add_type_decl(&mut self, file_id: FileId, type_decl: LuaTypeDecl) {
         let id = type_decl.get_id();
-        self.file_types
-            .entry(file_id)
-            .or_default()
-            .push(id.clone());
+        self.file_types.entry(file_id).or_default().push(id.clone());
 
         if let Some(old_decl) = self.full_name_type_map.get_mut(&id) {
             old_decl.merge_decl(type_decl);
@@ -149,14 +146,15 @@ impl LuaTypeIndex {
         for id in all_type_ids {
             let id_name = id.get_name();
             if id_name.starts_with(prefix)
-                && let Some(rest_name) = id_name.strip_prefix(prefix) {
-                    if let Some(i) = rest_name.find('.') {
-                        let name = rest_name[..i].to_string();
-                        result.entry(name).or_insert(None);
-                    } else {
-                        result.insert(rest_name.to_string(), Some(id.clone()));
-                    }
+                && let Some(rest_name) = id_name.strip_prefix(prefix)
+            {
+                if let Some(i) = rest_name.find('.') {
+                    let name = rest_name[..i].to_string();
+                    result.entry(name).or_insert(None);
+                } else {
+                    result.insert(rest_name.to_string(), Some(id.clone()));
                 }
+            }
         }
 
         result
@@ -178,7 +176,9 @@ impl LuaTypeIndex {
     }
 
     pub fn get_super_types(&self, decl_id: &LuaTypeDeclId) -> Option<Vec<LuaType>> {
-        self.supers.get(decl_id).map(|supers| supers.iter().map(|s| s.value.clone()).collect())
+        self.supers
+            .get(decl_id)
+            .map(|supers| supers.iter().map(|s| s.value.clone()).collect())
     }
 
     pub fn get_super_types_iter(

--- a/crates/emmylua_code_analysis/src/db_index/type/type_decl.rs
+++ b/crates/emmylua_code_analysis/src/db_index/type/type_decl.rs
@@ -234,7 +234,6 @@ impl LuaTypeDeclId {
 
     pub fn get_simple_name(&self) -> &str {
         let basic_name = self.get_name();
-        
 
         (if let Some(i) = basic_name.rfind('.') {
             &basic_name[i + 1..]

--- a/crates/emmylua_code_analysis/src/db_index/type/type_decl.rs
+++ b/crates/emmylua_code_analysis/src/db_index/type/type_decl.rs
@@ -141,7 +141,7 @@ impl LuaTypeDecl {
                     return Some(origin.clone());
                 }
 
-                Some(instantiate_type_generic(db, &origin, substitutor))
+                Some(instantiate_type_generic(db, origin, substitutor))
             }
             _ => None,
         }
@@ -155,20 +155,14 @@ impl LuaTypeDecl {
     }
 
     pub fn add_alias_origin(&mut self, replace: LuaType) {
-        match &mut self.extra {
-            LuaTypeExtra::Alias { origin, .. } => {
-                *origin = Some(replace);
-            }
-            _ => {}
+        if let LuaTypeExtra::Alias { origin, .. } = &mut self.extra {
+            *origin = Some(replace);
         }
     }
 
     pub fn add_enum_base(&mut self, base_type: LuaType) {
-        match &mut self.extra {
-            LuaTypeExtra::Enum { base } => {
-                *base = Some(base_type);
-            }
-            _ => {}
+        if let LuaTypeExtra::Enum { base } = &mut self.extra {
+            *base = Some(base_type);
         }
     }
 
@@ -191,7 +185,7 @@ impl LuaTypeDecl {
                 let member_key = enum_member.get_key();
                 let fake_type = match member_key {
                     LuaMemberKey::Name(name) => LuaType::DocStringConst(name.clone().into()),
-                    LuaMemberKey::Integer(i) => LuaType::IntegerConst(i.clone()),
+                    LuaMemberKey::Integer(i) => LuaType::IntegerConst(*i),
                     LuaMemberKey::ExprType(typ) => typ.clone(),
                     LuaMemberKey::None => continue,
                 };
@@ -204,8 +198,8 @@ impl LuaTypeDecl {
                     db.get_type_index().get_type_cache(&member.get_id().into())
                 {
                     let member_fake_type = match type_cache.as_type() {
-                        LuaType::StringConst(s) => LuaType::DocStringConst(s.clone().into()),
-                        LuaType::IntegerConst(i) => LuaType::DocIntegerConst(i.clone()),
+                        LuaType::StringConst(s) => LuaType::DocStringConst(s.clone()),
+                        LuaType::IntegerConst(i) => LuaType::DocIntegerConst(*i),
                         _ => type_cache.as_type().clone(),
                     };
 
@@ -214,7 +208,7 @@ impl LuaTypeDecl {
             }
         }
 
-        return Some(LuaType::Union(LuaUnionType::from_vec(union_types).into()));
+        Some(LuaType::Union(LuaUnionType::from_vec(union_types).into()))
     }
 }
 
@@ -240,13 +234,13 @@ impl LuaTypeDeclId {
 
     pub fn get_simple_name(&self) -> &str {
         let basic_name = self.get_name();
-        let just_name = if let Some(i) = basic_name.rfind('.') {
+        
+
+        (if let Some(i) = basic_name.rfind('.') {
             &basic_name[i + 1..]
         } else {
-            &basic_name
-        };
-
-        &just_name
+            basic_name
+        }) as _
     }
 
     pub fn collect_super_types(&self, db: &DbIndex, collected_types: &mut Vec<LuaType>) {

--- a/crates/emmylua_code_analysis/src/db_index/type/type_ops/remove_type.rs
+++ b/crates/emmylua_code_analysis/src/db_index/type/type_ops/remove_type.rs
@@ -74,9 +74,10 @@ pub fn remove_type(db: &DbIndex, source: LuaType, removed_type: LuaType) -> Opti
                     return Some(source.clone());
                 }
                 if type_decl.is_alias()
-                    && let Some(alias_ref) = get_real_type(db, real_type) {
-                        return remove_type(db, alias_ref.clone(), removed_type);
-                    }
+                    && let Some(alias_ref) = get_real_type(db, real_type)
+                {
+                    return remove_type(db, alias_ref.clone(), removed_type);
+                }
 
                 // 需要对`userdata`进行特殊处理
                 if let Some(super_types) = db.get_type_index().get_super_types_iter(type_decl_id) {

--- a/crates/emmylua_code_analysis/src/db_index/type/type_ops/remove_type.rs
+++ b/crates/emmylua_code_analysis/src/db_index/type/type_ops/remove_type.rs
@@ -73,11 +73,10 @@ pub fn remove_type(db: &DbIndex, source: LuaType, removed_type: LuaType) -> Opti
                 if type_decl.is_enum() {
                     return Some(source.clone());
                 }
-                if type_decl.is_alias() {
-                    if let Some(alias_ref) = get_real_type(db, &real_type) {
+                if type_decl.is_alias()
+                    && let Some(alias_ref) = get_real_type(db, real_type) {
                         return remove_type(db, alias_ref.clone(), removed_type);
                     }
-                }
 
                 // 需要对`userdata`进行特殊处理
                 if let Some(super_types) = db.get_type_index().get_super_types_iter(type_decl_id) {

--- a/crates/emmylua_code_analysis/src/db_index/type/type_ops/union_type.rs
+++ b/crates/emmylua_code_analysis/src/db_index/type/type_ops/union_type.rs
@@ -31,7 +31,7 @@ pub fn union_type(db: &DbIndex, source: LuaType, target: LuaType) -> LuaType {
         (LuaType::BooleanConst(_), LuaType::Boolean) => LuaType::Boolean,
         (LuaType::BooleanConst(left), LuaType::BooleanConst(right)) => {
             if left == right {
-                LuaType::BooleanConst(left.clone())
+                LuaType::BooleanConst(*left)
             } else {
                 LuaType::Boolean
             }

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/cast_type_mismatch.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/cast_type_mismatch.rs
@@ -38,7 +38,7 @@ fn check_cast_tag(
     // 检查每个 cast 操作类型
     for op_type in cast_tag.get_op_types() {
         // 如果具有操作符, 则不检查
-        if let Some(_) = op_type.get_op() {
+        if op_type.get_op().is_some() {
             continue;
         }
         if let Some(target_doc_type) = op_type.get_type() {
@@ -87,7 +87,7 @@ fn check_cast_compatibility(
         _ => cast_type_check(semantic_model, origin_type, target_type, 0),
     };
 
-    if !result.is_ok() {
+    if result.is_err() {
         add_cast_type_mismatch_diagnostic(
             context,
             semantic_model,
@@ -111,7 +111,7 @@ fn add_cast_type_mismatch_diagnostic(
 ) {
     let db = semantic_model.get_db();
     match result {
-        Ok(_) => return,
+        Ok(_) => (),
         Err(reason) => {
             let reason_message = match reason {
                 TypeCheckFailReason::TypeNotMatchWithReason(reason) => reason,
@@ -176,7 +176,7 @@ fn cast_type_check(
                     }
                 }
             }
-            return Ok(());
+            Ok(())
         }
         _ => {
             if origin_type.is_table() {
@@ -194,10 +194,8 @@ fn cast_type_check(
                 if target_type.is_string() {
                     return Ok(());
                 }
-            } else if origin_type.is_number() {
-                if target_type.is_number() {
-                    return Ok(());
-                }
+            } else if origin_type.is_number() && target_type.is_number() {
+                return Ok(());
             }
 
             semantic_model.type_check_detail(target_type, origin_type)

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/check_field.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/check_field.rs
@@ -244,28 +244,16 @@ fn is_valid_member(
     };
 
     // 一些类型组合需要特殊处理
-    match (prefix_typ, &key_type) {
-        // (LuaType::Tuple(tuple), LuaType::Integer | LuaType::IntegerConst(_)) => {
-        //     if tuple.is_infer_resolve() {
-        //         return Some(());
-        //     } else {
-        //         // 元组类型禁止修改
-        //         return None;
-        //     }
-        // }
-        (LuaType::Def(id), _) => {
-            if let Some(decl) = semantic_model.get_db().get_type_index().get_type_decl(id) {
-                if decl.is_class() {
-                    if code == DiagnosticCode::InjectField {
-                        return Some(());
-                    }
-                    if index_key.is_string() || matches!(key_type, LuaType::String) {
-                        return Some(());
-                    }
-                }
-            }
+    if let (LuaType::Def(id), _) = (prefix_typ, &key_type)
+        && let Some(decl) = semantic_model.get_db().get_type_index().get_type_decl(id)
+        && decl.is_class()
+    {
+        if code == DiagnosticCode::InjectField {
+            return Some(());
         }
-        _ => {}
+        if index_key.is_string() || matches!(key_type, LuaType::String) {
+            return Some(());
+        }
     }
 
     /*

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/code_style/non_literal_expressions_in_assert.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/code_style/non_literal_expressions_in_assert.rs
@@ -42,10 +42,10 @@ fn check_assert_rule(
                     .get_db()
                     .get_decl_index()
                     .get_decl_tree(&semantic_model.get_file_id())?;
-                if let Some(decl) = decl_tree.find_local_decl(&name, name_expr.get_position()) {
-                    if decl.is_local() {
-                        return Some(());
-                    }
+                if let Some(decl) = decl_tree.find_local_decl(&name, name_expr.get_position())
+                    && decl.is_local()
+                {
+                    return Some(());
                 }
             }
             _ => {}

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/code_style/preferred_local_alias.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/code_style/preferred_local_alias.rs
@@ -75,10 +75,10 @@ fn collect_local_alias(
                 .get_db()
                 .get_reference_index()
                 .get_decl_references(&semantic_model.get_file_id(), &decl_id);
-            if let Some(decl_refs) = decl_refs {
-                if decl_refs.mutable {
-                    continue;
-                }
+            if let Some(decl_refs) = decl_refs
+                && decl_refs.mutable
+            {
+                continue;
             }
 
             let name = match value_expr {

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/mod.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/mod.rs
@@ -139,7 +139,7 @@ impl<'a> DiagnosticContext<'a> {
     }
 
     pub fn get_db(&self) -> &DbIndex {
-        &self.db
+        self.db
     }
 
     pub fn get_file_id(&self) -> FileId {
@@ -192,7 +192,7 @@ impl<'a> DiagnosticContext<'a> {
 
     fn get_severity(&self, code: DiagnosticCode) -> Option<DiagnosticSeverity> {
         if let Some(severity) = self.config.severity.get(&code) {
-            return Some(severity.clone());
+            return Some(*severity);
         }
 
         Some(get_default_severity(code))
@@ -234,12 +234,12 @@ impl<'a> DiagnosticContext<'a> {
         let db = self.get_db();
         let diagnostic_index = db.get_diagnostic_index();
         // force enable
-        if diagnostic_index.is_file_enabled(&file_id, &code) {
+        if diagnostic_index.is_file_enabled(&file_id, code) {
             return true;
         }
 
         // workspace force disabled
-        if self.config.workspace_disabled.contains(&code) {
+        if self.config.workspace_disabled.contains(code) {
             return false;
         }
 
@@ -250,17 +250,17 @@ impl<'a> DiagnosticContext<'a> {
         }
 
         // is file disabled this code
-        if diagnostic_index.is_file_disabled(&file_id, &code) {
+        if diagnostic_index.is_file_disabled(&file_id, code) {
             return false;
         }
 
         // workspace force enabled
-        if self.config.workspace_enabled.contains(&code) {
+        if self.config.workspace_enabled.contains(code) {
             return true;
         }
 
         // default setting
-        is_code_default_enable(&code, self.config.level)
+        is_code_default_enable(code, self.config.level)
     }
 }
 
@@ -286,7 +286,7 @@ pub fn get_return_stats(closure_expr: &LuaClosureExpr) -> impl Iterator<Item = L
         .filter(move |stat| {
             stat.ancestors::<LuaClosureExpr>()
                 .next()
-                .map_or(false, |expr| &expr == closure_expr)
+                .is_some_and(|expr| &expr == closure_expr)
         })
 }
 

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/unused.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/unused.rs
@@ -87,13 +87,12 @@ fn get_unused_check_result(
             .last()
             .ok_or(UnusedCheckResult::Unused(decl_range))?;
 
-        if last_ref_cell.is_write {
-            if let Some(result) =
+        if last_ref_cell.is_write
+            && let Some(result) =
                 check_last_mutable_is_read(decl_range.start(), decl_ref, last_ref_cell.range, root)
             {
                 return Err(result);
             }
-        }
     }
 
     Ok(())

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/unused.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/unused.rs
@@ -90,9 +90,9 @@ fn get_unused_check_result(
         if last_ref_cell.is_write
             && let Some(result) =
                 check_last_mutable_is_read(decl_range.start(), decl_ref, last_ref_cell.range, root)
-            {
-                return Err(result);
-            }
+        {
+            return Err(result);
+        }
     }
 
     Ok(())

--- a/crates/emmylua_code_analysis/src/diagnostic/lua_diagnostic.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/lua_diagnostic.rs
@@ -12,6 +12,12 @@ pub struct LuaDiagnostic {
     config: Arc<LuaDiagnosticConfig>,
 }
 
+impl Default for LuaDiagnostic {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl LuaDiagnostic {
     pub fn new() -> Self {
         Self {
@@ -40,16 +46,16 @@ impl LuaDiagnostic {
         }
 
         let db = compilation.get_db();
-        if let Some(module_info) = db.get_module_index().get_workspace_id(file_id) {
-            if !module_info.is_main() {
-                return None;
-            }
+        if let Some(module_info) = db.get_module_index().get_workspace_id(file_id)
+            && !module_info.is_main()
+        {
+            return None;
         }
 
-        let mut semantic_model = compilation.get_semantic_model(file_id)?;
+        let semantic_model = compilation.get_semantic_model(file_id)?;
         let mut context = DiagnosticContext::new(file_id, db, self.config.clone());
 
-        check_file(&mut context, &mut semantic_model);
+        check_file(&mut context, &semantic_model);
 
         Some(context.get_diagnostics())
     }

--- a/crates/emmylua_code_analysis/src/diagnostic/lua_diagnostic_config.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/lua_diagnostic_config.rs
@@ -45,7 +45,7 @@ impl LuaDiagnosticConfig {
 
         let mut severity = HashMap::new();
         for (code, sev) in &emmyrc.diagnostics.severity {
-            severity.insert(code.clone(), sev.clone().into());
+            severity.insert(*code, (*sev).into());
         }
         Self {
             workspace_disabled,

--- a/crates/emmylua_code_analysis/src/lib.rs
+++ b/crates/emmylua_code_analysis/src/lib.rs
@@ -266,5 +266,11 @@ impl EmmyLuaAnalysis {
     }
 }
 
+impl Default for EmmyLuaAnalysis {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 unsafe impl Send for EmmyLuaAnalysis {}
 unsafe impl Sync for EmmyLuaAnalysis {}

--- a/crates/emmylua_code_analysis/src/resources/mod.rs
+++ b/crates/emmylua_code_analysis/src/resources/mod.rs
@@ -22,14 +22,11 @@ pub fn load_resource_std(
         };
         let std_dir = PathBuf::from(&resource_path).join("std");
         let result = load_resource_from_file_system(&resource_path);
-        match result {
-            Some(mut files) => {
-                if !is_jit {
-                    remove_jit_resource(&mut files);
-                }
-                return (std_dir, files);
+        if let Some(mut files) = result {
+            if !is_jit {
+                remove_jit_resource(&mut files);
             }
-            None => {}
+            return (std_dir, files);
         }
     }
 
@@ -102,7 +99,7 @@ fn load_resource_from_file_system(resources_dir: &Path) -> Option<Vec<LuaFileInf
         }
 
         let version_path = resources_dir.join("version");
-        let content = format!("{}", VERSION);
+        let content = VERSION.to_string();
         match std::fs::write(&version_path, content) {
             Ok(_) => {}
             Err(e) => {
@@ -123,7 +120,7 @@ fn load_resource_from_file_system(resources_dir: &Path) -> Option<Vec<LuaFileInf
         }
     };
 
-    return Some(files);
+    Some(files)
 }
 
 fn check_need_dump_to_file_system() -> bool {

--- a/crates/emmylua_code_analysis/src/semantic/generic/instantiate_func_generic.rs
+++ b/crates/emmylua_code_analysis/src/semantic/generic/instantiate_func_generic.rs
@@ -98,13 +98,12 @@ pub fn instantiate_func_generic(
                 continue;
             }
 
-            if !func_param_type.is_variadic() {
-                if check_expr_can_later_infer(&mut context, func_param_type, call_arg_expr)? {
+            if !func_param_type.is_variadic()
+                && check_expr_can_later_infer(&mut context, func_param_type, call_arg_expr)? {
                     // If the argument cannot be inferred later, we will handle it later.
                     unresolve_tpls.push((func_param_type.clone(), call_arg_expr.clone()));
                     continue;
                 }
-            }
 
             let arg_type = infer_expr(db, context.cache, call_arg_expr.clone())?;
 
@@ -142,11 +141,10 @@ pub fn instantiate_func_generic(
         }
     }
 
-    if contain_self {
-        if let Some(self_type) = infer_self_type(db, cache, &call_expr) {
+    if contain_self
+        && let Some(self_type) = infer_self_type(db, cache, &call_expr) {
             substitutor.add_self_type(self_type);
         }
-    }
 
     if let LuaType::DocFunction(f) = instantiate_doc_function(db, func, &substitutor) {
         Ok(f.deref().clone())
@@ -186,16 +184,15 @@ pub fn infer_self_type(
     call_expr: &LuaCallExpr,
 ) -> Option<LuaType> {
     let prefix_expr = call_expr.get_prefix_expr();
-    if let Some(prefix_expr) = prefix_expr {
-        if let LuaExpr::IndexExpr(index) = prefix_expr {
+    if let Some(prefix_expr) = prefix_expr
+        && let LuaExpr::IndexExpr(index) = prefix_expr {
             let self_expr = index.get_prefix_expr();
             if let Some(self_expr) = self_expr {
-                let self_type = infer_expr(db, cache, self_expr.into()).ok()?;
+                let self_type = infer_expr(db, cache, self_expr).ok()?;
                 let self_type = build_self_type(db, &self_type);
                 return Some(self_type);
             }
         }
-    }
 
     None
 }
@@ -211,7 +208,7 @@ fn check_expr_can_later_infer(
             let sig = context
                 .db
                 .get_signature_index()
-                .get(&sig_id)
+                .get(sig_id)
                 .ok_or(InferFailReason::None)?;
 
             sig.to_doc_func_type()

--- a/crates/emmylua_code_analysis/src/semantic/generic/instantiate_func_generic.rs
+++ b/crates/emmylua_code_analysis/src/semantic/generic/instantiate_func_generic.rs
@@ -99,11 +99,12 @@ pub fn instantiate_func_generic(
             }
 
             if !func_param_type.is_variadic()
-                && check_expr_can_later_infer(&mut context, func_param_type, call_arg_expr)? {
-                    // If the argument cannot be inferred later, we will handle it later.
-                    unresolve_tpls.push((func_param_type.clone(), call_arg_expr.clone()));
-                    continue;
-                }
+                && check_expr_can_later_infer(&mut context, func_param_type, call_arg_expr)?
+            {
+                // If the argument cannot be inferred later, we will handle it later.
+                unresolve_tpls.push((func_param_type.clone(), call_arg_expr.clone()));
+                continue;
+            }
 
             let arg_type = infer_expr(db, context.cache, call_arg_expr.clone())?;
 
@@ -141,10 +142,9 @@ pub fn instantiate_func_generic(
         }
     }
 
-    if contain_self
-        && let Some(self_type) = infer_self_type(db, cache, &call_expr) {
-            substitutor.add_self_type(self_type);
-        }
+    if contain_self && let Some(self_type) = infer_self_type(db, cache, &call_expr) {
+        substitutor.add_self_type(self_type);
+    }
 
     if let LuaType::DocFunction(f) = instantiate_doc_function(db, func, &substitutor) {
         Ok(f.deref().clone())
@@ -185,14 +185,15 @@ pub fn infer_self_type(
 ) -> Option<LuaType> {
     let prefix_expr = call_expr.get_prefix_expr();
     if let Some(prefix_expr) = prefix_expr
-        && let LuaExpr::IndexExpr(index) = prefix_expr {
-            let self_expr = index.get_prefix_expr();
-            if let Some(self_expr) = self_expr {
-                let self_type = infer_expr(db, cache, self_expr).ok()?;
-                let self_type = build_self_type(db, &self_type);
-                return Some(self_type);
-            }
+        && let LuaExpr::IndexExpr(index) = prefix_expr
+    {
+        let self_expr = index.get_prefix_expr();
+        if let Some(self_expr) = self_expr {
+            let self_type = infer_expr(db, cache, self_expr).ok()?;
+            let self_type = build_self_type(db, &self_type);
+            return Some(self_type);
         }
+    }
 
     None
 }

--- a/crates/emmylua_code_analysis/src/semantic/generic/instantiate_special_generic.rs
+++ b/crates/emmylua_code_analysis/src/semantic/generic/instantiate_special_generic.rs
@@ -42,11 +42,11 @@ pub fn instantiate_alias_call(
                 return LuaType::Unknown;
             }
 
-            let members = find_members(db, &operands[0]).unwrap_or(Vec::new());
+            let members = find_members(db, &operands[0]).unwrap_or_default();
             let member_key_types = members
                 .iter()
                 .filter_map(|m| match &m.key {
-                    LuaMemberKey::Integer(i) => Some(LuaType::DocIntegerConst(i.clone())),
+                    LuaMemberKey::Integer(i) => Some(LuaType::DocIntegerConst(*i)),
                     LuaMemberKey::Name(s) => Some(LuaType::DocStringConst(s.clone().into())),
                     _ => None,
                 })
@@ -157,7 +157,7 @@ fn instantiate_select_call(source: &LuaType, index: &LuaType) -> LuaType {
 }
 
 fn instantiate_unpack_call(db: &DbIndex, operands: &[LuaType]) -> LuaType {
-    if operands.len() < 1 {
+    if operands.is_empty() {
         return LuaType::Unknown;
     }
 
@@ -243,8 +243,8 @@ fn instantiate_rawget_call(db: &DbIndex, owner: &LuaType, key: &LuaType) -> LuaT
     let member_key = match key {
         LuaType::DocStringConst(s) => LuaMemberKey::Name(s.deref().clone()),
         LuaType::StringConst(s) => LuaMemberKey::Name(s.deref().clone()),
-        LuaType::DocIntegerConst(i) => LuaMemberKey::Integer(i.clone()),
-        LuaType::IntegerConst(i) => LuaMemberKey::Integer(i.clone()),
+        LuaType::DocIntegerConst(i) => LuaMemberKey::Integer(*i),
+        LuaType::IntegerConst(i) => LuaMemberKey::Integer(*i),
         _ => return LuaType::Unknown,
     };
 

--- a/crates/emmylua_code_analysis/src/semantic/generic/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/generic/mod.rs
@@ -80,7 +80,7 @@ pub fn get_tpl_ref_extend_type(
                                 match parent_owner {
                                     LuaMemberOwner::Type(type_id) => {
                                         let generic_params =
-                                            db.get_type_index().get_generic_params(&type_id)?;
+                                            db.get_type_index().get_generic_params(type_id)?;
                                         return generic_params
                                             .get(tpl_id as usize)?
                                             .type_constraint

--- a/crates/emmylua_code_analysis/src/semantic/generic/type_substitutor.rs
+++ b/crates/emmylua_code_analysis/src/semantic/generic/type_substitutor.rs
@@ -50,7 +50,9 @@ impl TypeSubstitutor {
 
     pub fn add_need_infer_tpls(&mut self, tpl_ids: HashSet<GenericTplId>) {
         for tpl_id in tpl_ids {
-            self.tpl_replace_map.entry(tpl_id).or_insert(SubstitutorValue::None);
+            self.tpl_replace_map
+                .entry(tpl_id)
+                .or_insert(SubstitutorValue::None);
         }
     }
 
@@ -149,9 +151,10 @@ impl TypeSubstitutor {
 
     pub fn check_recursion(&self, type_id: &LuaTypeDeclId) -> bool {
         if let Some(alias_type_id) = &self.alias_type_id
-            && alias_type_id == type_id {
-                return true;
-            }
+            && alias_type_id == type_id
+        {
+            return true;
+        }
 
         false
     }

--- a/crates/emmylua_code_analysis/src/semantic/generic/type_substitutor.rs
+++ b/crates/emmylua_code_analysis/src/semantic/generic/type_substitutor.rs
@@ -9,6 +9,12 @@ pub struct TypeSubstitutor {
     self_type: Option<LuaType>,
 }
 
+impl Default for TypeSubstitutor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TypeSubstitutor {
     pub fn new() -> Self {
         Self {
@@ -44,9 +50,7 @@ impl TypeSubstitutor {
 
     pub fn add_need_infer_tpls(&mut self, tpl_ids: HashSet<GenericTplId>) {
         for tpl_id in tpl_ids {
-            if !self.tpl_replace_map.contains_key(&tpl_id) {
-                self.tpl_replace_map.insert(tpl_id, SubstitutorValue::None);
-            }
+            self.tpl_replace_map.entry(tpl_id).or_insert(SubstitutorValue::None);
         }
     }
 
@@ -144,11 +148,10 @@ impl TypeSubstitutor {
     }
 
     pub fn check_recursion(&self, type_id: &LuaTypeDeclId) -> bool {
-        if let Some(alias_type_id) = &self.alias_type_id {
-            if alias_type_id == type_id {
+        if let Some(alias_type_id) = &self.alias_type_id
+            && alias_type_id == type_id {
                 return true;
             }
-        }
 
         false
     }

--- a/crates/emmylua_code_analysis/src/semantic/infer/infer_binary/infer_binary_or.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/infer_binary/infer_binary_or.rs
@@ -20,7 +20,7 @@ pub fn special_or_rule(
             }
         }
         LuaExpr::TableExpr(table_expr) => {
-            if table_expr.is_empty() && check_type_compact(db, &left_type, &LuaType::Table).is_ok()
+            if table_expr.is_empty() && check_type_compact(db, left_type, &LuaType::Table).is_ok()
             {
                 return Some(remove_false_or_nil(left_type.clone()));
             }
@@ -35,7 +35,7 @@ pub fn special_or_rule(
                 return None;
             }
 
-            if check_type_compact(db, &left_type, &right_type).is_ok() {
+            if check_type_compact(db, left_type, right_type).is_ok() {
                 return Some(remove_false_or_nil(left_type.clone()));
             }
         }

--- a/crates/emmylua_code_analysis/src/semantic/infer/infer_binary/infer_binary_or.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/infer_binary/infer_binary_or.rs
@@ -20,8 +20,7 @@ pub fn special_or_rule(
             }
         }
         LuaExpr::TableExpr(table_expr) => {
-            if table_expr.is_empty() && check_type_compact(db, left_type, &LuaType::Table).is_ok()
-            {
+            if table_expr.is_empty() && check_type_compact(db, left_type, &LuaType::Table).is_ok() {
                 return Some(remove_false_or_nil(left_type.clone()));
             }
         }

--- a/crates/emmylua_code_analysis/src/semantic/infer/infer_binary/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/infer_binary/mod.rs
@@ -32,9 +32,10 @@ pub fn infer_binary_expr(
             return Ok(ty);
         }
     } else if !matches!(op, BinaryOperator::OpAnd | BinaryOperator::OpOr)
-        && let Some(ty) = infer_union_binary_expr(db, op, left_type_ref, right_type_ref) {
-            return Ok(ty);
-        }
+        && let Some(ty) = infer_union_binary_expr(db, op, left_type_ref, right_type_ref)
+    {
+        return Ok(ty);
+    }
 
     match (real_left_type.is_some(), real_right_type.is_some()) {
         (false, false) => infer_binary_expr_type(db, left_type, right_type, op),
@@ -117,25 +118,27 @@ fn infer_binary_custom_operator(
 ) -> InferResult {
     // 先检查 left 是否是自定义类型，避免不必要的 clone
     if left.is_custom_type()
-        && let Some(operators) = get_custom_type_operator(db, left.clone(), op) {
-            for operator in operators {
-                let operand = operator.get_operand(db);
-                if check_type_compact(db, &operand, right).is_ok() {
-                    return operator.get_result(db);
-                }
+        && let Some(operators) = get_custom_type_operator(db, left.clone(), op)
+    {
+        for operator in operators {
+            let operand = operator.get_operand(db);
+            if check_type_compact(db, &operand, right).is_ok() {
+                return operator.get_result(db);
             }
         }
+    }
 
     // 再检查 right 是否是自定义类型，只在需要时 clone
     if right.is_custom_type()
-        && let Some(operators) = get_custom_type_operator(db, right.clone(), op) {
-            for operator in operators {
-                let operand = operator.get_operand(db);
-                if check_type_compact(db, &operand, left).is_ok() {
-                    return operator.get_result(db);
-                }
+        && let Some(operators) = get_custom_type_operator(db, right.clone(), op)
+    {
+        for operator in operators {
+            let operand = operator.get_operand(db);
+            if check_type_compact(db, &operand, left).is_ok() {
+                return operator.get_result(db);
             }
         }
+    }
 
     match op {
         LuaOperatorMetaMethod::Add

--- a/crates/emmylua_code_analysis/src/semantic/infer/infer_call/infer_setmetatable.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/infer_call/infer_setmetatable.rs
@@ -38,17 +38,17 @@ pub fn infer_setmetatable_call(
                 ));
             }
 
-            return Ok(LuaType::TableConst(InFiled::new(
+            Ok(LuaType::TableConst(InFiled::new(
                 cache.get_file_id(),
                 table_expr.get_range(),
-            )));
+            )))
         }
         _ => {
             if meta_type.is_unknown() {
                 return infer_expr(db, cache, basic_table);
             }
 
-            return Ok(meta_type);
+            Ok(meta_type)
         }
     }
 }
@@ -83,47 +83,41 @@ fn infer_metatable_index_type(
     cache: &mut LuaInferCache,
     metatable: LuaExpr,
 ) -> Result<(LuaType, bool /*__index type*/), InferFailReason> {
-    match &metatable {
-        LuaExpr::TableExpr(table) => {
-            let fields = table.get_fields();
-            for field in fields {
-                let field_name = match field.get_field_key() {
-                    Some(key) => match key {
-                        LuaIndexKey::Name(n) => n.get_name_text().to_string(),
-                        LuaIndexKey::String(s) => s.get_value(),
-                        _ => continue,
-                    },
-                    None => continue,
-                };
+    if let LuaExpr::TableExpr(table) = &metatable {
+        let fields = table.get_fields();
+        for field in fields {
+            let field_name = match field.get_field_key() {
+                Some(key) => match key {
+                    LuaIndexKey::Name(n) => n.get_name_text().to_string(),
+                    LuaIndexKey::String(s) => s.get_value(),
+                    _ => continue,
+                },
+                None => continue,
+            };
 
-                if field_name == "__index" {
-                    let field_value = field.get_value_expr().ok_or(InferFailReason::None)?;
-                    if matches!(
-                        field_value,
-                        LuaExpr::TableExpr(_)
-                            | LuaExpr::CallExpr(_)
-                            | LuaExpr::IndexExpr(_)
-                            | LuaExpr::NameExpr(_)
-                    ) {
-                        let meta_type = infer_expr(db, cache, field_value)?;
-                        return Ok((meta_type, true));
-                    }
+            if field_name == "__index" {
+                let field_value = field.get_value_expr().ok_or(InferFailReason::None)?;
+                if matches!(
+                    field_value,
+                    LuaExpr::TableExpr(_)
+                        | LuaExpr::CallExpr(_)
+                        | LuaExpr::IndexExpr(_)
+                        | LuaExpr::NameExpr(_)
+                ) {
+                    let meta_type = infer_expr(db, cache, field_value)?;
+                    return Ok((meta_type, true));
                 }
             }
         }
-        _ => {}
     };
 
     let meta_type = infer_expr(db, cache, metatable)?;
     if let Some(meta_members) =
         find_members_with_key(db, &meta_type, LuaMemberKey::Name("__index".into()), false)
-    {
-        if let Some(meta_member) = meta_members.first() {
-            if meta_member.typ.is_custom_type() {
+        && let Some(meta_member) = meta_members.first()
+            && meta_member.typ.is_custom_type() {
                 return Ok((meta_member.typ.clone(), true));
             }
-        }
-    }
 
     Ok((meta_type, false))
 }

--- a/crates/emmylua_code_analysis/src/semantic/infer/infer_call/infer_setmetatable.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/infer_call/infer_setmetatable.rs
@@ -115,9 +115,10 @@ fn infer_metatable_index_type(
     if let Some(meta_members) =
         find_members_with_key(db, &meta_type, LuaMemberKey::Name("__index".into()), false)
         && let Some(meta_member) = meta_members.first()
-            && meta_member.typ.is_custom_type() {
-                return Ok((meta_member.typ.clone(), true));
-            }
+        && meta_member.typ.is_custom_type()
+    {
+        return Ok((meta_member.typ.clone(), true));
+    }
 
     Ok((meta_type, false))
 }

--- a/crates/emmylua_code_analysis/src/semantic/infer/infer_fail_reason.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/infer_fail_reason.rs
@@ -15,13 +15,13 @@ pub enum InferFailReason {
 
 impl InferFailReason {
     pub fn is_need_resolve(&self) -> bool {
-        match self {
+        matches!(
+            self,
             InferFailReason::UnResolveExpr(_)
-            | InferFailReason::UnResolveSignatureReturn(_)
-            | InferFailReason::FieldNotFound
-            | InferFailReason::UnResolveDeclType(_)
-            | InferFailReason::UnResolveMemberType(_) => true,
-            _ => false,
-        }
+                | InferFailReason::UnResolveSignatureReturn(_)
+                | InferFailReason::FieldNotFound
+                | InferFailReason::UnResolveDeclType(_)
+                | InferFailReason::UnResolveMemberType(_)
+        )
     }
 }

--- a/crates/emmylua_code_analysis/src/semantic/infer/infer_unary.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/infer_unary.rs
@@ -58,8 +58,8 @@ fn infer_unary_expr_not(inner_type: LuaType) -> InferResult {
 fn infer_unary_expr_unm(db: &DbIndex, inner_type: LuaType) -> InferResult {
     match inner_type {
         LuaType::IntegerConst(i) => Ok(LuaType::IntegerConst(-i)),
-        LuaType::DocIntegerConst(i) => Ok(LuaType::DocIntegerConst((-i).into())),
-        LuaType::FloatConst(f) => Ok(LuaType::FloatConst((-f).into())),
+        LuaType::DocIntegerConst(i) => Ok(LuaType::DocIntegerConst(-i)),
+        LuaType::FloatConst(f) => Ok(LuaType::FloatConst(-f)),
         LuaType::Integer => Ok(LuaType::Integer),
         _ => infer_unary_custom_operator(db, &inner_type, LuaOperatorMetaMethod::Unm),
     }

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/call_flow.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/call_flow.rs
@@ -16,6 +16,7 @@ use crate::{
     },
 };
 
+#[allow(clippy::too_many_arguments)]
 pub fn get_type_at_call_expr(
     db: &DbIndex,
     tree: &FlowTree,
@@ -127,6 +128,7 @@ pub fn get_type_at_call_expr(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn get_type_at_call_expr_by_type_guard(
     db: &DbIndex,
     tree: &FlowTree,
@@ -189,6 +191,7 @@ fn get_type_at_call_expr_by_type_guard(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn get_type_at_call_expr_by_signature_self(
     db: &DbIndex,
     tree: &FlowTree,
@@ -239,6 +242,7 @@ fn get_type_at_call_expr_by_signature_self(
     Ok(ResultTypeOrContinue::Result(result_type))
 }
 
+#[allow(clippy::too_many_arguments)]
 fn get_type_at_call_expr_by_signature_param_name(
     db: &DbIndex,
     tree: &FlowTree,
@@ -314,7 +318,7 @@ fn get_type_at_call_expr_by_signature_param_name(
     Ok(ResultTypeOrContinue::Result(result_type))
 }
 
-#[allow(unused)]
+#[allow(unused, clippy::too_many_arguments)]
 fn get_type_at_call_expr_by_call(
     db: &DbIndex,
     tree: &FlowTree,
@@ -336,16 +340,13 @@ fn get_type_at_call_expr_by_call(
         return Ok(ResultTypeOrContinue::Continue);
     }
 
-    match alias_call_type.get_call_kind() {
-        LuaAliasCallKind::RawGet => {
-            let antecedent_type = infer_expr(db, cache, LuaExpr::CallExpr(call_expr))?;
-            let result_type = match condition_flow {
-                InferConditionFlow::FalseCondition => narrow_false_or_nil(db, antecedent_type),
-                InferConditionFlow::TrueCondition => remove_false_or_nil(antecedent_type),
-            };
-            return Ok(ResultTypeOrContinue::Result(result_type));
-        }
-        _ => {}
+    if alias_call_type.get_call_kind() == LuaAliasCallKind::RawGet {
+        let antecedent_type = infer_expr(db, cache, LuaExpr::CallExpr(call_expr))?;
+        let result_type = match condition_flow {
+            InferConditionFlow::FalseCondition => narrow_false_or_nil(db, antecedent_type),
+            InferConditionFlow::TrueCondition => remove_false_or_nil(antecedent_type),
+        };
+        return Ok(ResultTypeOrContinue::Result(result_type));
     };
 
     Ok(ResultTypeOrContinue::Continue)

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/index_flow.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/index_flow.rs
@@ -12,7 +12,7 @@ use crate::{
     },
 };
 
-#[allow(unused)]
+#[allow(clippy::too_many_arguments)]
 pub fn get_type_at_index_expr(
     db: &DbIndex,
     tree: &FlowTree,

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/mod.rs
@@ -46,6 +46,7 @@ impl InferConditionFlow {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn get_type_at_condition_flow(
     db: &DbIndex,
     tree: &FlowTree,
@@ -129,6 +130,7 @@ pub fn get_type_at_condition_flow(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn get_type_at_name_expr(
     db: &DbIndex,
     tree: &FlowTree,
@@ -169,6 +171,7 @@ fn get_type_at_name_expr(
     Ok(ResultTypeOrContinue::Result(result_type))
 }
 
+#[allow(clippy::too_many_arguments)]
 fn get_type_at_name_ref(
     db: &DbIndex,
     tree: &FlowTree,
@@ -206,6 +209,7 @@ fn get_type_at_name_ref(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn get_type_at_unary_flow(
     db: &DbIndex,
     tree: &FlowTree,

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/get_type_at_cast_flow.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/get_type_at_cast_flow.rs
@@ -31,6 +31,7 @@ pub fn get_type_at_cast_flow(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn get_type_at_cast_expr(
     db: &DbIndex,
     tree: &FlowTree,

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/mod.rs
@@ -61,7 +61,10 @@ fn get_var_ref_type(db: &DbIndex, cache: &mut LuaInferCache, var_ref_id: &VarRef
         find_decl_member_type(db, member_id)
     } else {
         if let Some(type_cache) = cache.index_ref_origin_type_cache.get(var_ref_id)
-            && let CacheEntry::Cache(ty) = type_cache { return Ok(ty.clone()) }
+            && let CacheEntry::Cache(ty) = type_cache
+        {
+            return Ok(ty.clone());
+        }
 
         Err(InferFailReason::None)
     }

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/mod.rs
@@ -60,12 +60,8 @@ fn get_var_ref_type(db: &DbIndex, cache: &mut LuaInferCache, var_ref_id: &VarRef
     } else if let Some(member_id) = var_ref_id.get_member_id_ref() {
         find_decl_member_type(db, member_id)
     } else {
-        if let Some(type_cache) = cache.index_ref_origin_type_cache.get(&var_ref_id) {
-            match type_cache {
-                CacheEntry::Cache(ty) => return Ok(ty.clone()),
-                _ => {}
-            }
-        }
+        if let Some(type_cache) = cache.index_ref_origin_type_cache.get(var_ref_id)
+            && let CacheEntry::Cache(ty) = type_cache { return Ok(ty.clone()) }
 
         Err(InferFailReason::None)
     }
@@ -79,7 +75,7 @@ fn get_single_antecedent(tree: &FlowTree, flow: &FlowNode) -> Result<FlowId, Inf
                 let multi_flow = tree
                     .get_multi_antecedents(*multi_id)
                     .ok_or(InferFailReason::None)?;
-                if multi_flow.len() > 0 {
+                if !multi_flow.is_empty() {
                     // If there are multiple antecedents, we need to handle them separately
                     // For now, we just return the first one
                     Ok(multi_flow[0])

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/narrow_type/false_or_nil_type.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/narrow_type/false_or_nil_type.rs
@@ -5,7 +5,7 @@ pub fn narrow_false_or_nil(db: &DbIndex, t: LuaType) -> LuaType {
         return LuaType::BooleanConst(false);
     }
 
-    return narrow_down_type(db, t.clone(), LuaType::Nil).unwrap_or(LuaType::Never);
+    narrow_down_type(db, t.clone(), LuaType::Nil).unwrap_or(LuaType::Never)
 }
 
 pub fn remove_false_or_nil(t: LuaType) -> LuaType {

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/narrow_type/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/narrow_type/mod.rs
@@ -186,7 +186,7 @@ pub fn narrow_down_type(db: &DbIndex, source: LuaType, target: LuaType) -> Optio
         LuaType::MultiLineUnion(multi_line_union) => {
             let union_types = multi_line_union
                 .get_unions()
-                .into_iter()
+                .iter()
                 .filter_map(|(ty, _)| narrow_down_type(db, ty.clone(), target.clone()))
                 .collect::<Vec<_>>();
 

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/var_ref_id.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/var_ref_id.rs
@@ -13,6 +13,7 @@ use crate::{
     },
 };
 
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum VarRefId {
     VarRef(LuaDeclId),
@@ -63,10 +64,7 @@ impl VarRefId {
     }
 
     pub fn is_self_ref(&self) -> bool {
-        match self {
-            VarRefId::SelfRef(_) => true,
-            _ => false,
-        }
+        matches!(self, VarRefId::SelfRef(_))
     }
 }
 
@@ -75,9 +73,7 @@ fn get_call_expr_var_ref_id(
     cache: &mut LuaInferCache,
     call_expr: &LuaCallExpr,
 ) -> Option<VarRefId> {
-    let Some(prefix_expr) = call_expr.get_prefix_expr() else {
-        return None;
-    };
+    let prefix_expr = call_expr.get_prefix_expr()?;
     let maybe_func = infer_expr(db, cache, prefix_expr.clone()).ok()?;
 
     let ret = match maybe_func {
@@ -106,7 +102,7 @@ fn get_call_expr_var_ref_id(
             // 开始构建 access_path
             let mut access_path = String::new();
             access_path.push_str(obj_expr.syntax().text().to_string().as_str()); // 这里不需要精确的文本
-            access_path.push_str(".");
+            access_path.push('.');
             let key_expr = args_iter.next()?;
             match key_expr {
                 LuaExpr::LiteralExpr(literal_expr) => match literal_expr.get_literal()? {
@@ -132,7 +128,7 @@ fn get_call_expr_var_ref_id(
                 ArcIntern::new(SmolStr::new(access_path)),
             ))
         }
-        _ => return None,
+        _ => None,
     }
 }
 

--- a/crates/emmylua_code_analysis/src/semantic/member/get_member_map.rs
+++ b/crates/emmylua_code_analysis/src/semantic/member/get_member_map.rs
@@ -19,23 +19,24 @@ pub fn get_member_map(
         let typ = &member.typ;
         // 通常是泛型实例化推断结果
         if let LuaType::Union(u) = typ
-            && u.into_vec().iter().all(|f| f.is_function()) {
-                for (index, f) in u.into_vec().iter().enumerate() {
-                    let new_member = LuaMemberInfo {
-                        key: key.clone(),
-                        typ: f.clone(),
-                        property_owner_id: member.property_owner_id.clone(),
-                        feature: member.feature,
-                        overload_index: Some(index),
-                    };
+            && u.into_vec().iter().all(|f| f.is_function())
+        {
+            for (index, f) in u.into_vec().iter().enumerate() {
+                let new_member = LuaMemberInfo {
+                    key: key.clone(),
+                    typ: f.clone(),
+                    property_owner_id: member.property_owner_id.clone(),
+                    feature: member.feature,
+                    overload_index: Some(index),
+                };
 
-                    member_map
-                        .entry(key.clone())
-                        .or_insert_with(Vec::new)
-                        .push(new_member);
-                }
-                continue;
+                member_map
+                    .entry(key.clone())
+                    .or_insert_with(Vec::new)
+                    .push(new_member);
             }
+            continue;
+        }
         member_map.entry(key).or_insert_with(Vec::new).push(member);
     }
 

--- a/crates/emmylua_code_analysis/src/semantic/member/get_member_map.rs
+++ b/crates/emmylua_code_analysis/src/semantic/member/get_member_map.rs
@@ -18,14 +18,14 @@ pub fn get_member_map(
         let key = member.key.clone();
         let typ = &member.typ;
         // 通常是泛型实例化推断结果
-        if let LuaType::Union(u) = typ {
-            if u.into_vec().iter().all(|f| f.is_function()) {
+        if let LuaType::Union(u) = typ
+            && u.into_vec().iter().all(|f| f.is_function()) {
                 for (index, f) in u.into_vec().iter().enumerate() {
                     let new_member = LuaMemberInfo {
                         key: key.clone(),
                         typ: f.clone(),
                         property_owner_id: member.property_owner_id.clone(),
-                        feature: member.feature.clone(),
+                        feature: member.feature,
                         overload_index: Some(index),
                     };
 
@@ -36,7 +36,6 @@ pub fn get_member_map(
                 }
                 continue;
             }
-        }
         member_map.entry(key).or_insert_with(Vec::new).push(member);
     }
 

--- a/crates/emmylua_code_analysis/src/semantic/member/infer_raw_member.rs
+++ b/crates/emmylua_code_analysis/src/semantic/member/infer_raw_member.rs
@@ -35,8 +35,7 @@ fn infer_raw_member_type_guard(
         | LuaType::StringConst(_)
         | LuaType::DocStringConst(_)
         | LuaType::Language(_) => {
-            let decl_id =
-                get_buildin_type_map_type_id(prefix_type).ok_or(InferFailReason::None)?;
+            let decl_id = get_buildin_type_map_type_id(prefix_type).ok_or(InferFailReason::None)?;
             let owner = LuaMemberOwner::Type(decl_id);
             infer_owner_raw_member_type(db, owner, member_key)
         }
@@ -96,19 +95,20 @@ fn infer_custom_type_raw_member_type(
     }
 
     if type_decl.is_class()
-        && let Some(super_types) = type_index.get_super_types(type_id) {
-            for super_type in super_types {
-                let result = infer_raw_member_type_guard(db, &super_type, member_key, infer_guard);
+        && let Some(super_types) = type_index.get_super_types(type_id)
+    {
+        for super_type in super_types {
+            let result = infer_raw_member_type_guard(db, &super_type, member_key, infer_guard);
 
-                match result {
-                    Ok(member_type) => {
-                        return Ok(member_type);
-                    }
-                    Err(InferFailReason::FieldNotFound) => {}
-                    Err(err) => return Err(err),
+            match result {
+                Ok(member_type) => {
+                    return Ok(member_type);
                 }
+                Err(InferFailReason::FieldNotFound) => {}
+                Err(err) => return Err(err),
             }
         }
+    }
 
     Err(InferFailReason::FieldNotFound)
 }

--- a/crates/emmylua_code_analysis/src/semantic/member/infer_raw_member.rs
+++ b/crates/emmylua_code_analysis/src/semantic/member/infer_raw_member.rs
@@ -36,7 +36,7 @@ fn infer_raw_member_type_guard(
         | LuaType::DocStringConst(_)
         | LuaType::Language(_) => {
             let decl_id =
-                get_buildin_type_map_type_id(&prefix_type).ok_or(InferFailReason::None)?;
+                get_buildin_type_map_type_id(prefix_type).ok_or(InferFailReason::None)?;
             let owner = LuaMemberOwner::Type(decl_id);
             infer_owner_raw_member_type(db, owner, member_key)
         }
@@ -80,7 +80,7 @@ fn infer_custom_type_raw_member_type(
     infer_guard.check(type_id)?;
     let type_index = db.get_type_index();
     let type_decl = type_index
-        .get_type_decl(&type_id)
+        .get_type_decl(type_id)
         .ok_or(InferFailReason::None)?;
     if type_decl.is_alias() {
         if let Some(origin_type) = type_decl.get_alias_origin(db, None) {
@@ -95,8 +95,8 @@ fn infer_custom_type_raw_member_type(
         return member_item.resolve_type(db);
     }
 
-    if type_decl.is_class() {
-        if let Some(super_types) = type_index.get_super_types(&type_id) {
+    if type_decl.is_class()
+        && let Some(super_types) = type_index.get_super_types(type_id) {
             for super_type in super_types {
                 let result = infer_raw_member_type_guard(db, &super_type, member_key, infer_guard);
 
@@ -109,7 +109,6 @@ fn infer_custom_type_raw_member_type(
                 }
             }
         }
-    }
 
     Err(InferFailReason::FieldNotFound)
 }
@@ -134,7 +133,7 @@ fn infer_object_raw_member_type(
     object: &LuaObjectType,
     member_key: &LuaMemberKey,
 ) -> RawGetMemberTypeResult {
-    if let Some(member_type) = object.get_field(&member_key) {
+    if let Some(member_type) = object.get_field(member_key) {
         return Ok(member_type.clone());
     }
 

--- a/crates/emmylua_code_analysis/src/semantic/member/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/member/mod.rs
@@ -59,7 +59,7 @@ pub fn find_member_origin_owner(
             break;
         }
 
-        visited_members.insert(current_member_id.clone());
+        visited_members.insert(*current_member_id);
         iteration_count += 1;
 
         match resolve_member_owner(db, infer_config, current_member_id) {

--- a/crates/emmylua_code_analysis/src/semantic/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/mod.rs
@@ -100,7 +100,7 @@ impl<'a> SemanticModel<'a> {
     }
 
     pub fn get_document_by_uri(&'_ self, uri: &Uri) -> Option<LuaDocument<'_>> {
-        let file_id = self.db.get_vfs().get_file_id(&uri)?;
+        let file_id = self.db.get_vfs().get_file_id(uri)?;
         self.db.get_vfs().get_document(&file_id)
     }
 
@@ -162,7 +162,7 @@ impl<'a> SemanticModel<'a> {
         let call_expr_type = infer_expr(
             self.db,
             &mut self.infer_cache.borrow_mut(),
-            prefix_expr.into(),
+            prefix_expr,
         )
         .ok()?;
         infer_call_expr_func(
@@ -324,6 +324,12 @@ impl<'a> SemanticModel<'a> {
 #[derive(Debug)]
 pub struct InferGuard {
     guard: HashSet<LuaTypeDeclId>,
+}
+
+impl Default for InferGuard {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl InferGuard {

--- a/crates/emmylua_code_analysis/src/semantic/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/mod.rs
@@ -159,12 +159,8 @@ impl<'a> SemanticModel<'a> {
         arg_count: Option<usize>,
     ) -> Option<Arc<LuaFunctionType>> {
         let prefix_expr = call_expr.get_prefix_expr()?;
-        let call_expr_type = infer_expr(
-            self.db,
-            &mut self.infer_cache.borrow_mut(),
-            prefix_expr,
-        )
-        .ok()?;
+        let call_expr_type =
+            infer_expr(self.db, &mut self.infer_cache.borrow_mut(), prefix_expr).ok()?;
         infer_call_expr_func(
             self.db,
             &mut self.infer_cache.borrow_mut(),

--- a/crates/emmylua_code_analysis/src/semantic/semantic_info/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/semantic_info/mod.rs
@@ -49,7 +49,7 @@ pub fn infer_token_semantic_info(
                 LuaDeclExtra::Param {
                     idx, signature_id, ..
                 } => {
-                    let signature = db.get_signature_index().get(&signature_id)?;
+                    let signature = db.get_signature_index().get(signature_id)?;
                     let param_info = signature.get_param_info_by_id(*idx)?;
                     let mut typ = param_info.type_ref.clone();
                     if param_info.nullable && !typ.is_nullable() {
@@ -135,7 +135,7 @@ pub fn infer_node_semantic_info(
                         semantic_decl: Some(LuaSemanticDeclId::Member(member_id)),
                     })
                 }
-                _ => return None,
+                _ => None,
             }
         }
         _ => None,
@@ -212,7 +212,7 @@ pub fn infer_node_semantic_decl(
                     let member_id = LuaMemberId::new(field.get_syntax_id(), cache.get_file_id());
                     Some(LuaSemanticDeclId::Member(member_id))
                 }
-                _ => return None,
+                _ => None,
             }
         }
         local_name if LuaLocalName::can_cast(local_name.kind().into()) => {

--- a/crates/emmylua_code_analysis/src/semantic/type_check/complex_type/array_type_check.rs
+++ b/crates/emmylua_code_analysis/src/semantic/type_check/complex_type/array_type_check.rs
@@ -97,17 +97,12 @@ fn check_array_type_compact_ref_def(
     };
 
     for member in &members {
-        match &member.key {
-            LuaMemberKey::ExprType(key_type) => {
-                if key_type.is_integer() {
-                    match check_general_type_compact(context, source_base, &member.typ, check_guard)
-                    {
-                        Ok(()) => return Ok(()),
-                        _ => {}
-                    }
-                }
-            }
-            _ => {}
+        if let LuaMemberKey::ExprType(key_type) = &member.key
+            && key_type.is_integer()
+            && let Ok(()) =
+                check_general_type_compact(context, source_base, &member.typ, check_guard)
+        {
+            return Ok(());
         }
     }
 

--- a/crates/emmylua_code_analysis/src/semantic/type_check/complex_type/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/type_check/complex_type/mod.rs
@@ -37,7 +37,7 @@ pub fn check_complex_type_compact(
             }
         }
         LuaType::Tuple(tuple) => {
-            match check_tuple_type_compact(context, &tuple, compact_type, check_guard) {
+            match check_tuple_type_compact(context, tuple, compact_type, check_guard) {
                 Err(TypeCheckFailReason::DonotCheck) => {}
                 result => return result,
             }
@@ -71,16 +71,13 @@ pub fn check_complex_type_compact(
             }
         }
         LuaType::Union(union_type) => {
-            match compact_type {
-                LuaType::Union(compact_union) => {
-                    return check_union_type_compact_union(
-                        context,
-                        source,
-                        compact_union,
-                        check_guard.next_level()?,
-                    );
-                }
-                _ => {}
+            if let LuaType::Union(compact_union) = compact_type {
+                return check_union_type_compact_union(
+                    context,
+                    source,
+                    compact_union,
+                    check_guard.next_level()?,
+                );
             }
             for sub_type in union_type.into_vec() {
                 match check_general_type_compact(
@@ -106,7 +103,7 @@ pub fn check_complex_type_compact(
             return check_complex_type_compact(
                 context,
                 &union,
-                &compact_type,
+                compact_type,
                 check_guard.next_level()?,
             );
         }

--- a/crates/emmylua_code_analysis/src/semantic/type_check/complex_type/table_generic_check.rs
+++ b/crates/emmylua_code_analysis/src/semantic/type_check/complex_type/table_generic_check.rs
@@ -114,7 +114,7 @@ pub fn check_table_generic_type_compact(
 
 fn check_table_generic_compact_member_owner(
     context: &TypeCheckContext,
-    source_generic_params: &Vec<LuaType>,
+    source_generic_params: &[LuaType],
     member_owner: LuaMemberOwner,
     check_guard: TypeCheckGuard,
 ) -> TypeCheckResult {
@@ -149,7 +149,7 @@ fn check_table_generic_compact_member_owner(
         check_general_type_compact(
             context,
             source_value,
-            &member_type,
+            member_type,
             check_guard.next_level()?,
         )?;
     }

--- a/crates/emmylua_code_analysis/src/semantic/type_check/complex_type/tuple_type_check.rs
+++ b/crates/emmylua_code_analysis/src/semantic/type_check/complex_type/tuple_type_check.rs
@@ -186,9 +186,7 @@ fn check_tuple_type_compact_table(
 ) -> TypeCheckResult {
     let member_index = context.db.get_member_index();
     let tuple_members = source_tuple.get_types();
-    let size = tuple_members.len();
-    for i in 0..size {
-        let source_tuple_member_type = &tuple_members[i];
+    for (i, source_tuple_member_type) in tuple_members.iter().enumerate() {
         let key = LuaMemberKey::Integer((i + 1) as i64);
         if let Some(member_item) = member_index.get_member_item(&table_owner, &key) {
             let member_type = member_item
@@ -241,9 +239,8 @@ fn check_tuple_type_compact_object_type(
     let object_members = object_type.get_fields();
 
     let tuple_members = source_tuple.get_types();
-    let size = tuple_members.len();
-    for i in 0..size {
-        let source_tuple_member_type = &tuple_members[i];
+    // for i in 0..size {
+    for (i, source_tuple_member_type) in tuple_members.iter().enumerate() {
         let key = LuaMemberKey::Integer((i + 1) as i64);
         if let Some(object_member_type) = object_members.get(&key) {
             match check_general_type_compact(

--- a/crates/emmylua_code_analysis/src/semantic/type_check/generic_type.rs
+++ b/crates/emmylua_code_analysis/src/semantic/type_check/generic_type.rs
@@ -116,7 +116,7 @@ fn check_generic_type_compact_table(
         .map(|members| {
             members
                 .iter()
-                .map(|m| (m.get_key().clone(), m.get_id().clone()))
+                .map(|m| (m.get_key().clone(), m.get_id()))
                 .collect()
         })
         .unwrap_or_default();
@@ -149,7 +149,7 @@ fn check_generic_type_compact_table(
                 if let Err(err) = check_general_type_compact(
                     context,
                     &source_member_type,
-                    &table_member_type,
+                    table_member_type,
                     next_guard,
                 ) && err.is_type_not_match()
                 {
@@ -162,8 +162,7 @@ fn check_generic_type_compact_table(
                             name = key.to_path(),
                             expect =
                                 humanize_type(context.db, &source_member_type, RenderLevel::Simple),
-                            got =
-                                humanize_type(context.db, &table_member_type, RenderLevel::Simple)
+                            got = humanize_type(context.db, table_member_type, RenderLevel::Simple)
                         )
                         .to_string(),
                     ));

--- a/crates/emmylua_code_analysis/src/semantic/type_check/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/type_check/mod.rs
@@ -54,7 +54,7 @@ fn check_general_type_compact(
         return Ok(());
     }
 
-    if let Some(origin_type) = escape_type(&context.db, compact_type) {
+    if let Some(origin_type) = escape_type(context.db, compact_type) {
         return check_general_type_compact(
             context,
             source,
@@ -143,7 +143,7 @@ fn check_general_type_compact(
             if compact_type.is_boolean() {
                 return Ok(());
             }
-            return Err(TypeCheckFailReason::TypeNotMatch);
+            Err(TypeCheckFailReason::TypeNotMatch)
         }
         _ => Err(TypeCheckFailReason::TypeNotMatch),
     }
@@ -164,10 +164,10 @@ fn escape_type(db: &DbIndex, typ: &LuaType) -> Option<LuaType> {
     match typ {
         LuaType::Ref(type_id) => {
             let type_decl = db.get_type_index().get_type_decl(type_id)?;
-            if type_decl.is_alias() {
-                if let Some(origin_type) = type_decl.get_alias_origin(db, None) {
-                    return Some(origin_type.clone());
-                }
+            if type_decl.is_alias()
+                && let Some(origin_type) = type_decl.get_alias_origin(db, None)
+            {
+                return Some(origin_type.clone());
             }
         }
         // todo donot escape

--- a/crates/emmylua_code_analysis/src/semantic/type_check/sub_type.rs
+++ b/crates/emmylua_code_analysis/src/semantic/type_check/sub_type.rs
@@ -32,7 +32,7 @@ fn check_sub_type_of_iterative(
             continue;
         }
 
-        let supers_iter = match type_index.get_super_types_iter(&current_id) {
+        let supers_iter = match type_index.get_super_types_iter(current_id) {
             Some(iter) => iter,
             None => continue,
         };
@@ -59,10 +59,10 @@ fn check_sub_type_of_iterative(
                     }
                 }
                 _ => {
-                    if let Some(base_id) = get_base_type_id(super_type) {
-                        if base_id == *super_type_ref_id {
-                            return Some(true);
-                        }
+                    if let Some(base_id) = get_base_type_id(super_type)
+                        && base_id == *super_type_ref_id
+                    {
+                        return Some(true);
                     }
                 }
             }

--- a/crates/emmylua_code_analysis/src/semantic/visibility/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/visibility/mod.rs
@@ -88,7 +88,7 @@ fn check_visibility_by_visibility(
         db,
         infer_config,
         file_id,
-        &member_owner,
+        member_owner,
         token.clone(),
         visibility,
     )
@@ -99,7 +99,7 @@ fn check_visibility_by_visibility(
 
     let blocks = token.ancestors::<LuaBlock>();
     for block in blocks {
-        if check_block_visibility(db, infer_config, &member_owner, block, visibility)
+        if check_block_visibility(db, infer_config, member_owner, block, visibility)
             .unwrap_or(false)
         {
             return Some(true);
@@ -123,19 +123,16 @@ fn check_block_visibility(
     let func_name = func_stat.get_func_name()?;
     if let LuaVarExpr::IndexExpr(index_expr) = func_name {
         let prefix_expr = index_expr.get_prefix_expr()?;
-        let typ = infer_expr(db, infer_config, prefix_expr.into()).ok()?;
+        let typ = infer_expr(db, infer_config, prefix_expr).ok()?;
         if visibility == VisibilityKind::Protected {
-            match (typ, member_owner) {
-                (LuaType::Def(left), LuaMemberOwner::Type(right)) => {
-                    if left == *right {
-                        return Some(true);
-                    }
-
-                    if is_sub_type_of(db, &left, &right) {
-                        return Some(true);
-                    }
+            if let (LuaType::Def(left), LuaMemberOwner::Type(right)) = (typ, member_owner) {
+                if left == *right {
+                    return Some(true);
                 }
-                _ => {}
+
+                if is_sub_type_of(db, &left, right) {
+                    return Some(true);
+                }
             }
         } else if visibility == VisibilityKind::Private {
             match (typ, member_owner) {
@@ -163,7 +160,7 @@ fn check_def_visibility(
 ) -> Option<bool> {
     let index_expr = token.get_parent::<LuaIndexExpr>()?;
     let prefix_expr = index_expr.get_prefix_expr()?;
-    let typ = infer_expr(db, infer_config, prefix_expr.into()).ok()?;
+    let typ = infer_expr(db, infer_config, prefix_expr).ok()?;
 
     // 这是为解决 require 后仍然是`Def`类型的问题, 但现在不需要了, 不过还是留着以防万一
     // if !in_def_file(db, &typ, file_id) {
@@ -173,7 +170,7 @@ fn check_def_visibility(
     match visibility {
         VisibilityKind::Protected => match (typ, member_owner) {
             (LuaType::Def(left), LuaMemberOwner::Type(right)) => {
-                Some(left == *right || is_sub_type_of(db, &left, &right))
+                Some(left == *right || is_sub_type_of(db, &left, right))
             }
             _ => Some(false),
         },
@@ -207,13 +204,13 @@ fn get_property<'a>(
     db: &'a DbIndex,
     property_owner: &'a LuaSemanticDeclId,
 ) -> Option<&'a LuaCommonProperty> {
-    match db.get_property_index().get_property(&property_owner) {
+    match db.get_property_index().get_property(property_owner) {
         Some(common_property) => Some(common_property),
         None => {
             let LuaSemanticDeclId::Member(member_id) = property_owner else {
                 return None;
             };
-            let member = db.get_member_index().get_member(&member_id)?;
+            let member = db.get_member_index().get_member(member_id)?;
             let signature_id = try_extract_signature_id_from_field(db, member)?;
             db.get_property_index()
                 .get_property(&LuaSemanticDeclId::Signature(signature_id))
@@ -229,9 +226,9 @@ fn check_member_name(
     token: LuaSyntaxToken,
     property_owner: LuaSemanticDeclId,
 ) -> Option<bool> {
-    if let LuaSemanticDeclId::Member(member_id) = property_owner {
-        if let Some(member) = db.get_member_index().get_member(&member_id) {
-            if let Some(name) = member.get_key().get_name() {
+    if let LuaSemanticDeclId::Member(member_id) = property_owner
+        && let Some(member) = db.get_member_index().get_member(&member_id)
+            && let Some(name) = member.get_key().get_name() {
                 let config = emmyrc;
                 for pattern in &config.doc.private_name {
                     let is_match = if let Some(prefix) = pattern.strip_suffix('*') {
@@ -255,8 +252,6 @@ fn check_member_name(
                         );
                     }
                 }
-            }
-        }
-    };
+            };
     Some(true)
 }

--- a/crates/emmylua_code_analysis/src/semantic/visibility/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/visibility/mod.rs
@@ -228,30 +228,31 @@ fn check_member_name(
 ) -> Option<bool> {
     if let LuaSemanticDeclId::Member(member_id) = property_owner
         && let Some(member) = db.get_member_index().get_member(&member_id)
-            && let Some(name) = member.get_key().get_name() {
-                let config = emmyrc;
-                for pattern in &config.doc.private_name {
-                    let is_match = if let Some(prefix) = pattern.strip_suffix('*') {
-                        name.starts_with(prefix)
-                    } else if let Some(suffix) = pattern.strip_prefix('*') {
-                        name.ends_with(suffix)
-                    } else {
-                        name == pattern
-                    };
-                    if is_match {
-                        return Some(
-                            check_visibility_by_visibility(
-                                db,
-                                infer_config,
-                                file_id,
-                                property_owner,
-                                token,
-                                VisibilityKind::Private,
-                            )
-                            .unwrap_or(false),
-                        );
-                    }
-                }
+        && let Some(name) = member.get_key().get_name()
+    {
+        let config = emmyrc;
+        for pattern in &config.doc.private_name {
+            let is_match = if let Some(prefix) = pattern.strip_suffix('*') {
+                name.starts_with(prefix)
+            } else if let Some(suffix) = pattern.strip_prefix('*') {
+                name.ends_with(suffix)
+            } else {
+                name == pattern
             };
+            if is_match {
+                return Some(
+                    check_visibility_by_visibility(
+                        db,
+                        infer_config,
+                        file_id,
+                        property_owner,
+                        token,
+                        VisibilityKind::Private,
+                    )
+                    .unwrap_or(false),
+                );
+            }
+        }
+    };
     Some(true)
 }

--- a/crates/emmylua_code_analysis/src/vfs/file_id.rs
+++ b/crates/emmylua_code_analysis/src/vfs/file_id.rs
@@ -2,7 +2,7 @@ use std::cmp;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-#[derive(Eq, PartialEq, Hash, Debug, Clone, Copy, PartialOrd)]
+#[derive(Eq, PartialEq, Hash, Debug, Clone, Copy)]
 pub struct FileId {
     pub id: u32,
 }
@@ -37,6 +37,12 @@ impl FileId {
 impl From<u32> for FileId {
     fn from(id: u32) -> Self {
         FileId { id }
+    }
+}
+
+impl cmp::PartialOrd for FileId {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
     }
 }
 

--- a/crates/emmylua_code_analysis/src/vfs/loader.rs
+++ b/crates/emmylua_code_analysis/src/vfs/loader.rs
@@ -23,9 +23,9 @@ impl LuaFileInfo {
 
 pub fn load_workspace_files(
     root: &Path,
-    include_pattern: &Vec<String>,
-    exclude_pattern: &Vec<String>,
-    exclude_dir: &Vec<PathBuf>,
+    include_pattern: &[String],
+    exclude_pattern: &[String],
+    exclude_dir: &[PathBuf],
     encoding: Option<&str>,
 ) -> Result<Vec<LuaFileInfo>, Box<dyn Error>> {
     let encoding = encoding.unwrap_or("utf-8");
@@ -67,13 +67,13 @@ pub fn load_workspace_files(
             continue;
         }
 
-        if include_set.is_match(relative_path) {
-            if let Some(content) = read_file_with_encoding(path, encoding) {
-                files.push(LuaFileInfo {
-                    path: path.to_string_lossy().to_string(),
-                    content,
-                });
-            }
+        if include_set.is_match(relative_path)
+            && let Some(content) = read_file_with_encoding(path, encoding)
+        {
+            files.push(LuaFileInfo {
+                path: path.to_string_lossy().to_string(),
+                content,
+            });
         }
     }
 

--- a/crates/emmylua_code_analysis/src/vfs/mod.rs
+++ b/crates/emmylua_code_analysis/src/vfs/mod.rs
@@ -29,6 +29,12 @@ pub struct Vfs {
     node_cache: NodeCache,
 }
 
+impl Default for Vfs {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Vfs {
     pub fn new() -> Self {
         Vfs {
@@ -70,7 +76,7 @@ impl Vfs {
 
     pub fn get_uri(&self, id: &FileId) -> Option<Uri> {
         let path = self.file_path_map.get(&id.id)?;
-        Some(file_path_to_uri(path)?)
+        file_path_to_uri(path)
     }
 
     pub fn get_file_path(&self, id: &FileId) -> Option<&PathBuf> {
@@ -82,13 +88,13 @@ impl Vfs {
         log::debug!("file_id: {:?}, uri: {}", fid, uri.as_str());
 
         if let Some(data) = &data {
-            let line_index = LineIndex::parse(&data);
+            let line_index = LineIndex::parse(data);
             let parse_config = self
                 .emmyrc
                 .as_ref()
                 .expect("emmyrc set")
                 .get_parse_config(&mut self.node_cache);
-            let tree = LuaParser::parse(&data, parse_config);
+            let tree = LuaParser::parse(data, parse_config);
             self.tree_map.insert(fid, tree);
             self.line_index_map.insert(fid, line_index);
         } else {
@@ -139,7 +145,7 @@ impl Vfs {
             return None;
         }
 
-        Some(errors.iter().map(|e| e.clone()).collect::<Vec<_>>())
+        Some(errors.to_vec())
     }
 
     pub fn get_all_file_ids(&self) -> Vec<FileId> {

--- a/crates/emmylua_code_analysis/src/vfs/virtual_url.rs
+++ b/crates/emmylua_code_analysis/src/vfs/virtual_url.rs
@@ -10,15 +10,21 @@ pub struct VirtualUrlGenerator {
 }
 
 #[allow(unused)]
+impl Default for VirtualUrlGenerator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl VirtualUrlGenerator {
     pub fn new() -> Self {
-        let env_path = std::env::current_dir().unwrap();
+        let env_path = std::env::current_dir().expect("Current dir should be set");
         VirtualUrlGenerator { base: env_path }
     }
 
     pub fn new_uri(&self, path: &str) -> Uri {
         let path = self.base.join(path);
-        file_path_to_uri(&path).unwrap()
+        file_path_to_uri(&path).expect("File should give a valid URI")
     }
 
     pub fn new_path(&self, path: &str) -> PathBuf {

--- a/crates/emmylua_code_style/src/format/mod.rs
+++ b/crates/emmylua_code_style/src/format/mod.rs
@@ -64,7 +64,7 @@ impl LuaFormatter {
                     (_, LuaTokenKind::TkEndOfLine) => {
                         // No space expected
                         context.reset_whitespace();
-                        context.text.push_str("\n");
+                        context.text.push('\n');
                         context.is_line_first_token = true;
                         continue;
                     }
@@ -97,10 +97,10 @@ impl LuaFormatter {
                         TokenNodeChange::Remove => continue,
                         TokenNodeChange::AddLeft(s) => {
                             context.text.push_str(s);
-                            context.text.push_str(&token.text());
+                            context.text.push_str(token.text());
                         }
                         TokenNodeChange::AddRight(s) => {
-                            context.text.push_str(&token.text());
+                            context.text.push_str(token.text());
                             context.text.push_str(s);
                         }
                         TokenNodeChange::ReplaceWith(s) => {
@@ -108,7 +108,7 @@ impl LuaFormatter {
                         }
                     }
                 } else {
-                    context.text.push_str(&token.text());
+                    context.text.push_str(token.text());
                 }
 
                 context.current_expected = self.token_right_expected.get(&syntax_id).cloned();

--- a/crates/emmylua_code_style/src/lib.rs
+++ b/crates/emmylua_code_style/src/lib.rs
@@ -11,13 +11,13 @@ pub fn reformat_lua_code(code: &str, styles: &LuaCodeStyle) -> String {
 
     let mut formatter = format::LuaFormatter::new(LuaAst::LuaChunk(tree.get_chunk_node()));
     style_ruler::apply_styles(&mut formatter, styles);
-    
+
     formatter.get_formatted_text()
 }
 
 pub fn reformat_node(node: &LuaAst, styles: &LuaCodeStyle) -> String {
     let mut formatter = format::LuaFormatter::new(node.clone());
     style_ruler::apply_styles(&mut formatter, styles);
-    
+
     formatter.get_formatted_text()
 }

--- a/crates/emmylua_code_style/src/lib.rs
+++ b/crates/emmylua_code_style/src/lib.rs
@@ -11,13 +11,13 @@ pub fn reformat_lua_code(code: &str, styles: &LuaCodeStyle) -> String {
 
     let mut formatter = format::LuaFormatter::new(LuaAst::LuaChunk(tree.get_chunk_node()));
     style_ruler::apply_styles(&mut formatter, styles);
-    let formatted_text = formatter.get_formatted_text();
-    formatted_text
+    
+    formatter.get_formatted_text()
 }
 
 pub fn reformat_node(node: &LuaAst, styles: &LuaCodeStyle) -> String {
     let mut formatter = format::LuaFormatter::new(node.clone());
     style_ruler::apply_styles(&mut formatter, styles);
-    let formatted_text = formatter.get_formatted_text();
-    formatted_text
+    
+    formatter.get_formatted_text()
 }

--- a/crates/emmylua_doc_cli/src/json_generator/export.rs
+++ b/crates/emmylua_doc_cli/src/json_generator/export.rs
@@ -104,7 +104,7 @@ fn export_globals(db: &DbIndex) -> Vec<Global> {
         .filter_map(|global| {
             let decl = db.get_decl_index().get_decl(&global)?;
             let typ = type_index.get_type_cache(&global.into())?.as_type();
-            let property = export_property(db, &LuaSemanticDeclId::LuaDecl(global.clone()));
+            let property = export_property(db, &LuaSemanticDeclId::LuaDecl(global));
             let loc = export_loc(vfs, decl.get_file_id(), decl.get_range());
             match typ {
                 LuaType::TableConst(table) => {
@@ -187,7 +187,7 @@ fn export_generics(db: &DbIndex, type_decl_id: &LuaTypeDeclId) -> Vec<TypeVar> {
     let type_index = db.get_type_index();
 
     type_index
-        .get_generic_params(&type_decl_id)
+        .get_generic_params(type_decl_id)
         .map(|v| v.as_slice())
         .unwrap_or_default()
         .iter()
@@ -234,7 +234,7 @@ fn export_members(db: &DbIndex, member_owner: LuaMemberOwner) -> Vec<Member> {
                 match typ {
                     LuaType::Signature(signature_id) => db
                         .get_signature_index()
-                        .get(&signature_id)
+                        .get(signature_id)
                         .map(|signature| {
                             Member::Fn(export_signature(db, signature, name, property, loc))
                         }),

--- a/crates/emmylua_doc_cli/src/json_generator/export.rs
+++ b/crates/emmylua_doc_cli/src/json_generator/export.rs
@@ -232,12 +232,11 @@ fn export_members(db: &DbIndex, member_owner: LuaMemberOwner) -> Vec<Member> {
                 let loc = export_loc(vfs, member.get_file_id(), member.get_range());
 
                 match typ {
-                    LuaType::Signature(signature_id) => db
-                        .get_signature_index()
-                        .get(signature_id)
-                        .map(|signature| {
+                    LuaType::Signature(signature_id) => {
+                        db.get_signature_index().get(signature_id).map(|signature| {
                             Member::Fn(export_signature(db, signature, name, property, loc))
-                        }),
+                        })
+                    }
                     _ => Some(Member::Field(export_field(db, typ, name, property, loc))),
                 }
             })

--- a/crates/emmylua_doc_cli/src/json_generator/mod.rs
+++ b/crates/emmylua_doc_cli/src/json_generator/mod.rs
@@ -12,12 +12,11 @@ pub fn generate_json(
 
     let output = match output {
         OutputDestination::File(output) if output.extension() == Some("json".as_ref()) => {
-            if let Some(parent) = output.parent() {
-                if !parent.exists() {
+            if let Some(parent) = output.parent()
+                && !parent.exists() {
                     log::info!("Creating output directory: {:?}", parent);
-                    std::fs::create_dir_all(&parent)?;
+                    std::fs::create_dir_all(parent)?;
                 }
-            }
 
             OutputDestination::File(output)
         }

--- a/crates/emmylua_doc_cli/src/json_generator/mod.rs
+++ b/crates/emmylua_doc_cli/src/json_generator/mod.rs
@@ -13,10 +13,11 @@ pub fn generate_json(
     let output = match output {
         OutputDestination::File(output) if output.extension() == Some("json".as_ref()) => {
             if let Some(parent) = output.parent()
-                && !parent.exists() {
-                    log::info!("Creating output directory: {:?}", parent);
-                    std::fs::create_dir_all(parent)?;
-                }
+                && !parent.exists()
+            {
+                log::info!("Creating output directory: {:?}", parent);
+                std::fs::create_dir_all(parent)?;
+            }
 
             OutputDestination::File(output)
         }

--- a/crates/emmylua_doc_cli/src/markdown_generator/generator/mod.rs
+++ b/crates/emmylua_doc_cli/src/markdown_generator/generator/mod.rs
@@ -36,14 +36,14 @@ fn collect_property(db: &DbIndex, semantic_decl: LuaSemanticDeclId) -> Property 
                     "see" => {
                         let see_content = doc_property.see.get_or_insert_with(String::new);
                         if !see_content.is_empty() {
-                            see_content.push_str("\n");
+                            see_content.push('\n');
                         }
                         see_content.push_str(content);
                     }
                     _ => {
                         let other_content = doc_property.other.get_or_insert_with(String::new);
                         if !other_content.is_empty() {
-                            other_content.push_str("\n");
+                            other_content.push('\n');
                         }
                         other_content.push_str(&format!("@{} {}", tag_name, content));
                     }

--- a/crates/emmylua_doc_cli/src/markdown_generator/generator/mod_gen.rs
+++ b/crates/emmylua_doc_cli/src/markdown_generator/generator/mod_gen.rs
@@ -108,9 +108,10 @@ pub fn generate_member_owner_module(
             let member_property_id = LuaSemanticDeclId::Member(member_id);
             let member_property = db.get_property_index().get_property(&member_property_id);
             if let Some(member_property) = member_property
-                && member_property.visibility != VisibilityKind::Public {
-                    continue;
-                }
+                && member_property.visibility != VisibilityKind::Public
+            {
+                continue;
+            }
 
             let member_property = collect_property(db, member_property_id);
             let member_key = member.get_key();

--- a/crates/emmylua_doc_cli/src/markdown_generator/generator/mod_gen.rs
+++ b/crates/emmylua_doc_cli/src/markdown_generator/generator/mod_gen.rs
@@ -107,11 +107,10 @@ pub fn generate_member_owner_module(
             let member_id = member.get_id();
             let member_property_id = LuaSemanticDeclId::Member(member_id);
             let member_property = db.get_property_index().get_property(&member_property_id);
-            if let Some(member_property) = member_property {
-                if member_property.visibility != VisibilityKind::Public {
+            if let Some(member_property) = member_property
+                && member_property.visibility != VisibilityKind::Public {
                     continue;
                 }
-            }
 
             let member_property = collect_property(db, member_property_id);
             let member_key = member.get_key();

--- a/crates/emmylua_doc_cli/src/markdown_generator/generator/typ_gen.rs
+++ b/crates/emmylua_doc_cli/src/markdown_generator/generator/typ_gen.rs
@@ -92,11 +92,10 @@ fn generate_class_type_markdown(
             let member_id = member.get_id();
             let member_property_id = LuaSemanticDeclId::Member(member_id);
             let member_property = db.get_property_index().get_property(&member_property_id);
-            if let Some(member_property) = member_property {
-                if member_property.visibility != VisibilityKind::Public {
+            if let Some(member_property) = member_property
+                && member_property.visibility != VisibilityKind::Public {
                     continue;
                 }
-            }
 
             let member_property = collect_property(db, member_property_id);
 
@@ -201,11 +200,10 @@ fn generate_enum_type_markdown(
             let member_id = member.get_id();
             let member_property_id = LuaSemanticDeclId::Member(member_id);
             let member_property = db.get_property_index().get_property(&member_property_id);
-            if let Some(member_property) = member_property {
-                if member_property.visibility != VisibilityKind::Public {
+            if let Some(member_property) = member_property
+                && member_property.visibility != VisibilityKind::Public {
                     continue;
                 }
-            }
 
             let member_property = collect_property(db, member_property_id);
 

--- a/crates/emmylua_doc_cli/src/markdown_generator/generator/typ_gen.rs
+++ b/crates/emmylua_doc_cli/src/markdown_generator/generator/typ_gen.rs
@@ -93,9 +93,10 @@ fn generate_class_type_markdown(
             let member_property_id = LuaSemanticDeclId::Member(member_id);
             let member_property = db.get_property_index().get_property(&member_property_id);
             if let Some(member_property) = member_property
-                && member_property.visibility != VisibilityKind::Public {
-                    continue;
-                }
+                && member_property.visibility != VisibilityKind::Public
+            {
+                continue;
+            }
 
             let member_property = collect_property(db, member_property_id);
 
@@ -201,9 +202,10 @@ fn generate_enum_type_markdown(
             let member_property_id = LuaSemanticDeclId::Member(member_id);
             let member_property = db.get_property_index().get_property(&member_property_id);
             if let Some(member_property) = member_property
-                && member_property.visibility != VisibilityKind::Public {
-                    continue;
-                }
+                && member_property.visibility != VisibilityKind::Public
+            {
+                continue;
+            }
 
             let member_property = collect_property(db, member_property_id);
 

--- a/crates/emmylua_parser/src/grammar/doc/mod.rs
+++ b/crates/emmylua_parser/src/grammar/doc/mod.rs
@@ -61,16 +61,15 @@ fn parse_docs(p: &mut LuaDocParser) {
             }
         }
 
-        if let Some(reader) = &p.lexer.reader {
-            if !reader.is_eof()
-                && !matches!(
-                    p.current_token(),
-                    LuaTokenKind::TkDocStart | LuaTokenKind::TkDocLongStart
-                )
-            {
-                p.bump_to_end();
-                continue;
-            }
+        if let Some(reader) = &p.lexer.reader
+            && !reader.is_eof()
+            && !matches!(
+                p.current_token(),
+                LuaTokenKind::TkDocStart | LuaTokenKind::TkDocLongStart
+            )
+        {
+            p.bump_to_end();
+            continue;
         }
 
         p.set_state(LuaDocLexerState::Init);
@@ -80,19 +79,13 @@ fn parse_docs(p: &mut LuaDocParser) {
 fn parse_description(p: &mut LuaDocParser) {
     let m = p.mark(LuaSyntaxKind::DocDescription);
 
-    loop {
-        match p.current_token() {
-            LuaTokenKind::TkDocDetail
-            | LuaTokenKind::TkEndOfLine
-            | LuaTokenKind::TkWhitespace
-            | LuaTokenKind::TkDocContinue
-            | LuaTokenKind::TkNormalStart => {
-                p.bump();
-            }
-            _ => {
-                break;
-            }
-        }
+    while let LuaTokenKind::TkDocDetail
+    | LuaTokenKind::TkEndOfLine
+    | LuaTokenKind::TkWhitespace
+    | LuaTokenKind::TkDocContinue
+    | LuaTokenKind::TkNormalStart = p.current_token()
+    {
+        p.bump();
     }
 
     m.complete(p);
@@ -126,19 +119,13 @@ fn if_token_bump(p: &mut LuaDocParser, token: LuaTokenKind) -> bool {
 fn parse_normal_description(p: &mut LuaDocParser) {
     let m = p.mark(LuaSyntaxKind::DocDescription);
 
-    loop {
-        match p.current_token() {
-            LuaTokenKind::TkDocDetail
-            | LuaTokenKind::TkEndOfLine
-            | LuaTokenKind::TkWhitespace
-            | LuaTokenKind::TkDocContinue
-            | LuaTokenKind::TkNormalStart => {
-                p.bump();
-            }
-            _ => {
-                break;
-            }
-        }
+    while let LuaTokenKind::TkDocDetail
+    | LuaTokenKind::TkEndOfLine
+    | LuaTokenKind::TkWhitespace
+    | LuaTokenKind::TkDocContinue
+    | LuaTokenKind::TkNormalStart = p.current_token()
+    {
+        p.bump();
     }
 
     m.complete(p);

--- a/crates/emmylua_parser/src/kind/lua_language_level.rs
+++ b/crates/emmylua_parser/src/kind/lua_language_level.rs
@@ -1,11 +1,13 @@
 use core::fmt;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum LuaLanguageLevel {
     Lua51,
     LuaJIT,
     Lua52,
     Lua53,
+    #[default]
     Lua54,
     Lua55,
 }
@@ -23,8 +25,3 @@ impl fmt::Display for LuaLanguageLevel {
     }
 }
 
-impl Default for LuaLanguageLevel {
-    fn default() -> Self {
-        LuaLanguageLevel::Lua54
-    }
-}

--- a/crates/emmylua_parser/src/kind/lua_language_level.rs
+++ b/crates/emmylua_parser/src/kind/lua_language_level.rs
@@ -1,7 +1,6 @@
 use core::fmt;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-#[derive(Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub enum LuaLanguageLevel {
     Lua51,
     LuaJIT,
@@ -24,4 +23,3 @@ impl fmt::Display for LuaLanguageLevel {
         }
     }
 }
-

--- a/crates/emmylua_parser/src/kind/lua_non_std_symbol.rs
+++ b/crates/emmylua_parser/src/kind/lua_non_std_symbol.rs
@@ -25,6 +25,12 @@ pub enum LuaNonStdSymbol {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LuaNonStdSymbolSet(u64);
 
+impl Default for LuaNonStdSymbolSet {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl LuaNonStdSymbolSet {
     pub fn new() -> Self {
         LuaNonStdSymbolSet(0)

--- a/crates/emmylua_parser/src/kind/lua_version.rs
+++ b/crates/emmylua_parser/src/kind/lua_version.rs
@@ -24,6 +24,7 @@ impl LuaVersionNumber {
         patch: 0,
     };
 
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Option<Self> {
         if s == "JIT" {
             return Some(Self::LUA_JIT);

--- a/crates/emmylua_parser/src/kind/mod.rs
+++ b/crates/emmylua_parser/src/kind/mod.rs
@@ -87,9 +87,9 @@ impl LuaKind {
 
     pub fn from_raw(raw: u16) -> LuaKind {
         if raw & 0x8000 != 0 {
-            LuaKind::Syntax(unsafe { std::mem::transmute(raw & 0x7FFF) })
+            LuaKind::Syntax(unsafe { std::mem::transmute::<u16, LuaSyntaxKind>(raw & 0x7FFF) })
         } else {
-            LuaKind::Token(unsafe { std::mem::transmute(raw) })
+            LuaKind::Token(unsafe { std::mem::transmute::<u16, LuaTokenKind>(raw) })
         }
     }
 }

--- a/crates/emmylua_parser/src/lexer/lua_lexer.rs
+++ b/crates/emmylua_parser/src/lexer/lua_lexer.rs
@@ -292,16 +292,16 @@ impl<'a> LuaLexer<'a> {
                     }
                     '=' if self.support_non_std_symbol(LuaNonStdSymbol::SlashAssign) => {
                         self.reader.bump();
-                        return LuaTokenKind::TkSlashAssign;
+                        LuaTokenKind::TkSlashAssign
                     }
                     _ if current_char != '/' => {
-                        return LuaTokenKind::TkDiv;
+                        LuaTokenKind::TkDiv
                     }
                     _ if self.support_non_std_symbol(LuaNonStdSymbol::DoubleSlash) => {
                         // "//" is a short comment
                         self.reader.bump();
                         self.reader.eat_while(|ch| ch != '\n' && ch != '\r');
-                        return LuaTokenKind::TkShortComment;
+                        LuaTokenKind::TkShortComment
                     }
                     _ => {
                         if !self.lexer_config.support_integer_operation() {

--- a/crates/emmylua_parser/src/lexer/lua_lexer.rs
+++ b/crates/emmylua_parser/src/lexer/lua_lexer.rs
@@ -294,9 +294,7 @@ impl<'a> LuaLexer<'a> {
                         self.reader.bump();
                         LuaTokenKind::TkSlashAssign
                     }
-                    _ if current_char != '/' => {
-                        LuaTokenKind::TkDiv
-                    }
+                    _ if current_char != '/' => LuaTokenKind::TkDiv,
                     _ if self.support_non_std_symbol(LuaNonStdSymbol::DoubleSlash) => {
                         // "//" is a short comment
                         self.reader.bump();

--- a/crates/emmylua_parser/src/parser/lua_doc_parser.rs
+++ b/crates/emmylua_parser/src/parser/lua_doc_parser.rs
@@ -281,8 +281,5 @@ impl<'b> LuaDocParser<'_, 'b> {
 }
 
 fn is_invalid_kind(kind: LuaTokenKind) -> bool {
-    match kind {
-        LuaTokenKind::None | LuaTokenKind::TkEof => true,
-        _ => false,
-    }
+    matches!(kind, LuaTokenKind::None | LuaTokenKind::TkEof)
 }

--- a/crates/emmylua_parser/src/parser/lua_parser.rs
+++ b/crates/emmylua_parser/src/parser/lua_parser.rs
@@ -278,7 +278,7 @@ impl<'a> LuaParser<'a> {
         }
     }
 
-    fn parse_comments(&mut self, comment_tokens: &Vec<LuaTokenData>) {
+    fn parse_comments(&mut self, comment_tokens: &[LuaTokenData]) {
         let mut trivia_token_start = comment_tokens.len();
         // Reverse iterate over comment_tokens, removing whitespace and end-of-line tokens
         for i in (0..comment_tokens.len()).rev() {
@@ -295,8 +295,7 @@ impl<'a> LuaParser<'a> {
         let tokens = &comment_tokens[..trivia_token_start];
         LuaDocParser::parse(self, tokens);
 
-        for i in trivia_token_start..comment_tokens.len() {
-            let token = &comment_tokens[i];
+        for token in comment_tokens.iter().skip(trivia_token_start) {
             self.events.push(MarkEvent::EatToken {
                 kind: token.kind,
                 range: token.range,

--- a/crates/emmylua_parser/src/syntax/node/doc/types.rs
+++ b/crates/emmylua_parser/src/syntax/node/doc/types.rs
@@ -48,23 +48,23 @@ impl LuaAstNode for LuaDocType {
     where
         Self: Sized,
     {
-        match kind {
-            LuaSyntaxKind::TypeName => true,
-            LuaSyntaxKind::TypeArray => true,
-            LuaSyntaxKind::TypeFun => true,
-            LuaSyntaxKind::TypeObject => true,
-            LuaSyntaxKind::TypeBinary => true,
-            LuaSyntaxKind::TypeUnary => true,
-            LuaSyntaxKind::TypeConditional => true,
-            LuaSyntaxKind::TypeTuple => true,
-            LuaSyntaxKind::TypeLiteral => true,
-            LuaSyntaxKind::TypeVariadic => true,
-            LuaSyntaxKind::TypeNullable => true,
-            LuaSyntaxKind::TypeGeneric => true,
-            LuaSyntaxKind::TypeStringTemplate => true,
-            LuaSyntaxKind::TypeMultiLineUnion => true,
-            _ => false,
-        }
+        matches!(
+            kind,
+            LuaSyntaxKind::TypeName
+                | LuaSyntaxKind::TypeArray
+                | LuaSyntaxKind::TypeFun
+                | LuaSyntaxKind::TypeObject
+                | LuaSyntaxKind::TypeBinary
+                | LuaSyntaxKind::TypeUnary
+                | LuaSyntaxKind::TypeConditional
+                | LuaSyntaxKind::TypeTuple
+                | LuaSyntaxKind::TypeLiteral
+                | LuaSyntaxKind::TypeVariadic
+                | LuaSyntaxKind::TypeNullable
+                | LuaSyntaxKind::TypeGeneric
+                | LuaSyntaxKind::TypeStringTemplate
+                | LuaSyntaxKind::TypeMultiLineUnion
+        )
     }
 
     fn cast(syntax: LuaSyntaxNode) -> Option<Self>

--- a/crates/emmylua_parser/src/syntax/node/lua/stat.rs
+++ b/crates/emmylua_parser/src/syntax/node/lua/stat.rs
@@ -61,26 +61,26 @@ impl LuaAstNode for LuaStat {
     where
         Self: Sized,
     {
-        match kind {
-            LuaSyntaxKind::LocalStat => true,
-            LuaSyntaxKind::AssignStat => true,
-            LuaSyntaxKind::CallExprStat => true,
-            LuaSyntaxKind::FuncStat => true,
-            LuaSyntaxKind::LocalFuncStat => true,
-            LuaSyntaxKind::IfStat => true,
-            LuaSyntaxKind::WhileStat => true,
-            LuaSyntaxKind::DoStat => true,
-            LuaSyntaxKind::ForStat => true,
-            LuaSyntaxKind::ForRangeStat => true,
-            LuaSyntaxKind::RepeatStat => true,
-            LuaSyntaxKind::BreakStat => true,
-            LuaSyntaxKind::ReturnStat => true,
-            LuaSyntaxKind::GotoStat => true,
-            LuaSyntaxKind::LabelStat => true,
-            LuaSyntaxKind::EmptyStat => true,
-            LuaSyntaxKind::GlobalStat => true,
-            _ => false,
-        }
+        matches!(
+            kind,
+            LuaSyntaxKind::LocalStat
+                | LuaSyntaxKind::AssignStat
+                | LuaSyntaxKind::CallExprStat
+                | LuaSyntaxKind::FuncStat
+                | LuaSyntaxKind::LocalFuncStat
+                | LuaSyntaxKind::IfStat
+                | LuaSyntaxKind::WhileStat
+                | LuaSyntaxKind::DoStat
+                | LuaSyntaxKind::ForStat
+                | LuaSyntaxKind::ForRangeStat
+                | LuaSyntaxKind::RepeatStat
+                | LuaSyntaxKind::BreakStat
+                | LuaSyntaxKind::ReturnStat
+                | LuaSyntaxKind::GotoStat
+                | LuaSyntaxKind::LabelStat
+                | LuaSyntaxKind::EmptyStat
+                | LuaSyntaxKind::GlobalStat
+        )
     }
 
     fn cast(syntax: LuaSyntaxNode) -> Option<Self>
@@ -146,13 +146,13 @@ impl LuaAstNode for LuaLoopStat {
     where
         Self: Sized,
     {
-        match kind {
-            LuaSyntaxKind::WhileStat => true,
-            LuaSyntaxKind::RepeatStat => true,
-            LuaSyntaxKind::ForStat => true,
-            LuaSyntaxKind::ForRangeStat => true,
-            _ => false,
-        }
+        matches!(
+            kind,
+            LuaSyntaxKind::WhileStat
+                | LuaSyntaxKind::RepeatStat
+                | LuaSyntaxKind::ForStat
+                | LuaSyntaxKind::ForRangeStat
+        )
     }
 
     fn cast(syntax: LuaSyntaxNode) -> Option<Self>
@@ -224,10 +224,10 @@ impl LuaLocalStat {
         let value_exprs = self.get_value_exprs().collect::<Vec<_>>();
 
         for (i, local_name) in local_names.enumerate() {
-            if let Some(value_expr) = value_exprs.get(i) {
-                if value_expr.syntax() == value.syntax() {
-                    return Some(local_name);
-                }
+            if let Some(value_expr) = value_exprs.get(i)
+                && value_expr.syntax() == value.syntax()
+            {
+                return Some(local_name);
             }
         }
         None
@@ -295,10 +295,10 @@ impl LuaAssignStat {
 
     pub fn get_assign_op(&self) -> Option<LuaGeneralToken> {
         for child in self.syntax.children_with_tokens() {
-            if let Some(token) = child.into_token() {
-                if token.kind().to_token().is_assign_op() {
-                    return LuaGeneralToken::cast(token);
-                }
+            if let Some(token) = child.into_token()
+                && token.kind().to_token().is_assign_op()
+            {
+                return LuaGeneralToken::cast(token);
             }
         }
         None

--- a/crates/emmylua_parser/src/syntax/node/mod.rs
+++ b/crates/emmylua_parser/src/syntax/node/mod.rs
@@ -199,94 +199,95 @@ impl LuaAstNode for LuaAst {
     where
         Self: Sized,
     {
-        match kind {
-            LuaSyntaxKind::Chunk => true,
-            LuaSyntaxKind::Block => true,
-            LuaSyntaxKind::AssignStat => true,
-            LuaSyntaxKind::LocalStat => true,
-            LuaSyntaxKind::CallExprStat => true,
-            LuaSyntaxKind::LabelStat => true,
-            LuaSyntaxKind::BreakStat => true,
-            LuaSyntaxKind::GotoStat => true,
-            LuaSyntaxKind::DoStat => true,
-            LuaSyntaxKind::WhileStat => true,
-            LuaSyntaxKind::RepeatStat => true,
-            LuaSyntaxKind::IfStat => true,
-            LuaSyntaxKind::ForStat => true,
-            LuaSyntaxKind::ForRangeStat => true,
-            LuaSyntaxKind::FuncStat => true,
-            LuaSyntaxKind::LocalFuncStat => true,
-            LuaSyntaxKind::ReturnStat => true,
-            LuaSyntaxKind::GlobalStat => true,
-            LuaSyntaxKind::NameExpr => true,
-            LuaSyntaxKind::IndexExpr => true,
-            LuaSyntaxKind::TableEmptyExpr
-            | LuaSyntaxKind::TableArrayExpr
-            | LuaSyntaxKind::TableObjectExpr => true,
-            LuaSyntaxKind::BinaryExpr => true,
-            LuaSyntaxKind::UnaryExpr => true,
-            LuaSyntaxKind::ParenExpr => true,
-            LuaSyntaxKind::CallExpr
-            | LuaSyntaxKind::AssertCallExpr
-            | LuaSyntaxKind::ErrorCallExpr
-            | LuaSyntaxKind::RequireCallExpr
-            | LuaSyntaxKind::TypeCallExpr
-            | LuaSyntaxKind::SetmetatableCallExpr => true,
-            LuaSyntaxKind::LiteralExpr => true,
-            LuaSyntaxKind::ClosureExpr => true,
-            LuaSyntaxKind::ParamList => true,
-            LuaSyntaxKind::CallArgList => true,
-            LuaSyntaxKind::LocalName => true,
-            LuaSyntaxKind::TableFieldAssign | LuaSyntaxKind::TableFieldValue => true,
-            LuaSyntaxKind::ParamName => true,
-            LuaSyntaxKind::Attribute => true,
-            LuaSyntaxKind::ElseIfClauseStat => true,
-            LuaSyntaxKind::ElseClauseStat => true,
-            LuaSyntaxKind::Comment => true,
-            LuaSyntaxKind::DocTagClass => true,
-            LuaSyntaxKind::DocTagEnum => true,
-            LuaSyntaxKind::DocTagAlias => true,
-            LuaSyntaxKind::DocTagType => true,
-            LuaSyntaxKind::DocTagParam => true,
-            LuaSyntaxKind::DocTagReturn => true,
-            LuaSyntaxKind::DocTagOverload => true,
-            LuaSyntaxKind::DocTagField => true,
-            LuaSyntaxKind::DocTagModule => true,
-            LuaSyntaxKind::DocTagSee => true,
-            LuaSyntaxKind::DocTagDiagnostic => true,
-            LuaSyntaxKind::DocTagDeprecated => true,
-            LuaSyntaxKind::DocTagVersion => true,
-            LuaSyntaxKind::DocTagCast => true,
-            LuaSyntaxKind::DocTagSource => true,
-            LuaSyntaxKind::DocTagOther => true,
-            LuaSyntaxKind::DocTagNamespace => true,
-            LuaSyntaxKind::DocTagUsing => true,
-            LuaSyntaxKind::DocTagMeta => true,
-            LuaSyntaxKind::DocTagNodiscard => true,
-            LuaSyntaxKind::DocTagReadonly => true,
-            LuaSyntaxKind::DocTagOperator => true,
-            LuaSyntaxKind::DocTagGeneric => true,
-            LuaSyntaxKind::DocTagAsync => true,
-            LuaSyntaxKind::DocTagAs => true,
-            LuaSyntaxKind::DocTagReturnCast => true,
-            LuaSyntaxKind::DocTagExport => true,
-            LuaSyntaxKind::DocTagLanguage => true,
-            LuaSyntaxKind::TypeName => true,
-            LuaSyntaxKind::TypeArray => true,
-            LuaSyntaxKind::TypeFun => true,
-            LuaSyntaxKind::TypeObject => true,
-            LuaSyntaxKind::TypeBinary => true,
-            LuaSyntaxKind::TypeUnary => true,
-            LuaSyntaxKind::TypeConditional => true,
-            LuaSyntaxKind::TypeTuple => true,
-            LuaSyntaxKind::TypeLiteral => true,
-            LuaSyntaxKind::TypeVariadic => true,
-            LuaSyntaxKind::TypeNullable => true,
-            LuaSyntaxKind::TypeGeneric => true,
-            LuaSyntaxKind::TypeStringTemplate => true,
-            LuaSyntaxKind::TypeMultiLineUnion => true,
-            _ => false,
-        }
+        matches!(
+            kind,
+            LuaSyntaxKind::Chunk
+                | LuaSyntaxKind::Block
+                | LuaSyntaxKind::AssignStat
+                | LuaSyntaxKind::LocalStat
+                | LuaSyntaxKind::CallExprStat
+                | LuaSyntaxKind::LabelStat
+                | LuaSyntaxKind::BreakStat
+                | LuaSyntaxKind::GotoStat
+                | LuaSyntaxKind::DoStat
+                | LuaSyntaxKind::WhileStat
+                | LuaSyntaxKind::RepeatStat
+                | LuaSyntaxKind::IfStat
+                | LuaSyntaxKind::ForStat
+                | LuaSyntaxKind::ForRangeStat
+                | LuaSyntaxKind::FuncStat
+                | LuaSyntaxKind::LocalFuncStat
+                | LuaSyntaxKind::ReturnStat
+                | LuaSyntaxKind::GlobalStat
+                | LuaSyntaxKind::NameExpr
+                | LuaSyntaxKind::IndexExpr
+                | LuaSyntaxKind::TableEmptyExpr
+                | LuaSyntaxKind::TableArrayExpr
+                | LuaSyntaxKind::TableObjectExpr
+                | LuaSyntaxKind::BinaryExpr
+                | LuaSyntaxKind::UnaryExpr
+                | LuaSyntaxKind::ParenExpr
+                | LuaSyntaxKind::CallExpr
+                | LuaSyntaxKind::AssertCallExpr
+                | LuaSyntaxKind::ErrorCallExpr
+                | LuaSyntaxKind::RequireCallExpr
+                | LuaSyntaxKind::TypeCallExpr
+                | LuaSyntaxKind::SetmetatableCallExpr
+                | LuaSyntaxKind::LiteralExpr
+                | LuaSyntaxKind::ClosureExpr
+                | LuaSyntaxKind::ParamList
+                | LuaSyntaxKind::CallArgList
+                | LuaSyntaxKind::LocalName
+                | LuaSyntaxKind::TableFieldAssign
+                | LuaSyntaxKind::TableFieldValue
+                | LuaSyntaxKind::ParamName
+                | LuaSyntaxKind::Attribute
+                | LuaSyntaxKind::ElseIfClauseStat
+                | LuaSyntaxKind::ElseClauseStat
+                | LuaSyntaxKind::Comment
+                | LuaSyntaxKind::DocTagClass
+                | LuaSyntaxKind::DocTagEnum
+                | LuaSyntaxKind::DocTagAlias
+                | LuaSyntaxKind::DocTagType
+                | LuaSyntaxKind::DocTagParam
+                | LuaSyntaxKind::DocTagReturn
+                | LuaSyntaxKind::DocTagOverload
+                | LuaSyntaxKind::DocTagField
+                | LuaSyntaxKind::DocTagModule
+                | LuaSyntaxKind::DocTagSee
+                | LuaSyntaxKind::DocTagDiagnostic
+                | LuaSyntaxKind::DocTagDeprecated
+                | LuaSyntaxKind::DocTagVersion
+                | LuaSyntaxKind::DocTagCast
+                | LuaSyntaxKind::DocTagSource
+                | LuaSyntaxKind::DocTagOther
+                | LuaSyntaxKind::DocTagNamespace
+                | LuaSyntaxKind::DocTagUsing
+                | LuaSyntaxKind::DocTagMeta
+                | LuaSyntaxKind::DocTagNodiscard
+                | LuaSyntaxKind::DocTagReadonly
+                | LuaSyntaxKind::DocTagOperator
+                | LuaSyntaxKind::DocTagGeneric
+                | LuaSyntaxKind::DocTagAsync
+                | LuaSyntaxKind::DocTagAs
+                | LuaSyntaxKind::DocTagReturnCast
+                | LuaSyntaxKind::DocTagExport
+                | LuaSyntaxKind::DocTagLanguage
+                | LuaSyntaxKind::TypeName
+                | LuaSyntaxKind::TypeArray
+                | LuaSyntaxKind::TypeFun
+                | LuaSyntaxKind::TypeObject
+                | LuaSyntaxKind::TypeBinary
+                | LuaSyntaxKind::TypeUnary
+                | LuaSyntaxKind::TypeConditional
+                | LuaSyntaxKind::TypeTuple
+                | LuaSyntaxKind::TypeLiteral
+                | LuaSyntaxKind::TypeVariadic
+                | LuaSyntaxKind::TypeNullable
+                | LuaSyntaxKind::TypeGeneric
+                | LuaSyntaxKind::TypeStringTemplate
+                | LuaSyntaxKind::TypeMultiLineUnion
+        )
     }
 
     fn cast(syntax: LuaSyntaxNode) -> Option<Self>

--- a/crates/emmylua_parser/src/syntax/node/token/number_analyzer.rs
+++ b/crates/emmylua_parser/src/syntax/node/token/number_analyzer.rs
@@ -42,11 +42,10 @@ pub fn float_token_value(token: &LuaSyntaxToken) -> Result<f64, LuaParseError> {
         };
 
         let mut value = integer_part as f64 + fraction_value;
-        if !exponent_part.is_empty() {
-            if let Ok(exp) = exponent_part.parse::<i32>() {
+        if !exponent_part.is_empty()
+            && let Ok(exp) = exponent_part.parse::<i32>() {
                 value *= 2f64.powi(exp);
             }
-        }
         value
     } else {
         let (float_part, exponent_part) =
@@ -68,11 +67,10 @@ pub fn float_token_value(token: &LuaSyntaxToken) -> Result<f64, LuaParseError> {
             )
         })?;
 
-        if !exponent_part.is_empty() {
-            if let Ok(exp) = exponent_part.parse::<i32>() {
+        if !exponent_part.is_empty()
+            && let Ok(exp) = exponent_part.parse::<i32>() {
                 value *= 10f64.powi(exp);
             }
-        }
         value
     };
 

--- a/crates/emmylua_parser/src/syntax/node/token/number_analyzer.rs
+++ b/crates/emmylua_parser/src/syntax/node/token/number_analyzer.rs
@@ -43,9 +43,10 @@ pub fn float_token_value(token: &LuaSyntaxToken) -> Result<f64, LuaParseError> {
 
         let mut value = integer_part as f64 + fraction_value;
         if !exponent_part.is_empty()
-            && let Ok(exp) = exponent_part.parse::<i32>() {
-                value *= 2f64.powi(exp);
-            }
+            && let Ok(exp) = exponent_part.parse::<i32>()
+        {
+            value *= 2f64.powi(exp);
+        }
         value
     } else {
         let (float_part, exponent_part) =
@@ -68,9 +69,10 @@ pub fn float_token_value(token: &LuaSyntaxToken) -> Result<f64, LuaParseError> {
         })?;
 
         if !exponent_part.is_empty()
-            && let Ok(exp) = exponent_part.parse::<i32>() {
-                value *= 10f64.powi(exp);
-            }
+            && let Ok(exp) = exponent_part.parse::<i32>()
+        {
+            value *= 10f64.powi(exp);
+        }
         value
     };
 

--- a/crates/emmylua_parser/src/syntax/node/token/string_analyzer.rs
+++ b/crates/emmylua_parser/src/syntax/node/token/string_analyzer.rs
@@ -167,7 +167,7 @@ fn normal_string_value(token: &LuaSyntaxToken) -> Result<String, LuaParseError> 
                                     chars.next();
                                 }
                             }
-                            if let Ok(value) = u8::from_str_radix(&dec, 10) {
+                            if let Ok(value) = dec.parse::<u8>() {
                                 result.push(value as char);
                             }
                         }

--- a/crates/emmylua_parser/src/syntax/node/token/tokens.rs
+++ b/crates/emmylua_parser/src/syntax/node/token/tokens.rs
@@ -242,31 +242,31 @@ impl LuaAstToken for LuaKeywordToken {
     where
         Self: Sized,
     {
-        match kind {
+        matches!(
+            kind,
             LuaTokenKind::TkAnd
-            | LuaTokenKind::TkBreak
-            | LuaTokenKind::TkDo
-            | LuaTokenKind::TkElse
-            | LuaTokenKind::TkElseIf
-            | LuaTokenKind::TkEnd
-            | LuaTokenKind::TkFalse
-            | LuaTokenKind::TkFor
-            | LuaTokenKind::TkFunction
-            | LuaTokenKind::TkGoto
-            | LuaTokenKind::TkIf
-            | LuaTokenKind::TkIn
-            | LuaTokenKind::TkLocal
-            | LuaTokenKind::TkNil
-            | LuaTokenKind::TkNot
-            | LuaTokenKind::TkOr
-            | LuaTokenKind::TkRepeat
-            | LuaTokenKind::TkReturn
-            | LuaTokenKind::TkThen
-            | LuaTokenKind::TkTrue
-            | LuaTokenKind::TkUntil
-            | LuaTokenKind::TkWhile => true,
-            _ => false,
-        }
+                | LuaTokenKind::TkBreak
+                | LuaTokenKind::TkDo
+                | LuaTokenKind::TkElse
+                | LuaTokenKind::TkElseIf
+                | LuaTokenKind::TkEnd
+                | LuaTokenKind::TkFalse
+                | LuaTokenKind::TkFor
+                | LuaTokenKind::TkFunction
+                | LuaTokenKind::TkGoto
+                | LuaTokenKind::TkIf
+                | LuaTokenKind::TkIn
+                | LuaTokenKind::TkLocal
+                | LuaTokenKind::TkNil
+                | LuaTokenKind::TkNot
+                | LuaTokenKind::TkOr
+                | LuaTokenKind::TkRepeat
+                | LuaTokenKind::TkReturn
+                | LuaTokenKind::TkThen
+                | LuaTokenKind::TkTrue
+                | LuaTokenKind::TkUntil
+                | LuaTokenKind::TkWhile
+        )
     }
 
     fn cast(syntax: LuaSyntaxToken) -> Option<Self>
@@ -377,19 +377,19 @@ impl LuaAstToken for LuaLiteralToken {
     where
         Self: Sized,
     {
-        match kind {
+        matches!(
+            kind,
             LuaTokenKind::TkInt
-            | LuaTokenKind::TkFloat
-            | LuaTokenKind::TkComplex
-            | LuaTokenKind::TkNil
-            | LuaTokenKind::TkTrue
-            | LuaTokenKind::TkFalse
-            | LuaTokenKind::TkDots
-            | LuaTokenKind::TkString
-            | LuaTokenKind::TkLongString
-            | LuaTokenKind::TkDocQuestion => true,
-            _ => false,
-        }
+                | LuaTokenKind::TkFloat
+                | LuaTokenKind::TkComplex
+                | LuaTokenKind::TkNil
+                | LuaTokenKind::TkTrue
+                | LuaTokenKind::TkFalse
+                | LuaTokenKind::TkDots
+                | LuaTokenKind::TkString
+                | LuaTokenKind::TkLongString
+                | LuaTokenKind::TkDocQuestion
+        )
     }
 
     fn cast(syntax: LuaSyntaxToken) -> Option<Self>
@@ -430,10 +430,7 @@ impl LuaAstToken for LuaSpaceToken {
     where
         Self: Sized,
     {
-        match kind {
-            LuaTokenKind::TkWhitespace | LuaTokenKind::TkEndOfLine => true,
-            _ => false,
-        }
+        matches!(kind, LuaTokenKind::TkWhitespace | LuaTokenKind::TkEndOfLine)
     }
 
     fn cast(syntax: LuaSyntaxToken) -> Option<Self>

--- a/crates/emmylua_parser/src/syntax/traits/mod.rs
+++ b/crates/emmylua_parser/src/syntax/traits/mod.rs
@@ -109,7 +109,7 @@ pub trait LuaAstNode {
     where
         Self: Sized,
     {
-        LuaAstPtr::new(&self)
+        LuaAstPtr::new(self)
     }
 }
 

--- a/crates/emmylua_parser/src/syntax/tree/lua_green_builder.rs
+++ b/crates/emmylua_parser/src/syntax/tree/lua_green_builder.rs
@@ -147,24 +147,20 @@ impl LuaGreenNodeBuilder<'_> {
     }
 
     fn is_trivia(&self, pos: usize) -> bool {
-        if let Some(element) = self.elements.get(pos) {
-            match element {
+        self.elements.get(pos).is_some_and(|element| {
+            matches!(
+                element,
                 LuaGreenElement::Token {
-                    kind:
-                        LuaTokenKind::TkWhitespace
+                    kind: LuaTokenKind::TkWhitespace
                         | LuaTokenKind::TkEndOfLine
                         | LuaTokenKind::TkDocContinue,
                     ..
-                } => true,
-                LuaGreenElement::Node {
+                } | LuaGreenElement::Node {
                     kind: LuaSyntaxKind::Comment | LuaSyntaxKind::DocDescription,
                     ..
-                } => true,
-                _ => false,
-            }
-        } else {
-            false
-        }
+                }
+            )
+        })
     }
 
     pub fn is_trivia_whitespace(&self, pos: usize) -> bool {

--- a/crates/emmylua_parser_desc/src/lang/lua.rs
+++ b/crates/emmylua_parser_desc/src/lang/lua.rs
@@ -102,9 +102,10 @@ fn to_highlight_kind(
                 && matches!(
                     prev_token.kind,
                     LuaTokenKind::TkDot | LuaTokenKind::TkDbColon
-                ) {
-                    return CodeBlockHighlightKind::Property;
-                }
+                )
+            {
+                return CodeBlockHighlightKind::Property;
+            }
 
             CodeBlockHighlightKind::Variable
         }

--- a/crates/emmylua_parser_desc/src/lang/lua.rs
+++ b/crates/emmylua_parser_desc/src/lang/lua.rs
@@ -98,14 +98,13 @@ fn to_highlight_kind(
                 }
             }
 
-            if let Some(prev_token) = tokens.get(i.wrapping_sub(1)) {
-                if matches!(
+            if let Some(prev_token) = tokens.get(i.wrapping_sub(1))
+                && matches!(
                     prev_token.kind,
                     LuaTokenKind::TkDot | LuaTokenKind::TkDbColon
                 ) {
                     return CodeBlockHighlightKind::Property;
                 }
-            }
 
             CodeBlockHighlightKind::Variable
         }

--- a/crates/emmylua_parser_desc/src/lang/mod.rs
+++ b/crates/emmylua_parser_desc/src/lang/mod.rs
@@ -60,7 +60,7 @@ pub fn process_code<'a, C: ResultContainer>(
         CodeBlockLang::Protobuf => process_protobuf_code_block(c, reader, state),
         _ => {
             c.emit_range(range, DescItemKind::CodeBlock);
-            return state;
+            state
         }
     }
 }

--- a/crates/emmylua_parser_desc/src/lib.rs
+++ b/crates/emmylua_parser_desc/src/lib.rs
@@ -75,7 +75,9 @@ pub struct DescItem {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Default)]
 pub enum DescParserType {
+    #[default]
     None,
     Md,
     MySt {
@@ -87,11 +89,6 @@ pub enum DescParserType {
     },
 }
 
-impl Default for DescParserType {
-    fn default() -> Self {
-        DescParserType::None
-    }
-}
 
 /// Parses markup in comments.
 pub trait LuaDescParser {

--- a/crates/emmylua_parser_desc/src/lib.rs
+++ b/crates/emmylua_parser_desc/src/lib.rs
@@ -74,8 +74,7 @@ pub struct DescItem {
     pub kind: DescItemKind,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-#[derive(Default)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Default)]
 pub enum DescParserType {
     #[default]
     None,
@@ -88,7 +87,6 @@ pub enum DescParserType {
         default_role: Option<String>,
     },
 }
-
 
 /// Parses markup in comments.
 pub trait LuaDescParser {

--- a/crates/emmylua_parser_desc/src/markdown/mod.rs
+++ b/crates/emmylua_parser_desc/src/markdown/mod.rs
@@ -946,7 +946,7 @@ impl MarkdownParser {
             bt.rollback(self, reader);
             return Err(());
         }
-        if !is_blank(&reader.tail_text()) {
+        if !is_blank(reader.tail_text()) {
             bt.rollback(self, reader);
             return Err(());
         }
@@ -977,7 +977,7 @@ impl MarkdownParser {
             reader.reset_buff();
             reader.bump();
             reader.bump();
-            if !is_blank(&reader.tail_text()) {
+            if !is_blank(reader.tail_text()) {
                 bt.rollback(self, reader);
                 return Err(());
             }

--- a/crates/emmylua_parser_desc/src/markdown_rst/mod.rs
+++ b/crates/emmylua_parser_desc/src/markdown_rst/mod.rs
@@ -347,8 +347,8 @@ impl MarkdownRstParser {
             return Err(());
         }
 
-        if let Some(next_line) = next_line {
-            if !(is_ws(next_line.current_char())
+        if let Some(next_line) = next_line
+            && !(is_ws(next_line.current_char())
                 || next_line.is_eof()
                 || Self::is_list_start(
                     next_line.tail_text(),
@@ -359,7 +359,6 @@ impl MarkdownRstParser {
                 bt.rollback(self, line);
                 return Err(());
             }
-        }
 
         self.emit(line, DescItemKind::Markup);
         indent += line.eat_while(is_ws);
@@ -1307,12 +1306,11 @@ impl MarkdownRstParser {
             }
         }
 
-        if let Some(cursor_position) = cursor_position {
-            if reader.current_range().contains_inclusive(cursor_position) {
+        if let Some(cursor_position) = cursor_position
+            && reader.current_range().contains_inclusive(cursor_position) {
                 process_lua_ref(self, reader.reset_buff_into_sub_reader());
                 return true;
             }
-        }
 
         false
     }

--- a/crates/emmylua_parser_desc/src/markdown_rst/mod.rs
+++ b/crates/emmylua_parser_desc/src/markdown_rst/mod.rs
@@ -355,10 +355,10 @@ impl MarkdownRstParser {
                     list_enumerator_kind,
                     list_marker_kind,
                 ))
-            {
-                bt.rollback(self, line);
-                return Err(());
-            }
+        {
+            bt.rollback(self, line);
+            return Err(());
+        }
 
         self.emit(line, DescItemKind::Markup);
         indent += line.eat_while(is_ws);
@@ -1307,10 +1307,11 @@ impl MarkdownRstParser {
         }
 
         if let Some(cursor_position) = cursor_position
-            && reader.current_range().contains_inclusive(cursor_position) {
-                process_lua_ref(self, reader.reset_buff_into_sub_reader());
-                return true;
-            }
+            && reader.current_range().contains_inclusive(cursor_position)
+        {
+            process_lua_ref(self, reader.reset_buff_into_sub_reader());
+            return true;
+        }
 
         false
     }


### PR DESCRIPTION
This cleans the whole crate, and also some parts in other crates where the code is used. Most were applied with `cargo clippy --fix`, but many had to be resolved manually.

This is one step closer to hopefully having `cargo clippy` run in CI, to help with correctness.