### PR TITLE
fix(code-analysis): strip implicit self from doc call operators

### DIFF
--- a/crates/emmylua_code_analysis/src/compilation/analyzer/doc/field_or_operator_def_tags.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/doc/field_or_operator_def_tags.rs
@@ -176,13 +176,12 @@ pub fn analyze_operator(analyzer: &mut DocAnalyzer, tag: LuaDocTagOperator) -> O
         })
         .unwrap_or_default();
 
-    operands.insert(
-        0,
-        (
-            "self".to_string(),
-            Some(LuaType::Ref(current_type_id.clone())),
-        ),
-    );
+    let self_name = if op_kind == LuaOperatorMetaMethod::Call {
+        "@call_self"
+    } else {
+        "self"
+    };
+    operands.insert(0, (self_name.to_string(), Some(LuaType::SelfInfer)));
 
     let return_type = if let Some(return_type) = tag.get_return_type() {
         infer_type(analyzer, return_type)

--- a/crates/emmylua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/generic_test.rs
@@ -680,6 +680,24 @@ mod test {
     }
 
     #[test]
+    fn test_call_overload_self_generic() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@class Callable
+            ---@overload fun<T>(self: self, value: T): T
+            ---@type Callable
+            local c
+
+            result = c(c, 1)
+            "#,
+        );
+
+        let result_ty = ws.expr_ty("result");
+        assert_eq!(ws.humanize_type(result_ty), "integer");
+    }
+
+    #[test]
     fn test_generic_default_constraint_used() {
         let mut ws = VirtualWorkspace::new();
         {

--- a/crates/emmylua_code_analysis/src/db_index/operators/lua_operator.rs
+++ b/crates/emmylua_code_analysis/src/db_index/operators/lua_operator.rs
@@ -121,7 +121,13 @@ impl LuaOperator {
 
     pub fn get_operator_func(&self, db: &DbIndex) -> LuaType {
         match &self.func {
-            OperatorFunction::Func(func) => LuaType::DocFunction(func.clone()),
+            OperatorFunction::Func(func) => {
+                if self.op == LuaOperatorMetaMethod::Call {
+                    LuaType::DocFunction(func.to_call_operator_func_type())
+                } else {
+                    LuaType::DocFunction(func.clone())
+                }
+            }
             OperatorFunction::Signature(signature) => LuaType::Signature(*signature),
             OperatorFunction::DefaultClassCtor {
                 id,

--- a/crates/emmylua_code_analysis/src/db_index/type/types.rs
+++ b/crates/emmylua_code_analysis/src/db_index/type/types.rs
@@ -749,6 +749,21 @@ impl LuaFunctionType {
             false
         }
     }
+
+    pub fn to_call_operator_func_type(&self) -> Arc<LuaFunctionType> {
+        let mut params = self.get_params().to_vec();
+        if params.first().is_some_and(|(name, _)| name == "@call_self") {
+            params.remove(0);
+        }
+
+        Arc::new(LuaFunctionType::new(
+            self.async_state,
+            false,
+            self.is_variadic,
+            params,
+            self.ret.clone(),
+        ))
+    }
 }
 
 impl From<LuaFunctionType> for LuaType {

--- a/crates/emmylua_code_analysis/src/diagnostic/test/missing_parameter_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/missing_parameter_test.rs
@@ -226,4 +226,88 @@ mod test {
         "#
         ));
     }
+
+    #[test]
+    fn test_call_operator_implicit_self() {
+        let mut ws = VirtualWorkspace::new();
+
+        assert!(ws.check_code_for(
+            DiagnosticCode::MissingParameter,
+            r#"
+                ---@class Task
+                local Task = {}
+
+                ---@param callback fun()
+                function Task:await(callback)
+                end
+
+                ---@class TaskFun
+                ---@operator call: Task
+
+                ---@type TaskFun[]
+                local tasks = {}
+
+                tasks[1]():await(function()
+                end)
+        "#
+        ));
+    }
+
+    #[test]
+    fn test_call_overload_named_self_is_not_stripped() {
+        let mut ws = VirtualWorkspace::new();
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::MissingParameter,
+            r#"
+                ---@class Callable
+                ---@overload fun(self: string)
+                ---@type Callable
+                local c
+
+                c()
+        "#
+        ));
+
+        assert!(ws.check_code_for(
+            DiagnosticCode::MissingParameter,
+            r#"
+                ---@class Callable
+                ---@overload fun(self: string)
+                ---@type Callable
+                local c
+
+                c("x")
+        "#
+        ));
+    }
+
+    #[test]
+    fn test_call_overload_self_type_is_not_stripped() {
+        let mut ws = VirtualWorkspace::new();
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::MissingParameter,
+            r#"
+                ---@class Callable
+                ---@overload fun(self: self)
+                ---@type Callable
+                local c
+
+                c()
+        "#
+        ));
+
+        assert!(ws.check_code_for(
+            DiagnosticCode::MissingParameter,
+            r#"
+                ---@class Callable
+                ---@overload fun(self: self)
+                ---@type Callable
+                local c
+
+                c(c)
+        "#
+        ));
+    }
 }

