### PR TITLE
fix(config): Refactor path handling and add normalization function

### DIFF
--- a/crates/emmylua_code_analysis/src/config/mod.rs
+++ b/crates/emmylua_code_analysis/src/config/mod.rs
@@ -227,15 +227,15 @@ fn normalize_path(path: &Path) -> PathBuf {
                 // skip
             }
             Component::ParentDir => {
-                if let Some(_last) = out.pop() {
-                    // popped a normal component
-                } else {
-                    // nothing to pop:
-                    // - if path is absolute (has_root or prefix), ignore leading ".." (can't go above root)
-                    // - if relative, keep ".."
-                    if !has_root && prefix.is_none() {
-                        out.push(OsString::from(".."));
+                if let Some(last) = out.last() {
+                    if last != std::ffi::OsStr::new("..") {
+                        out.pop();
+                        continue;
                     }
+                }
+
+                if !has_root && prefix.is_none() {
+                    out.push(OsString::from(".."));
                 }
             }
             Component::Normal(n) => {


### PR DESCRIPTION
Refactor path handling to use PathBuf and normalize paths lexically. Introduce a new normalize_path function for better path normalization.

AI写的，编译测试了一下确实解决问题了。

如果觉得AI代码不太好的话，可以关掉这个PR，也算是帮你找一下问题所在了。😄

https://github.com/EmmyLua/VSCode-EmmyLua/issues/272