### PR TITLE
feat(generics): add object literal pattern matching in conditional type infer

### DIFF
--- a/crates/emmylua_code_analysis/src/compilation/test/generic_infer_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/generic_infer_test.rs
@@ -1,0 +1,231 @@
+#[cfg(test)]
+mod test {
+    use crate::VirtualWorkspace;
+
+    #[test]
+    fn test_simple_infer_through_generic_func() {
+        // First verify that basic infer through generic function works
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@alias Identity<T> T extends infer P and P or never
+
+            ---@generic T
+            ---@param v T
+            ---@return Identity<T>
+            function identity(v) end
+
+            Z = identity("hello")
+            "#,
+        );
+
+        let z_ty = ws.expr_ty("Z");
+        // Should be "string" if basic infer works through generic functions
+        assert_eq!(ws.humanize_type(z_ty), "string");
+    }
+
+    #[test]
+    fn test_object_literal_infer_basic() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@alias ExtractFoo<T> T extends { foo: infer F } and F or never
+
+            ---@generic T
+            ---@param v T
+            ---@return ExtractFoo<T>
+            function extractFoo(v) end
+
+            ---@type { foo: string, bar: number }
+            local myTable
+
+            A = extractFoo(myTable)
+            "#,
+        );
+
+        let a_ty = ws.expr_ty("A");
+        assert_eq!(ws.humanize_type(a_ty), "string");
+    }
+
+    #[test]
+    fn test_object_literal_infer_from_class() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@alias ExtractFoo<T> T extends { foo: infer F } and F or never
+
+            ---@class MyClass
+            ---@field foo number
+            ---@field bar string
+
+            ---@generic T
+            ---@param v T
+            ---@return ExtractFoo<T>
+            function extractFoo(v) end
+
+            ---@type MyClass
+            local myObj
+
+            B = extractFoo(myObj)
+            "#,
+        );
+
+        let b_ty = ws.expr_ty("B");
+        assert_eq!(ws.humanize_type(b_ty), "number");
+    }
+
+    #[test]
+    fn test_object_literal_infer_constructor_params_multiple() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@alias ConstructorParams<T> T extends { constructor: fun(self: any, ...: infer P): any } and P or never
+
+            ---@class Widget
+            ---@field constructor fun(self: Widget, name: string, width: number): Widget
+
+            ---@generic T
+            ---@param v T
+            ---@return ConstructorParams<T>
+            function getParams(v) end
+
+            ---@type Widget
+            local widget
+
+            C = getParams(widget)
+            "#,
+        );
+
+        let c_ty = ws.expr_ty("C");
+        // Should be a tuple of the inferred parameters
+        assert_eq!(ws.humanize_type(c_ty), "(string,number)");
+    }
+
+    #[test]
+    fn test_object_literal_infer_constructor_params_single() {
+        // Test that single parameter constructors also return a tuple for consistent spreading
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@alias ConstructorParams<T> T extends { constructor: fun(self: any, ...: infer P): any } and P or never
+
+            ---@class SimpleWidget
+            ---@field constructor fun(self: SimpleWidget, name: string): SimpleWidget
+
+            ---@generic T
+            ---@param v T
+            ---@return ConstructorParams<T>
+            function getParams(v) end
+
+            ---@type SimpleWidget
+            local widget
+
+            D = getParams(widget)
+            "#,
+        );
+
+        let d_ty = ws.expr_ty("D");
+        // Single parameter should also be a tuple for consistent variadic spreading
+        // This ensures `fun(...: ConstructorParams<T>...)` works correctly
+        assert_eq!(ws.humanize_type(d_ty), "(string)");
+    }
+
+    #[test]
+    fn test_object_literal_infer_nested() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@alias ExtractNested<T> T extends { outer: { inner: infer I } } and I or never
+
+            ---@generic T
+            ---@param v T
+            ---@return ExtractNested<T>
+            function extractNested(v) end
+
+            ---@type { outer: { inner: boolean } }
+            local nested
+
+            D = extractNested(nested)
+            "#,
+        );
+
+        let d_ty = ws.expr_ty("D");
+        assert_eq!(ws.humanize_type(d_ty), "boolean");
+    }
+
+    #[test]
+    fn test_object_literal_infer_no_match() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@alias ExtractFoo<T> T extends { foo: infer F } and F or never
+
+            ---@generic T
+            ---@param v T
+            ---@return ExtractFoo<T>
+            function extractFoo(v) end
+
+            ---@type { bar: string }
+            local noFoo
+
+            E = extractFoo(noFoo)
+            "#,
+        );
+
+        let e_ty = ws.expr_ty("E");
+        assert_eq!(ws.humanize_type(e_ty), "never");
+    }
+
+    #[test]
+    fn test_object_literal_infer_function_field() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@alias ExtractCallback<T> T extends { callback: infer C } and C or never
+
+            ---@generic T
+            ---@param v T
+            ---@return ExtractCallback<T>
+            function extractCallback(v) end
+
+            ---@type { callback: fun(x: number): string }
+            local obj
+
+            F = extractCallback(obj)
+            "#,
+        );
+
+        let f_ty = ws.expr_ty("F");
+        assert_eq!(ws.humanize_type(f_ty), "fun(x: number) -> string");
+    }
+
+    #[test]
+    fn test_object_literal_infer_true_variadic_params() {
+        // Test that true variadic functions (fun(self, ...: T)) preserve variadic behavior
+        // This should NOT be wrapped in a tuple - it should stay as the base type
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@alias ExtractVariadic<T> T extends { handler: fun(self: any, ...: infer P): any } and P or never
+
+            ---@class VariadicWidget
+            ---@field handler fun(self: VariadicWidget, ...: string): VariadicWidget
+
+            ---@generic T
+            ---@param v T
+            ---@return ExtractVariadic<T>
+            function getVariadicType(v) end
+
+            ---@type VariadicWidget
+            local widget
+
+            V = getVariadicType(widget)
+            "#,
+        );
+
+        let v_ty = ws.expr_ty("V");
+        // True variadic should return the base type (not wrapped in tuple)
+        // so that variadic spreading continues to work as expected
+        assert_eq!(ws.humanize_type(v_ty), "string");
+    }
+}

