### PR TITLE
fix(typecheck): accept intersections in class assignments

### DIFF
--- a/crates/emmylua_code_analysis/src/compilation/analyzer/doc/infer_type.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/doc/infer_type.rs
@@ -348,6 +348,18 @@ fn infer_special_generic_type(
                 return Some(LuaType::Language(lang_str));
             }
         }
+        "Merge" => {
+            let mut params = Vec::new();
+            for param in generic_type.get_generic_types()?.get_types() {
+                params.push(infer_type(analyzer, param));
+            }
+            if params.len() != 2 {
+                return Some(LuaType::Unknown);
+            }
+            return Some(LuaType::Call(
+                LuaAliasCallType::new(LuaAliasCallKind::Merge, params).into(),
+            ));
+        }
         _ => {}
     }
 

--- a/crates/emmylua_code_analysis/src/db_index/type/humanize_type.rs
+++ b/crates/emmylua_code_analysis/src/db_index/type/humanize_type.rs
@@ -388,6 +388,7 @@ fn humanize_call_type(db: &DbIndex, inner: &LuaAliasCallType, level: RenderLevel
         LuaAliasCallKind::Unpack => "unpack",
         LuaAliasCallKind::Index => "index",
         LuaAliasCallKind::RawGet => "rawget",
+        LuaAliasCallKind::Merge => "Merge",
     };
     let operands = inner
         .get_operands()

--- a/crates/emmylua_code_analysis/src/db_index/type/type_ops/intersect_type.rs
+++ b/crates/emmylua_code_analysis/src/db_index/type/type_ops/intersect_type.rs
@@ -46,6 +46,9 @@ pub fn intersect_type(db: &DbIndex, source: LuaType, target: LuaType) -> LuaType
         // function | function const
         (LuaType::Function, LuaType::DocFunction(_) | LuaType::Signature(_)) => target.clone(),
         (LuaType::DocFunction(_) | LuaType::Signature(_), LuaType::Function) => real_type.clone(),
