### PR TITLE
fix(analysis): resolve alias-call returns and simplify flow assignments

### DIFF
--- a/crates/emmylua_code_analysis/src/compilation/test/unpack_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/unpack_test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod test {
-    use crate::{DiagnosticCode, EmmyrcLuaVersion, VirtualWorkspace};
+    use crate::{DiagnosticCode, EmmyrcLuaVersion, LuaType, VirtualWorkspace};
 
     #[test]
     fn test_unpack() {
@@ -28,6 +28,106 @@ mod test {
         let e_ty = ws.expr_ty("e");
         let e_expected = ws.ty("string?");
         assert_eq!(e_ty, e_expected);
+    }
+
+    #[test]
+    fn test_unpack_alias_call_union() {
+        let mut ws = VirtualWorkspace::new_with_init_std_lib();
+        ws.def(
+            r#"
+            ---@overload fun<T>(t: T): std.Unpack<T>
+            ---@overload fun(t: number): number
+            local function f(t)
+            end
+
+            a, b, c = f({ 1, 2, 3 })
+        "#,
+        );
+
+        assert_eq!(ws.expr_ty("a"), LuaType::IntegerConst(1));
+        assert_eq!(ws.expr_ty("b"), LuaType::IntegerConst(2));
+        assert_eq!(ws.expr_ty("c"), LuaType::IntegerConst(3));
+    }
+
+    #[test]
+    fn test_unpack_alias_call_colon_mismatch() {
+        let mut ws = VirtualWorkspace::new_with_init_std_lib();
+        ws.def(
+            r#"
+            ---@class Obj
+            ---@field unpack (fun<T>(self: Obj, t: T): std.Unpack<T>) | (fun(self: Obj, t: number): number)
+            local Obj = {}
+
+            a, b = Obj:unpack({ 1, 2 })
+        "#,
+        );
+
+        assert_eq!(ws.expr_ty("a"), LuaType::IntegerConst(1));
+        assert_eq!(ws.expr_ty("b"), LuaType::IntegerConst(2));
+    }
+
+    #[test]
+    fn test_unpack_method_dot_call_with_instance() {
+        let mut ws = VirtualWorkspace::new_with_init_std_lib();
+        ws.def(
+            r#"
+            ---@class Obj
+            local Obj = {}
+
+            ---@generic T
+            ---@param t T
+            ---@return std.Unpack<T>
+            function Obj:unpack(t)
+            end
+
+            ---@type Obj
+            obj = {}
+
+            a, b = Obj.unpack(obj, { 1, 2 })
+        "#,
+        );
+
+        assert_eq!(ws.expr_ty("a"), LuaType::IntegerConst(1));
+        assert_eq!(ws.expr_ty("b"), LuaType::IntegerConst(2));
+    }
+
+    #[test]
+    fn test_unpack_alias_call_self_type() {
+        let mut ws = VirtualWorkspace::new_with_init_std_lib();
+        ws.def(
+            r#"
+            ---@return std.Unpack<[self, self]>
+            function table:dup()
+            end
+
+            a, b = table:dup()
+        "#,
+        );
+
+        let a_ty = ws.expr_ty("a");
+        let b_ty = ws.expr_ty("b");
+        assert_eq!(ws.humanize_type(a_ty), "tablelib");
+        assert_eq!(ws.humanize_type(b_ty), "tablelib");
+    }
+
+    #[test]
+    fn test_unpack_alias_call_explicit_generic_list() {
+        let mut ws = VirtualWorkspace::new_with_init_std_lib();
+        ws.def(
+            r#"
+            ---@generic T
+            ---@return std.Unpack<T>
+            function f()
+            end
+
+            a, b = f--[[@<[string, number]>]]()
+        "#,
+        );
+
+        let a_ty = ws.expr_ty("a");
+        let b_ty = ws.expr_ty("b");
+        assert_eq!(ws.humanize_type(a_ty), "string");
+        assert_eq!(ws.humanize_type(b_ty), "number");
     }
 
     #[test]

--- a/crates/emmylua_code_analysis/src/db_index/type/types.rs
+++ b/crates/emmylua_code_analysis/src/db_index/type/types.rs
@@ -516,6 +516,7 @@ impl TypeVisitTrait for LuaType {
         f(self);
         match self {
             LuaType::Array(base) => base.visit_type(f),
+            LuaType::Call(base) => base.visit_type(f),
             LuaType::Tuple(base) => base.visit_type(f),
             LuaType::DocFunction(base) => base.visit_type(f),
             LuaType::Object(base) => base.visit_type(f),

--- a/crates/emmylua_code_analysis/src/diagnostic/test/inject_field_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/inject_field_test.rs
@@ -46,6 +46,26 @@ mod test {
     }
 
     #[test]
+    fn test_class_def_dynamic_key_in_method_is_allowed() {
+        let mut ws = VirtualWorkspace::new();
+        assert!(ws.check_code_for(
+            DiagnosticCode::InjectField,
+            r#"
+            ---@class TestBind
+            Bind = {}
+
+            ---@class TestFunc
+            ---@field call_name string
+            local M = {}
+
+            function M:call()
+                Bind[self.call_name] = 1
+            end
+        "#
+        ));
+    }
+
+    #[test]
     fn test_super_table() {
         let mut ws = VirtualWorkspace::new();
         assert!(ws.check_code_for(

--- a/crates/emmylua_code_analysis/src/semantic/infer/infer_call/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/infer_call/mod.rs
@@ -4,10 +4,7 @@ use emmylua_parser::{LuaAstNode, LuaCallExpr, LuaExpr, LuaSyntaxKind};
 use rowan::TextRange;
 
 use super::{
-    super::{
-        InferGuard, LuaInferCache, generic::TypeSubstitutor, instantiate_type_generic,
-        resolve_signature,
-    },
+    super::{InferGuard, LuaInferCache, instantiate_type_generic, resolve_signature},
     InferFailReason, InferResult,
 };
 use crate::{
@@ -18,7 +15,8 @@ use crate::{
 use crate::{
     InferGuardRef,
     semantic::{
-        generic::instantiate_doc_function, infer::narrow::get_type_at_call_expr_inline_cast,
+        generic::{TypeSubstitutor, instantiate_doc_function},
+        infer::narrow::get_type_at_call_expr_inline_cast,
     },
 };
 use crate::{build_self_type, infer_self_type, instantiate_func_generic, semantic::infer_expr};
@@ -99,6 +97,16 @@ pub fn infer_call_expr_func(
     };
 
     let result = if let Ok(func_ty) = result {
+        let func_ty = match func_ty.get_ret() {
+            LuaType::Call(_) => {
+                match instantiate_func_generic(db, cache, func_ty.as_ref(), call_expr.clone()) {
+                    Ok(func_ty) => Arc::new(func_ty),
+                    Err(_) => func_ty,
+                }
+            }
+            _ => func_ty,
+        };
+
         let func_ret = func_ty.get_ret();
         match func_ret {
             LuaType::TypeGuard(_) => Ok(func_ty),

--- a/crates/emmylua_code_analysis/src/semantic/infer/infer_index/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/infer_index/mod.rs
@@ -699,9 +699,16 @@ fn infer_instance_member(
     let base_result =
         infer_member_by_member_key(db, cache, origin_type, index_expr.clone(), infer_guard);
     match base_result {
-        Ok(typ) => {
-            return Ok(typ);
-        }
+        Ok(typ) => match infer_table_member(db, cache, range.clone(), index_expr.clone()) {
+            Ok(table_type) => {
+                return Ok(match TypeOps::Intersect.apply(db, &typ, &table_type) {
+                    LuaType::Never => typ,
+                    intersected => intersected,
+                });
+            }
+            Err(InferFailReason::FieldNotFound) => return Ok(typ),
+            Err(err) => return Err(err),
+        },
         Err(InferFailReason::FieldNotFound) => {}
         Err(err) => return Err(err),
     }

--- a/crates/emmylua_code_analysis/src/semantic/infer/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/mod.rs
@@ -176,15 +176,51 @@ fn get_custom_type_operator(
     }
 }
 
-pub fn infer_expr_list_types(
+pub fn infer_expr_list_value_type_at(
+    db: &DbIndex,
+    cache: &mut LuaInferCache,
+    exprs: &[LuaExpr],
+    value_idx: usize,
+) -> Result<Option<LuaType>, InferFailReason> {
+    let exprs_len = exprs.len();
+    if exprs_len == 0 {
+        Ok(None)
+    } else if value_idx < exprs_len {
+        Ok(
+            infer_expr_list_types(db, cache, &exprs[value_idx..], Some(1), infer_expr)?
+                .first()
+                .map(|(ty, _)| ty.clone()),
+        )
+    } else {
+        let last_idx = exprs_len - 1;
+        let offset = value_idx - last_idx;
+        Ok(
+            infer_expr_list_types(db, cache, &exprs[last_idx..], Some(offset + 1), infer_expr)?
+                .get(offset)
+                .map(|(ty, _)| ty.clone()),
+        )
+    }
+}
+
+pub fn infer_expr_list_types<F>(
     db: &DbIndex,
     cache: &mut LuaInferCache,
     exprs: &[LuaExpr],
     var_count: Option<usize>,
-) -> Vec<(LuaType, TextRange)> {
+    mut infer: F,
+) -> Result<Vec<(LuaType, TextRange)>, InferFailReason>
+where
+    F: FnMut(&DbIndex, &mut LuaInferCache, LuaExpr) -> InferResult,
+{
     let mut value_types = Vec::new();
     for (idx, expr) in exprs.iter().enumerate() {
-        let expr_type = infer_expr(db, cache, expr.clone()).unwrap_or(LuaType::Unknown);
+        if let Some(var_count) = var_count
+            && value_types.len() >= var_count
+        {
+            break;
+        }
+
+        let expr_type = infer(db, cache, expr.clone())?;
         match expr_type {
             LuaType::Variadic(variadic) => {
                 if let Some(var_count) = var_count {
@@ -212,11 +248,11 @@ pub fn infer_expr_list_types(
 
                 break;
             }
-            _ => value_types.push((expr_type.clone(), expr.get_range())),
+            _ => value_types.push((expr_type, expr.get_range())),
         }
     }
 
-    value_types
+    Ok(value_types)
 }
 
 /// 推断值已经绑定的类型(不是推断值的类型). 例如从右值推断左值类型, 从调用参数推断函数参数类型参数类型

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/binary_flow.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/binary_flow.rs
@@ -328,7 +328,7 @@ fn maybe_type_guard_binary(
 
     let result_type = match condition_flow {
         InferConditionFlow::TrueCondition => {
-            narrow_down_type(db, antecedent_type.clone(), narrow.clone()).unwrap_or(narrow)
+            narrow_down_type(db, antecedent_type.clone(), narrow.clone(), None).unwrap_or(narrow)
         }
         InferConditionFlow::FalseCondition => TypeOps::Remove.apply(db, &antecedent_type, &narrow),
     };

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/get_type_at_flow.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/get_type_at_flow.rs
@@ -4,14 +4,13 @@ use crate::{
     CacheEntry, DbIndex, FlowId, FlowNode, FlowNodeKind, FlowTree, InferFailReason, LuaDeclId,
     LuaInferCache, LuaMemberId, LuaSignatureId, LuaType, TypeOps, infer_expr,
     semantic::infer::{
-        InferResult, VarRefId,
+        InferResult, VarRefId, infer_expr_list_value_type_at,
         narrow::{
             ResultTypeOrContinue,
             condition_flow::{InferConditionFlow, get_type_at_condition_flow},
             get_multi_antecedents, get_single_antecedent,
             get_type_at_cast_flow::get_type_at_cast_flow,
-            get_var_ref_type,
-            narrow_type::narrow_down_type,
+            get_var_ref_type, narrow_down_type,
             var_ref_id::get_var_expr_var_ref_id,
         },
     },
@@ -213,68 +212,47 @@ fn get_type_at_assign_stat(
         }
 
         // Check if there's an explicit type annotation (not just inferred type)
-        let explicit_var_type = match var {
+        let var_id = match var {
             LuaVarExpr::NameExpr(name_expr) => {
-                let decl_id = LuaDeclId::new(cache.get_file_id(), name_expr.get_position());
-                db.get_type_index()
-                    .get_type_cache(&decl_id.into())
-                    .filter(|tc| tc.is_doc())
-                    .map(|tc| tc.as_type().clone())
+                Some(LuaDeclId::new(cache.get_file_id(), name_expr.get_position()).into())
             }
             LuaVarExpr::IndexExpr(index_expr) => {
-                let member_id = LuaMemberId::new(index_expr.get_syntax_id(), cache.get_file_id());
-                db.get_type_index()
-                    .get_type_cache(&member_id.into())
-                    .filter(|tc| tc.is_doc())
-                    .map(|tc| tc.as_type().clone())
+                Some(LuaMemberId::new(index_expr.get_syntax_id(), cache.get_file_id()).into())
             }
         };
 
-        // infer from expr
-        let expr_type = match exprs.get(i) {
-            Some(expr) => {
-                let expr_type = infer_expr(db, cache, expr.clone())?;
-                match &expr_type {
-                    LuaType::Variadic(variadic) => match variadic.get_type(0) {
-                        Some(typ) => typ.clone(),
-                        None => return Ok(ResultTypeOrContinue::Continue),
-                    },
-                    _ => expr_type,
-                }
-            }
-            None => {
-                let expr_len = exprs.len();
-                if expr_len == 0 {
-                    return Ok(ResultTypeOrContinue::Continue);
-                }
+        let explicit_var_type = var_id
+            .and_then(|id| db.get_type_index().get_type_cache(&id))
+            .filter(|tc| tc.is_doc())
+            .map(|tc| tc.as_type().clone());
 
-                let last_expr = exprs[expr_len - 1].clone();
-                let last_expr_type = infer_expr(db, cache, last_expr)?;
-                if let LuaType::Variadic(variadic) = last_expr_type {
-                    let idx = i - expr_len + 1;
-                    match variadic.get_type(idx) {
-                        Some(typ) => typ.clone(),
-                        None => return Ok(ResultTypeOrContinue::Continue),
-                    }
-                } else {
-                    return Ok(ResultTypeOrContinue::Continue);
-                }
-            }
+        let expr_type = infer_expr_list_value_type_at(db, cache, &exprs, i)?;
+        let Some(expr_type) = expr_type else {
+            return Ok(ResultTypeOrContinue::Continue);
         };
 
-        let antecedent_flow_id = get_single_antecedent(tree, flow_node)?;
-        let antecedent_type =
-            get_type_at_flow(db, tree, cache, root, var_ref_id, antecedent_flow_id)?;
-
-        // If there's an explicit type annotation (from ---@type comment), use it
-        // Otherwise, use flow-based narrowing
-        let result_type = if let Some(annotation) = explicit_var_type {
-            annotation
-        } else if antecedent_type == LuaType::Nil {
-            expr_type.clone()
+        let source_type = if let Some(explicit) = explicit_var_type.clone() {
+            explicit
         } else {
-            narrow_down_type(db, antecedent_type, expr_type.clone()).unwrap_or(expr_type)
+            let antecedent_flow_id = get_single_antecedent(tree, flow_node)?;
+            get_type_at_flow(db, tree, cache, root, var_ref_id, antecedent_flow_id)?
         };
+
+        let narrowed = if source_type == LuaType::Nil {
+            None
+        } else {
+            let declared =
+                get_var_ref_type(db, cache, var_ref_id)
+                    .ok()
+                    .and_then(|decl| match decl {
+                        LuaType::Def(_) | LuaType::Ref(_) => Some(decl),
+                        _ => None,
+                    });
+
+            narrow_down_type(db, source_type.clone(), expr_type.clone(), declared)
+        };
+
+        let result_type = narrowed.unwrap_or(explicit_var_type.unwrap_or(expr_type));
 
         return Ok(ResultTypeOrContinue::Result(result_type));
     }

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/narrow_type/false_or_nil_type.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/narrow_type/false_or_nil_type.rs
@@ -33,7 +33,7 @@ pub fn narrow_false_or_nil(db: &DbIndex, t: LuaType) -> LuaType {
         _ => {}
     }
 
-    narrow_down_type(db, t.clone(), LuaType::Nil).unwrap_or(LuaType::Never)
+    narrow_down_type(db, t.clone(), LuaType::Nil, None).unwrap_or(LuaType::Never)
 }
 
 /// Removes falsy values (false and nil) from a type.

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/narrow_type/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/narrow_type/mod.rs
@@ -1,13 +1,57 @@
 mod false_or_nil_type;
 
-use crate::{DbIndex, LuaType, TypeOps, get_real_type, semantic::type_check::is_sub_type_of};
+use crate::{
+    DbIndex, LuaInstanceType, LuaIntersectionType, LuaType, TypeOps, get_real_type,
+    semantic::type_check::is_sub_type_of,
+};
 pub use false_or_nil_type::{narrow_false_or_nil, remove_false_or_nil};
+
+fn is_class_def(db: &DbIndex, declared_type: &LuaType) -> bool {
+    match declared_type {
+        LuaType::Def(type_id) => db
+            .get_type_index()
+            .get_type_decl(type_id)
+            .is_some_and(|decl| decl.is_class()),
+        _ => false,
+    }
+}
 
 // need to be optimized
 // `source` is the current/antecedent type, `target` is the narrowing candidate (e.g. assignment RHS).
-pub fn narrow_down_type(db: &DbIndex, source: LuaType, target: LuaType) -> Option<LuaType> {
+pub fn narrow_down_type(
+    db: &DbIndex,
+    source: LuaType,
+    target: LuaType,
+    declared: Option<LuaType>,
+) -> Option<LuaType> {
     if source == target {
         return Some(source);
+    }
+
+    let declared_override = if let Some(declared_type) = &declared
+        && matches!(declared_type, LuaType::Def(_) | LuaType::Ref(_))
+    {
+        let is_class_def = is_class_def(db, declared_type);
+        match &target {
+            // Preserve structural object fields by intersecting with the declared type.
+            LuaType::Object(_) => {
+                Some(LuaIntersectionType::new(vec![declared_type.clone(), target.clone()]).into())
+            }
+            // Preserve declared class/alias types while keeping concrete table fields.
+            LuaType::TableConst(range) if !is_class_def => Some(LuaType::Instance(
+                LuaInstanceType::new(declared_type.clone(), range.clone()).into(),
+            )),
+            LuaType::Instance(inst) if !is_class_def => Some(LuaType::Instance(
+                LuaInstanceType::new(declared_type.clone(), inst.get_range().clone()).into(),
+            )),
+            _ => None,
+        }
+    } else {
+        None
+    };
+
+    if let Some(result) = declared_override {
+        return Some(result);
     }
 
     let real_source_ref = get_real_type(db, &source).unwrap_or(&source);
@@ -147,7 +191,9 @@ pub fn narrow_down_type(db: &DbIndex, source: LuaType, target: LuaType) -> Optio
             | LuaType::TableGeneric(_) => return Some(source),
             _ => {}
         },
-        LuaType::Instance(base) => return narrow_down_type(db, source, base.get_base().clone()),
+        LuaType::Instance(base) => {
+            return narrow_down_type(db, source, base.get_base().clone(), declared);
+        }
         LuaType::BooleanConst(_) => {
             if real_source_ref.is_boolean() {
                 return Some(LuaType::Boolean);
@@ -159,7 +205,7 @@ pub fn narrow_down_type(db: &DbIndex, source: LuaType, target: LuaType) -> Optio
             let source_types = target_u
                 .into_vec()
                 .into_iter()
-                .filter_map(|t| narrow_down_type(db, real_source_ref.clone(), t))
+                .filter_map(|t| narrow_down_type(db, real_source_ref.clone(), t, declared.clone()))
                 .collect::<Vec<_>>();
             let mut result_type = LuaType::Unknown;
             for source_type in source_types {
@@ -185,7 +231,7 @@ pub fn narrow_down_type(db: &DbIndex, source: LuaType, target: LuaType) -> Optio
             let union_types = union
                 .into_vec()
                 .into_iter()
-                .filter_map(|t| narrow_down_type(db, t, target.clone()))
+                .filter_map(|t| narrow_down_type(db, t, target.clone(), declared.clone()))
                 .collect::<Vec<_>>();
 
             return (!union_types.is_empty()).then_some(LuaType::from_vec(union_types));
@@ -194,7 +240,9 @@ pub fn narrow_down_type(db: &DbIndex, source: LuaType, target: LuaType) -> Optio
             let union_types = multi_line_union
                 .get_unions()
                 .iter()
-                .filter_map(|(ty, _)| narrow_down_type(db, ty.clone(), target.clone()))
+                .filter_map(|(ty, _)| {
+                    narrow_down_type(db, ty.clone(), target.clone(), declared.clone())
+                })
                 .collect::<Vec<_>>();
 
             return (!union_types.is_empty()).then_some(LuaType::from_vec(union_types));

--- a/crates/emmylua_code_analysis/src/semantic/infer/test.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod test {
-    use crate::VirtualWorkspace;
+    use crate::{DiagnosticCode, VirtualWorkspace};
 
     #[test]
     fn test_custom_binary() {
@@ -67,5 +67,36 @@ mod test {
         let ty = ws.expr_ty("c");
         let expected = ws.ty("number");
         assert_eq!(ty, expected);
+    }
+
+    #[test]
+    fn test_infer_expr_list_types_tolerates_infer_failures() {
+        let mut ws = VirtualWorkspace::new();
+        let code = r#"
+            local t ---@type { a: number }
+
+            ---@type string, string
+            local y, x
+
+            x, y = t.b, 1
+        "#;
+
+        assert!(!ws.check_code_for(DiagnosticCode::UndefinedField, code));
+        assert!(!ws.check_code_for(DiagnosticCode::AssignTypeMismatch, code));
+    }
+
+    #[test]
+    fn test_flow_assign_preserves_doc_type_on_infer_error() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            local t ---@type { a: number }
+            local x ---@type string
+            x = t.b
+            R = x
+        "#,
+        );
+
+        assert_eq!(ws.expr_ty("R"), ws.ty("nil"));
     }
 }

--- a/crates/emmylua_code_analysis/src/semantic/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/mod.rs
@@ -184,12 +184,11 @@ impl<'a> SemanticModel<'a> {
         exprs: &[LuaExpr],
         var_count: Option<usize>,
     ) -> Vec<(LuaType, TextRange)> {
-        infer_expr_list_types(
-            self.db,
-            &mut self.infer_cache.borrow_mut(),
-            exprs,
-            var_count,
-        )
+        let cache = &mut self.infer_cache.borrow_mut();
+        infer_expr_list_types(self.db, cache, exprs, var_count, |db, cache, expr| {
+            Ok(infer_expr(db, cache, expr).unwrap_or(LuaType::Unknown))
+        })
+        .unwrap_or_default()
     }
 
     /// 推断值已经绑定的类型(不是推断值的类型). 例如从右值推断左值类型, 从调用参数推断函数参数类型


### PR DESCRIPTION
- infer_call: infer and apply alias-call substitutions from call-site
  arguments, including colon/dot alignment, so returns like std.Unpack
  are concrete at the call site.
- narrow/get_type_at_flow: drop explicit-annotation precedence and
  antecedent narrowing for assignments; just use the resolved expression
  type.
- stats: prefer declared global type caches for name prefixes so member
  owners attach to their type defs (e.g., stdlib globals).
- tests: add unpack alias-call coverage and a flow regression for
  doc-function assignment narrowing.