--- a/crates/emmylua_code_analysis/src/compilation/test/mod.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/mod.rs
@@ -10,6 +10,7 @@ mod diagnostic_disable_test;
 mod export_test;
 mod flow;
 mod for_range_var_infer_test;
+mod generic_infer_test;
 mod generic_test;
 mod infer_str_tpl_test;
 mod inherit_type;


### PR DESCRIPTION
## Summary

This PR adds support for extracting `infer` types from object literal patterns in conditional type expressions. This enables patterns like:

```lua
---@alias ExtractFoo<T> T extends { foo: infer F } and F or never
```

## Motivation

This feature was developed to solve a specific use case that could not be achieved with existing functionality.

### The Specific Use Case: Custom Class System with Constructor Fields

I maintain a lightweight single-inheritance class system for Lua/Neovim that uses a `constructor` **field** pattern rather than the `@overload` pattern:

```lua
-- A simplified version of our existing class system:

---@class Class<T>
---@overload fun(...: any): T <- where any is parameters from Object.constructor(self, ...) below
---@field name string The class name
---@field members? T The prototype containing instance methods
---@field superclass? Class The parent class, if any

---@class Object<T>
---@field class Class<T> The class this instance was created from
---@field super? table Proxy for calling parent class methods
---@field constructor? fun(self: T, ...: any) Constructor called during instantiation

---@class ClassBuilder<T>: Class<T>
---@overload fun(members: Partial<T>): Class<T>

---@generic T
---@param `T` instance name
---@return ClassBuilder<T>
local function class(name)
    -- returns a class builder
    -- the class builder can then be called to define or extend and define a class
end

-- Usage pattern:

---@class MyObject: Object<MyClass>
---@field name string
---@field count number
---@field constructor fun(self: self, name: string)  -- Constructor as a FIELD

local MyObjectClass = class('MyObject')({
  name = '',
  count = 0,
  constructor = function(self, name)
    self.name = name or 'default'
  end,
})

local obj = MyObjectClass('hello')  -- Instantiation: calls the class overload and delegates to the instance types constructor function
                                    -- obj type should be `MyObject` but can't be inferred without an additional @type annotation
```

**The goal**: I wanted to create a `ConstructorParameters<T>` type alias that could extract the parameter types from the `constructor` field, enabling type-safe generic factory functions:

```lua
---@return ClassBuilder<T, ConstructorParameters<T>>
local function class(name) ... end
```

### What Was Tried (Existing Approach That Failed)

#### `@[constructor(...)]` and `ConstructorParameters<T>` with `new` keyword

