### PR TITLE
feat: return_cast class field

### DIFF
--- a/crates/emmylua_code_analysis/src/diagnostic/test/undefined_global_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/undefined_global_test.rs
@@ -20,4 +20,41 @@ mod test {
             "#
         ));
     }
+
+    #[test]
+    fn test_return_cast_self_no_undefined_global() {
+        let mut ws = VirtualWorkspace::new();
+        // @return_cast self should not produce undefined-global error in methods
+        assert!(!ws.check_code_for(
+            DiagnosticCode::UndefinedGlobal,
+            r#"
+            ---@class MyClass
+            local MyClass = {}
+
+            ---@return_cast self MyClass
+            function MyClass:check1()
+                return true
+            end
+            "#
+        ));
+    }
+
+    #[test]
+    fn test_return_cast_self_field_no_undefined_global() {
+        let mut ws = VirtualWorkspace::new();
+        // @return_cast self.field should not produce undefined-global error in methods
+        assert!(!ws.check_code_for(
+            DiagnosticCode::UndefinedGlobal,
+            r#"
+            ---@class MyClass
+            ---@field value string|number
+            local MyClass = {}
+
+            ---@return_cast self.value string
+            function MyClass:check_string()
+                return type(self.value) == "string"
+            end
+            "#
+        ));
+    }
 }

--- a/crates/emmylua_parser/src/syntax/node/doc/tag.rs
+++ b/crates/emmylua_parser/src/syntax/node/doc/tag.rs
@@ -1500,6 +1500,10 @@ impl LuaDocTagReturnCast {
     pub fn get_name_token(&self) -> Option<LuaNameToken> {
         self.token()
     }
+
+    pub fn get_key_expr(&self) -> Option<LuaExpr> {
+        self.child()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]


### PR DESCRIPTION
Most of code are written by ai now, it seems work as my expected.
```lua
---@class MyClass
---@field value string|number
---@field data table|nil
local MyClass = {}

---Check if value field is string
---@return_cast self.value string
function MyClass:check_string()
	return type(self.value) == "string"
end

---Check if data field exists
---@return_cast self table else nil
function MyClass:has_data()
	return self.data ~= nil
end

---@param obj MyClass
function test_simple_field(obj)
	if obj:check_string() then
		-- Here obj.value should be narrowed to string
		local v = obj.value -- should be: string
		print(v:upper()) -- string method should work
	else
		-- Here obj.value should remain string|number
		local v = obj.value
		print(v)
	end
end

---@param obj MyClass
function test_with_fallback(obj)
	if obj:has_data() then
		-- Here obj.data should be table
		local d = obj.data -- should be: table
		print(#d)
	else
		-- Here obj.data should be nil (if fallback works)
		local d = obj.data -- should be: nil
		print(d)
	end
end
```
