### PR TITLE
feat(diagnostic): report unresolved require modules

### DIFF
--- a/crates/emmylua_code_analysis/resources/schema.json
+++ b/crates/emmylua_code_analysis/resources/schema.json
@@ -389,6 +389,11 @@
           "const": "cast-type-mismatch"
         },
         {
+          "description": "unresolved-require",
+          "type": "string",
+          "const": "unresolved-require"
+        },
+        {
           "description": "require-module-not-visible",
           "type": "string",
           "const": "require-module-not-visible"

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/require_module_visibility.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/require_module_visibility.rs
@@ -7,7 +7,10 @@ use super::{Checker, DiagnosticContext};
 pub struct RequireModuleVisibilityChecker;
 
 impl Checker for RequireModuleVisibilityChecker {
-    const CODES: &[DiagnosticCode] = &[DiagnosticCode::RequireModuleNotVisible];
+    const CODES: &[DiagnosticCode] = &[
+        DiagnosticCode::RequireModuleNotVisible,
+        DiagnosticCode::UnresolvedRequire,
+    ];
 
     fn check(context: &mut DiagnosticContext, semantic_model: &SemanticModel) {
         let root = semantic_model.get_root().clone();
@@ -37,10 +40,19 @@ fn check_require_call_expr(
     };
 
     // 查找模块信息
-    let module_info = semantic_model
+    let Some(module_info) = semantic_model
         .get_db()
         .get_module_index()
-        .find_module(&module_path)?;
+        .find_module(&module_path)
+    else {
+        context.add_diagnostic(
+            DiagnosticCode::UnresolvedRequire,
+            arg_expr.get_range(),
+            t!("Cannot resolve module `%{module}`.", module = module_path).to_string(),
+            None,
+        );
+        return Some(());
+    };
 
     // 检查可见性
     if !check_export_visibility(semantic_model, module_info).unwrap_or(false) {

--- a/crates/emmylua_code_analysis/src/diagnostic/lua_diagnostic_code.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/lua_diagnostic_code.rs
@@ -97,6 +97,8 @@ pub enum DiagnosticCode {
     GenericConstraintMismatch,
     /// cast-type-mismatch
     CastTypeMismatch,
+    /// unresolved-require
+    UnresolvedRequire,
     /// require-module-not-visible
     RequireModuleNotVisible,
     /// enum-value-mismatch
@@ -142,6 +144,7 @@ pub fn get_default_severity(code: DiagnosticCode) -> DiagnosticSeverity {
         DiagnosticCode::AnnotationUsageError => DiagnosticSeverity::ERROR,
         DiagnosticCode::RedefinedLocal => DiagnosticSeverity::HINT,
         DiagnosticCode::DuplicateRequire => DiagnosticSeverity::HINT,
+        DiagnosticCode::UnresolvedRequire => DiagnosticSeverity::WARNING,
         DiagnosticCode::IterVariableReassign => DiagnosticSeverity::ERROR,
         DiagnosticCode::PreferredLocalAlias => DiagnosticSeverity::HINT,
         DiagnosticCode::CallNonCallable => DiagnosticSeverity::WARNING,

--- a/crates/emmylua_code_analysis/src/diagnostic/test/mod.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/mod.rs
@@ -31,4 +31,5 @@ mod undefined_global_test;
 mod unknown_doc_tag;
 mod unnecessary_assert_test;
 mod unnecessary_if_test;
+mod unresolved_require_test;
 mod unused_test;

--- a/crates/emmylua_code_analysis/src/diagnostic/test/unresolved_require_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/unresolved_require_test.rs
@@ -1,0 +1,48 @@
+#[cfg(test)]
+mod tests {
+    use crate::{DiagnosticCode, VirtualWorkspace};
+
+    #[test]
+    fn test_unresolved_require() {
+        let mut ws = VirtualWorkspace::new();
+        assert!(!ws.check_code_for(
+            DiagnosticCode::UnresolvedRequire,
+            r#"
+            local a = require("missing.module")
+            "#,
+        ));
+    }
+
+    #[test]
+    fn test_resolved_require() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def_file(
+            "test.lua",
+            r#"
+            local M = {}
+            return M
+            "#,
+        );
+
+        assert!(ws.check_code_for(
+            DiagnosticCode::UnresolvedRequire,
+            r#"
+            local a = require("test")
+            "#,
+        ));
+    }
+
+    #[test]
+    fn test_non_literal_require() {
+        let mut ws = VirtualWorkspace::new();
+        assert!(ws.check_code_for(
+            DiagnosticCode::UnresolvedRequire,
+            r#"
+            local function module_name()
+                return "missing.module"
+            end
+            local a = require(module_name)
+            "#,
+        ));
+    }
+}


### PR DESCRIPTION
Add an unresolved-require diagnostic for require("...") calls that
resolve to a string module path but cannot be found in the module index.

Extend the existing require visibility checker to emit
unresolved-require when module lookup fails.
