### PR TITLE
Fix type annotations for `utf8` standard library

### DIFF
--- a/crates/emmylua_code_analysis/resources/std/utf8.lua
+++ b/crates/emmylua_code_analysis/resources/std/utf8.lua
@@ -48,11 +48,11 @@ function utf8.codes(s) end
 --- between byte position `i` and `j` (both included). The default for `i` is
 --- 1  and for `j` is `i`. It raises an error if it meets any invalid byte
 --- sequence.
----@overload fun(s:string):number
+---@overload fun(s:string):integer
 ---@param s string
----@param i? number
----@param j? number
----@return number
+---@param i? integer
+---@param j? integer
+---@return integer
 function utf8.codepoint(s, i, j) end
 
 ---
@@ -81,9 +81,9 @@ function utf8.len(s, i, j, lax) end
 --- byte of `s`.
 ---
 --- This function assumes that `s` is a valid UTF-8 string.
----@overload fun(s:string):number
+---@overload fun(s:string):integer
 ---@param s string
----@param n number
----@param i? number
----@return number
+---@param n integer
+---@param i? integer
+---@return integer
 function utf8.offset(s, n, i) end


### PR DESCRIPTION
Currently some functions in `utf8` are annotated to accept and return `number`s. Source code for all three of those functions ([`codepoint`](https://www.lua.org/source/5.5/lutf8lib.c.html#codepoint), [`len`](https://www.lua.org/source/5.5/lutf8lib.c.html#utflen), [`offset`](https://www.lua.org/source/5.5/lutf8lib.c.html#byteoffset)) indicates that none of them operate with numbers, but instead with integers.

This PR replaces all `number` annotations in `utf8.lua` with `integer`s.