### PR TITLE
Enhance `setmetatable()` with generic type support

### DIFF
--- a/crates/emmylua_code_analysis/resources/std/global.lua
+++ b/crates/emmylua_code_analysis/resources/std/global.lua
@@ -385,9 +385,10 @@ function select(index, ...) end
 --- metatable has a `"__metatable"` field, raises an error.
 ---
 --- This function returns `table`.
----@param table table
+---@generic T: table
+---@param table T
 ---@param metatable std.metatable|table|nil
----@return table
+---@return T
 function setmetatable(table, metatable) end
 
 ---


### PR DESCRIPTION
Add generic type annotation to `setmetatable()` function to avoid errors.
Now it possible to do like this:
```lua
--- @generic GenericCuboid: Voxrame.map.Cuboid
--- @param child_class GenericCuboid|nil
--- @return GenericCuboid
function Cuboid:extended(child_class)
	return setmetatable(child_class or {}, { __index = self })
end
```