### PR TITLE
fix(module): enforce segment-boundary fuzzy require matching

### DIFF
--- a/crates/emmylua_code_analysis/src/db_index/module/mod.rs
+++ b/crates/emmylua_code_analysis/src/db_index/module/mod.rs
@@ -256,14 +256,16 @@ impl LuaModuleIndex {
 
     fn fuzzy_find_module(&self, module_path: &str, last_name: &str) -> Option<&ModuleInfo> {
         let file_ids = self.module_name_to_file_ids.get(last_name)?;
-        if file_ids.len() == 1 {
-            return self.file_module_map.get(&file_ids[0]);
-        }
+        let suffix_with_boundary = format!(".{}", module_path);
 
         // find the first matched module
         for file_id in file_ids {
             let module_info = self.file_module_map.get(file_id)?;
-            if module_info.full_module_name.ends_with(module_path) {
+            if module_info.full_module_name == module_path
+                || module_info
+                    .full_module_name
+                    .ends_with(&suffix_with_boundary)
+            {
                 return Some(module_info);
             }
         }

--- a/crates/emmylua_code_analysis/src/db_index/module/test.rs
+++ b/crates/emmylua_code_analysis/src/db_index/module/test.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
+    use std::{path::Path, sync::Arc};
 
     use crate::{
-        FileId, WorkspaceId,
+        Emmyrc, FileId, WorkspaceId,
         db_index::{module::LuaModuleIndex, traits::LuaIndex},
     };
 
@@ -166,5 +166,25 @@ mod tests {
         assert!(module_info.is_none());
         let module_node = m.find_module_node("test2.aaa");
         assert!(module_node.is_none());
+    }
+
+    #[test]
+    fn test_require_fuzzy_match_honors_segment_boundaries() {
+        let mut m = LuaModuleIndex::new();
+        m.update_config(Arc::new(Emmyrc::default()));
+        m.add_workspace_root(
+            Path::new("C:/Users/username/Documents").into(),
+            WorkspaceId::MAIN,
+        );
+
+        let file_id = FileId { id: 1 };
+        m.add_module_by_path(
+            file_id,
+            "C:/Users/username/Documents/nvim-cmp/lua/cmp/utils/event.lua",
+        );
+
+        assert!(m.find_module("pckr.event").is_none());
+        let module_info = m.find_module("event").unwrap();
+        assert_eq!(module_info.full_module_name, "nvim-cmp.lua.cmp.utils.event");
     }
 }


### PR DESCRIPTION
Fix incorrect module resolution where a multi-segment require path could
be matched by raw string suffix in fuzzy mode.

Previous logic accepted any ends_with(module_path) match and also
short-circuited when only one candidate shared the same leaf name. That
allowed pckr.event to resolve to nvim-cmp.lua.cmp.utils.event because
event was the only leaf candidate.

Update LuaModuleIndex::fuzzy_find_module to only match when the
candidate is either an exact module path or a segment-boundary suffix (.
+ module_path). Remove the single-candidate early return so we always
validate boundary correctness.

Add regression coverage in module index tests to assert both behaviors
in one test: pckr.event must not match cmp.utils.event, while leaf fuzzy
lookup for event still resolves as intended.