--- a/crates/emmylua_code_analysis/src/diagnostic/test/param_type_check_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/param_type_check_test.rs
@@ -1532,4 +1532,27 @@ mod test {
         "#,
         ));
     }
+
+    #[test]
+    fn test_call_operator_implicit_self_param_type() {
+        let mut ws = VirtualWorkspace::new();
+
+        assert!(ws.check_code_for(
+            DiagnosticCode::ParamTypeMismatch,
+            r#"
+                ---@class Iter
+
+                ---@class IterMod
+                ---@operator call: Iter
+
+                ---@type string[]
+                local paths = { "a" }
+
+                ---@type IterMod
+                local iter
+
+                local value = iter(paths)
+        "#,
+        ));
+    }
 }

--- a/crates/emmylua_code_analysis/src/semantic/infer/infer_call/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/infer_call/mod.rs
@@ -10,7 +10,7 @@ use super::{
 use crate::{
     CacheEntry, DbIndex, InFiled, LuaFunctionType, LuaGenericType, LuaInstanceType,
     LuaOperatorMetaMethod, LuaOperatorOwner, LuaSignature, LuaSignatureId, LuaType, LuaTypeDeclId,
-    LuaUnionType,
+    LuaUnionType, TypeVisitTrait,
 };
 use crate::{
     InferGuardRef,
@@ -295,7 +295,21 @@ fn infer_type_doc_function(
         let func = operator.get_operator_func(db);
         match func {
             LuaType::DocFunction(f) => {
-                if f.contain_self() {
+                let has_generic_tpl = {
+                    let mut has_generic_tpl = false;
+                    f.visit_type(&mut |t| {
+                        has_generic_tpl |= matches!(
+                            t,
+                            LuaType::TplRef(_) | LuaType::ConstTplRef(_) | LuaType::StrTplRef(_)
+                        );
+                    });
+                    has_generic_tpl
+                };
+
+                if has_generic_tpl {
+                    let result = instantiate_func_generic(db, cache, &f, call_expr.clone())?;
+                    overloads.push(Arc::new(result));
+                } else if f.contain_self() {
                     let mut substitutor = TypeSubstitutor::new();
                     let self_type = build_self_type(db, call_expr_type);
                     substitutor.add_self_type(self_type);
@@ -303,9 +317,6 @@ fn infer_type_doc_function(
                     {
                         overloads.push(f);
                     }
-                } else if f.contain_tpl() {
-                    let result = instantiate_func_generic(db, cache, &f, call_expr.clone())?;
-                    overloads.push(Arc::new(result));
                 } else {
                     overloads.push(f.clone());
                 }


### PR DESCRIPTION
Normalize doc-defined `---@operator call` functions by dropping the
implicit `self` parameter when exposing them as callable function types.
This fixes false `missing-parameter` and `param-type-mismatch`
diagnostics for zero-arg call operators and chained method calls on
their return values.
