### PR TITLE
fix(emmylua_doc_cli): generate boolean literal

### DIFF
--- a/crates/emmylua_doc_cli/src/common.rs
+++ b/crates/emmylua_doc_cli/src/common.rs
@@ -17,6 +17,7 @@ pub fn render_const(typ: &LuaType) -> Option<String> {
         LuaType::StringConst(s) | LuaType::DocStringConst(s) => {
             Some(format!("{:?}", s.to_string()))
         }
+        LuaType::BooleanConst(b) => Some(b.to_string()),
         _ => None,
     }
 }


### PR DESCRIPTION
I'm using emmylua_doc_cli to generate docs for a nvim plugin.
This is a quick fix for missing boolean literal.