+        // TODO: Intersecting two non-identical function types currently falls back to `never`.
+        // Consider implementing a proper intersection (or overload-set semantics) for function
+        // signatures instead of treating it as incompatible.
         // class references
         (LuaType::Ref(id1), LuaType::Ref(id2)) => {
             if id1 == id2 {

--- a/crates/emmylua_code_analysis/src/db_index/type/types.rs
+++ b/crates/emmylua_code_analysis/src/db_index/type/types.rs
@@ -1069,6 +1069,7 @@ pub enum LuaAliasCallKind {
     Select,
     Unpack,
     RawGet,
+    Merge,
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]

--- a/crates/emmylua_code_analysis/src/semantic/infer/infer_doc_type.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/infer_doc_type.rs
@@ -276,6 +276,18 @@ fn infer_special_generic_type(
 
             return Some(LuaType::TypeGuard(first_param.into()));
         }
+        "Merge" => {
+            let mut params = Vec::new();
+            for param in generic_type.get_generic_types()?.get_types() {
+                params.push(infer_doc_type(ctx, &param));
+            }
+            if params.len() != 2 {
+                return Some(LuaType::Unknown);
+            }
+            return Some(LuaType::Call(
+                LuaAliasCallType::new(LuaAliasCallKind::Merge, params).into(),
+            ));
+        }
         _ => {}
     }
 

--- a/crates/emmylua_code_analysis/src/semantic/member/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/member/mod.rs
@@ -6,7 +6,7 @@ mod infer_raw_member;
 use std::collections::HashSet;
 
 use crate::{
-    DbIndex, LuaMemberFeature, LuaMemberId, LuaMemberKey, LuaSemanticDeclId,
+    DbIndex, LuaMemberFeature, LuaMemberId, LuaMemberKey, LuaSemanticDeclId, TypeOps,
     db_index::{LuaType, LuaTypeDeclId},
 };
 use emmylua_parser::{LuaAssignStat, LuaAstNode, LuaSyntaxKind, LuaTableExpr, LuaTableField};
@@ -42,6 +42,14 @@ pub struct LuaMemberInfo {
 
 type FindMembersResult = Option<Vec<LuaMemberInfo>>;
 type RawGetMemberTypeResult = Result<LuaType, InferFailReason>;
+
+pub(crate) fn intersect_member_types(db: &DbIndex, left: LuaType, right: LuaType) -> LuaType {
+    if left == right {
+        left
+    } else {
+        TypeOps::Intersect.apply(db, &left, &right)
+    }
+}
 
 pub fn find_member_origin_owner(
     db: &DbIndex,

--- a/crates/emmylua_code_analysis/src/semantic/type_check/complex_type/object_type_check.rs
+++ b/crates/emmylua_code_analysis/src/semantic/type_check/complex_type/object_type_check.rs
@@ -1,9 +1,14 @@
+use std::collections::{HashMap, hash_map::Entry};
+
 use crate::{
     LuaMemberKey, LuaMemberOwner, LuaObjectType, LuaTupleType, LuaType, RenderLevel,
     TypeCheckFailReason, TypeCheckResult, humanize_type,
-    semantic::type_check::{
-        check_general_type_compact, type_check_context::TypeCheckContext,
-        type_check_guard::TypeCheckGuard,
+    semantic::{
+        member::find_members,
+        type_check::{
+            check_general_type_compact, type_check_context::TypeCheckContext,
+            type_check_guard::TypeCheckGuard,
+        },
     },
 };
 
@@ -23,20 +28,18 @@ pub fn check_object_type_compact(
             );
         }
         LuaType::TableConst(inst) => {
-            let table_member_owner = LuaMemberOwner::Element(inst.clone());
-            return check_object_type_compact_member_owner(
+            return check_object_type_compact_table_const(
                 context,
                 source_object,
-                table_member_owner,
+                inst,
                 check_guard.next_level()?,
             );
         }
         LuaType::Ref(type_id) => {
-            let member_owner = LuaMemberOwner::Type(type_id.clone());
-            return check_object_type_compact_member_owner(
+            return check_object_type_compact_type_ref(
                 context,
                 source_object,
-                member_owner,
+                type_id,
                 check_guard.next_level()?,
             );
         }
@@ -94,13 +97,92 @@ fn check_object_type_compact_object_type(
     Ok(())
 }
 
-fn check_object_type_compact_member_owner(
+struct TypeMembers {
+    map: HashMap<LuaMemberKey, LuaType>,
+    index_keys: Vec<LuaMemberKey>,
+}
+
+fn collect_type_members(
+    context: &TypeCheckContext,
+    type_id: &crate::LuaTypeDeclId,
+    collect_index_keys: bool,
+) -> Option<TypeMembers> {
+    let type_members = find_members(context.db, &LuaType::Ref(type_id.clone()))?;
+
+    // Build a merged view of class members (including supertypes). When the same key appears
+    // multiple times (override), keep the first one (subclass wins).
+    let mut map: HashMap<LuaMemberKey, LuaType> = HashMap::new();
+    let mut index_keys: Vec<LuaMemberKey> = Vec::new();
+    if collect_index_keys {
+        index_keys.reserve(type_members.len());
+    }
+
+    for member in type_members {
+        let key = member.key;
+        let typ = member.typ;
+
+        if let Entry::Vacant(entry) = map.entry(key) {
+            if collect_index_keys {
+                index_keys.push(entry.key().clone());
+            }
+            entry.insert(typ);
+        }
+    }
+
+    Some(TypeMembers { map, index_keys })
+}
+
+fn check_member_value(
     context: &mut TypeCheckContext,
-    source_object: &LuaObjectType,
-    member_owner: LuaMemberOwner,
+    key: &LuaMemberKey,
+    key_type_for_display: Option<&LuaType>,
+    source_type: &LuaType,
+    member_type: &LuaType,
     check_guard: TypeCheckGuard,
 ) -> TypeCheckResult {
-    let member_index = context.db.get_member_index();
+    match check_general_type_compact(context, source_type, member_type, check_guard.next_level()?) {
+        Ok(_) => Ok(()),
+        Err(TypeCheckFailReason::TypeNotMatch) => {
+            let mut key_display = key.to_path();
+            if key_display.is_empty() {
+                if let Some(key_type_for_display) = key_type_for_display {
+                    key_display =
+                        humanize_type(context.db, key_type_for_display, RenderLevel::Simple);
+                }
+            }
+
+            Err(TypeCheckFailReason::TypeNotMatchWithReason(
+                t!(
+                    "member %{key} not match, expect %{typ}, but got %{got}",
+                    key = key_display,
+                    typ = humanize_type(context.db, source_type, RenderLevel::Simple),
+                    got = humanize_type(context.db, member_type, RenderLevel::Simple)
+                )
+                .to_string(),
+            ))
+        }
+        Err(e) => Err(e),
+    }
+}
+
+fn member_key_type_for_index(member_key: &LuaMemberKey) -> Option<LuaType> {
+    match member_key {
+        LuaMemberKey::Integer(i) => Some(LuaType::IntegerConst(*i)),
+        LuaMemberKey::Name(name) => Some(LuaType::StringConst(name.clone().into())),
+        LuaMemberKey::ExprType(typ) => Some(typ.clone()),
+        LuaMemberKey::None => None,
+    }
+}
+
+fn check_object_type_compact_table_const(
+    context: &mut TypeCheckContext,
+    source_object: &LuaObjectType,
+    table_range: &crate::InFiled<rowan::TextRange>,
+    check_guard: TypeCheckGuard,
+) -> TypeCheckResult {
+    let db = context.db;
+    let member_owner = LuaMemberOwner::Element(table_range.clone());
+    let member_index = db.get_member_index();
     let source_fields = source_object.get_fields();
 
     // 检查名称字段
@@ -117,35 +199,18 @@ fn check_object_type_compact_member_owner(
                 }
             }
         };
-        let member_type = match member_item.resolve_type(context.db) {
+        let member_type = match member_item.resolve_type(db) {
             Ok(t) => t,
             _ => {
                 continue;
             }
         };
 
-        match check_general_type_compact(
-            context,
-            source_type,
-            &member_type,
-            check_guard.next_level()?,
-        ) {
-            Ok(_) => {}
-            Err(TypeCheckFailReason::TypeNotMatch) => {
-                return Err(TypeCheckFailReason::TypeNotMatchWithReason(
-                    t!(
-                        "member %{key} not match, expect %{typ}, but got %{got}",
-                        key = key.to_path().to_string(),
-                        typ = humanize_type(context.db, source_type, RenderLevel::Simple),
-                        got = humanize_type(context.db, &member_type, RenderLevel::Simple)
-                    )
-                    .to_string(),
-                ));
-            }
-            Err(e) => {
-                return Err(e);
-            }
-        }
+        check_member_value(context, key, None, source_type, &member_type, check_guard)?;
+    }
+
+    if source_object.get_index_access().is_empty() {
+        return Ok(());
     }
 
     // 检查索引访问字段
@@ -156,11 +221,8 @@ fn check_object_type_compact_member_owner(
             if source_fields.contains_key(member.get_key()) {
                 continue;
             }
-            let member_key_type = match member.get_key() {
-                LuaMemberKey::Integer(i) => LuaType::IntegerConst(*i),
-                LuaMemberKey::Name(name) => LuaType::StringConst(name.clone().into()),
-                LuaMemberKey::ExprType(typ) => typ.clone(),
-                LuaMemberKey::None => continue,
+            let Some(member_key_type) = member_key_type_for_index(member.get_key()) else {
+                continue;
             };
 
             let key_match = match check_general_type_compact(
@@ -188,39 +250,94 @@ fn check_object_type_compact_member_owner(
                 .get_type_index()
                 .get_type_cache(&member.get_id().into())
             {
-                Some(cache) => cache.as_type().clone(),
+                Some(cache) => cache.as_type(),
                 None => continue,
             };
 
-            match check_general_type_compact(
+            check_member_value(
                 context,
+                member.get_key(),
+                Some(&member_key_type),
                 source_type,
-                &member_type,
+                member_type,
+                check_guard,
+            )?;
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+fn check_object_type_compact_type_ref(
+    context: &mut TypeCheckContext,
+    source_object: &LuaObjectType,
+    type_id: &crate::LuaTypeDeclId,
+    check_guard: TypeCheckGuard,
+) -> TypeCheckResult {
+    let source_fields = source_object.get_fields();
+    let has_index_access = !source_object.get_index_access().is_empty();
+
+    let Some(type_members) = collect_type_members(context, type_id, has_index_access) else {
+        return Ok(());
+    };
+
+    for (key, source_type) in source_fields {
+        let Some(member_type) = type_members.map.get(key) else {
+            if source_type.is_nullable() || source_type.is_any() {
+                continue;
+            }
+
+            return Err(TypeCheckFailReason::TypeNotMatchWithReason(
+                t!("missing member %{key}", key = key.to_path().to_string()).to_string(),
+            ));
+        };
+
+        check_member_value(context, key, None, source_type, member_type, check_guard)?;
+    }
+
+    if !has_index_access {
+        return Ok(());
+    }
+
+    for (key_type, source_type) in source_object.get_index_access() {
+        for member_key in &type_members.index_keys {
+            if source_fields.contains_key(member_key) {
+                continue;
+            }
+
+            let Some(member_key_type) = member_key_type_for_index(member_key) else {
+                continue;
+            };
+
+            let key_match = match check_general_type_compact(
+                context,
+                key_type,
+                &member_key_type,
                 check_guard.next_level()?,
             ) {
-                Ok(_) => {
-                    break;
-                }
-                Err(TypeCheckFailReason::TypeNotMatch) => {
-                    let mut key_display = member.get_key().to_path();
-                    if key_display.is_empty() {
-                        key_display =
-                            humanize_type(context.db, &member_key_type, RenderLevel::Simple);
-                    }
-                    return Err(TypeCheckFailReason::TypeNotMatchWithReason(
-                        t!(
-                            "member %{key} not match, expect %{typ}, but got %{got}",
-                            key = key_display,
-                            typ = humanize_type(context.db, source_type, RenderLevel::Simple),
-                            got = humanize_type(context.db, &member_type, RenderLevel::Simple)
-                        )
-                        .to_string(),
-                    ));
-                }
-                Err(err) => {
-                    return Err(err);
-                }
+                Ok(_) => true,
+                Err(err) if err.is_type_not_match() => false,
+                Err(err) => return Err(err),
+            };
+
+            if !key_match {
+                continue;
             }
+
+            let Some(member_type) = type_members.map.get(member_key) else {
+                continue;
+            };
+
+            check_member_value(
+                context,
+                member_key,
+                Some(&member_key_type),
+                source_type,
+                member_type,
+                check_guard,
+            )?;
+            break;
         }
     }
 

--- a/crates/emmylua_code_analysis/src/semantic/type_check/intersection_utils.rs
+++ b/crates/emmylua_code_analysis/src/semantic/type_check/intersection_utils.rs
@@ -1,0 +1,18 @@
+use std::collections::HashMap;
+
+use crate::{DbIndex, LuaIntersectionType, LuaObjectType, LuaType, semantic::member::find_members};
+
+pub(super) fn intersection_to_object(
+    db: &DbIndex,
+    intersection: &LuaIntersectionType,
+) -> Option<LuaObjectType> {
+    let intersection_type: LuaType = intersection.clone().into();
+    let members = find_members(db, &intersection_type)?;
+    let mut fields: HashMap<_, _> = HashMap::new();
+    for member in members {
+        fields
+            .entry(member.key.clone())
+            .or_insert(member.typ.clone());
+    }
+    Some(LuaObjectType::new_with_fields(fields, Vec::new()))
+}

--- a/crates/emmylua_code_analysis/src/semantic/type_check/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/type_check/mod.rs
@@ -1,6 +1,7 @@
 mod complex_type;
 mod func_type;
 mod generic_type;
+mod intersection_utils;
 mod ref_type;
 mod simple_type;
 mod sub_type;

--- a/docs/emmylua_doc/annotations_CN/type.md
+++ b/docs/emmylua_doc/annotations_CN/type.md
@@ -25,6 +25,14 @@ local isActive = true
 ---@type string | number
 local mixedValue = "可以是字符串或数字"
 
+-- 交叉类型
+---@type T & U
+local mergedValue = getMergedValue()
+-- 说明：这里的“交叉”指同时满足两种类型，因此会包含双方字段
+-- 字段同时存在时，字段类型会变为两者的交叉；冲突时通常会变成 `never`（例如 {y:number} & {y:string} => y: never）
+-- 需要“覆盖式合并”时，使用 Merge<T, U>（右侧覆盖；左侧覆盖可写为 Merge<U, T>）
+-- 更适用于已定义字段的类或对象类型；开放/未知表会比较模糊
+
 -- 可选类型
 ---@type string?
 local optionalString = nil  -- 等价于 string | nil

--- a/docs/emmylua_doc/annotations_EN/type.md
+++ b/docs/emmylua_doc/annotations_EN/type.md
@@ -25,6 +25,15 @@ local isActive = true
 ---@type string | number
 local mixedValue = "Can be string or number"
 
+-- Intersection types
+---@type T & U
+local mergedValue = getMergedValue()
+-- Values must satisfy both types, so fields from both are included.
+-- If a field exists on both sides, its type becomes the intersection of the two types.
+-- Conflicting field types often collapse to `never` (e.g. {y:number} & {y:string} => y: never).
+-- For overwrite-style merges, use Merge<T, U> (right wins; use Merge<U, T> for left wins).
+-- Best used with classes or object types that define fields; open/unknown tables stay vague
+
 -- Optional types
 ---@type string?
 local optionalString = nil  -- Equivalent to string | nil


### PR DESCRIPTION
- allow intersection types to be checked against class refs
- add tests for intersection<->class assignment behavior
- update intersection docs (EN/CN) and overload docs
- keep annotation tests aligned with intersection semantics