The existing pattern from [Issue #785](https://github.com/EmmyLuaLs/emmylua-analyzer-rust/issues/785) / [PR #786](https://github.com/EmmyLuaLs/emmylua-analyzer-rust/pull/786):

```lua
-- The builtin:
---@alias ConstructorParameters<T> T extends new (fun(...: infer P): any) and P or never

---@generic T
---@[constructor('constructor', 'Object', false, false)]
---@param `T` instance name
---@return ClassBuilder<T, ConstructorParameters<T>>
local function class(name) end
```

**Why it failed**: This relies on the `new` keyword which looks for `@overload` on the instance type. My class system doesn't have an overload on the instance type. It defines constructors as `@field constructor fun(...)` on the instance type. The `@overload fun(...)` on the class type is simply an instance factory that delegates to the instance's constructor function.

#### What Was Needed

A way to match against the **shape** of an object and extract types from its fields:

```lua
---@alias ConstructorParams<T> T extends { constructor: fun(self: any, ...: infer P) } and P or never
```

This pattern says: "If T has a `constructor` field that is a function, extract the parameter types from that function."

### The Solution

This PR enables exactly that pattern. Now the following works:

```lua
---@alias ConstructorParams<T> T extends { constructor: fun(self: any, ...: infer P) } and P or never

---@class Class<T>
---@overload fun(...: ConstructorParams<T>...): T
---@field name string The class name
---@field members? T The prototype containing instance methods
---@field superclass? Class The parent class, if any

---@class Object<T>
---@field class Class<T> The class this instance was created from
---@field super? table Proxy for calling parent class methods
---@field constructor? fun(self: T, ...: any) Constructor called during instantiation

---@class ClassBuilder<T,P>: Class<T>
---@overload fun(members: Partial<T>): Class<T>

---@class MyObject: Object<MyClass>
---@field name string
---@field count number
---@field constructor fun(self: self, name: string) 

local MyObjectClass = class('MyObject')({ ... })

local obj = MyObjectClass('hello')  -- obj type is now `MyObject`
```

## Changes

### Files Modified

1. **`crates/emmylua_code_analysis/src/semantic/generic/instantiate_type/mod.rs`**
   - Added `LuaType::Object` case to `collect_infer_assignments()` function
   - Implemented three helper functions:
     - `collect_infer_from_object_to_object()` - matches Object type to Object pattern
     - `collect_infer_from_class_to_object()` - matches class/Ref type to Object pattern
     - `collect_infer_from_table_to_object()` - matches TableConst to Object pattern (limited support)

2. **`crates/emmylua_code_analysis/src/compilation/test/object_infer_test.rs`** (new file)
   - 7 test cases covering various object pattern matching scenarios

3. **`crates/emmylua_code_analysis/src/compilation/test/mod.rs`**
   - Added module declaration for new test file

### Implementation Details

The implementation follows the existing pattern for `DocFunction` and `Generic` type matching in `collect_infer_assignments()`. When the pattern is an `Object` type, it:

1. Iterates over the pattern's fields
2. Looks up corresponding fields in the source type (using `find_members_with_key` for class types)
3. Recursively collects infer assignments from matching fields
4. Returns `false` if a required field with `infer` is missing (triggering the false branch of the conditional)

## Test Cases

All 7 new tests pass, plus all 530+ existing tests:

| Test | Description |
|------|-------------|
| `test_simple_infer_through_generic_func` | Baseline: verifies basic infer works |
| `test_object_literal_infer_basic` | Extract field type from object type |
| `test_object_literal_infer_from_class` | Extract field type from class |
| `test_object_literal_infer_constructor_params` | Extract function params from constructor field |
| `test_object_literal_infer_nested` | Extract from nested object patterns |
| `test_object_literal_infer_no_match` | Returns `never` when field missing |
| `test_object_literal_infer_function_field` | Extract function type from field |

### Key Test: Constructor Parameters Extraction

```lua
---@alias ConstructorParams<T> T extends { constructor: fun(self: any, ...: infer P): any } and P or never

---@class Widget
---@field constructor fun(self: Widget, name: string, width: number): Widget

---@generic T
---@param v T
---@return ConstructorParams<T>
function getParams(v) end

---@type Widget
local widget

C = getParams(widget)  -- C is typed as (string, number) ✓
```

## Known Limitations

- **Inline table literals (`TableConst`)**: Member lookup for inline table literals (e.g., `extractFoo({ foo = "hello" })`) has limited support. The feature works best with typed variables (`---@type { foo: string }`) or class types (`---@class`).

## AI-Generated Disclosure

This implementation was generated with assistance from Claude (Anthropic). The code follows the existing patterns in the codebase and all tests pass.

I personally have limited experience with rust but thought this pattern may be useful to others as it's not specific to Lua class-like implementations.

## Related

- [Issue #785: Implementing Complex Generic Constraints](https://github.com/EmmyLuaLs/emmylua-analyzer-rust/issues/785)
- [PR #786: Generic constraints implementation](https://github.com/EmmyLuaLs/emmylua-analyzer-rust/pull/786)
- Existing test: `test_infer_new_constructor` in `generic_test.rs` (lines 441-472)
- Existing test: `test_generic_extends_function_params` in `generic_test.rs` (lines 723-784)

## Checklist

- [x] Code compiles without errors
- [x] All existing tests pass
- [x] New tests added for the feature
- [x] Code formatted with `cargo fmt`
- [x] Implementation follows existing code patterns
