### PR TITLE
fix: honor explicit library roots despite workspace excludes

### DIFF
--- a/crates/emmylua_code_analysis/src/vfs/collect_workspace_files.rs
+++ b/crates/emmylua_code_analysis/src/vfs/collect_workspace_files.rs
@@ -65,7 +65,11 @@ pub fn collect_workspace_files(
 
     for (idx, workspace) in workspaces.iter().enumerate() {
         // Build exclude_dirs for this workspace by finding child workspaces
-        let mut workspace_exclude_dir = exclude_dir.clone();
+        let mut workspace_exclude_dir = if workspace.is_library {
+            Vec::new()
+        } else {
+            exclude_dir.clone()
+        };
 
         // Find all other workspaces that are children of current workspace
         for (other_idx, other_workspace) in workspaces.iter().enumerate() {
@@ -242,4 +246,183 @@ fn find_library_exclude(library: &WorkspaceFolder, emmyrc: &Emmyrc) -> (Vec<Stri
     }
 
     (exclude, exclude_dirs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Emmyrc;
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+        sync::atomic::{AtomicU64, Ordering},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    static TEST_WORKSPACE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    struct TestWorkspace {
+        root: PathBuf,
+    }
+
+    impl TestWorkspace {
+        fn new() -> Self {
+            let unique = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let counter = TEST_WORKSPACE_COUNTER.fetch_add(1, Ordering::Relaxed);
+            let root = std::env::temp_dir().join(format!(
+                "emmylua-collect-workspace-files-{}-{}-{}",
+                std::process::id(),
+                unique,
+                counter,
+            ));
+            fs::create_dir_all(&root).unwrap();
+            Self { root }
+        }
+
+        fn write_file(&self, relative_path: &str) -> PathBuf {
+            let path = self.root.join(relative_path);
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(&path, "return true\n").unwrap();
+            path
+        }
+
+        fn path(&self, relative_path: &str) -> PathBuf {
+            self.root.join(relative_path)
+        }
+    }
+
+    impl Drop for TestWorkspace {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn loaded_paths(files: Vec<LuaFileInfo>) -> HashSet<PathBuf> {
+        files
+            .into_iter()
+            .map(|file| PathBuf::from(file.path))
+            .collect()
+    }
+
+    fn to_string(path: &Path) -> String {
+        path.to_string_lossy().to_string()
+    }
+
+    fn json_string(value: &str) -> String {
+        serde_json::to_string(value).unwrap()
+    }
+
+    fn emmyrc_from_json(json: &str) -> Emmyrc {
+        serde_json::from_str(json).unwrap()
+    }
+
+    #[test]
+    fn library_is_indexed_even_when_root_is_globally_ignored() {
+        let workspace = TestWorkspace::new();
+        let main_file = workspace.write_file("lua/main.lua");
+        let library_root = workspace.path(".test-deps/runtime/lua/vim");
+        let library_file = workspace.write_file(".test-deps/runtime/lua/vim/shared.lua");
+
+        let emmyrc = emmyrc_from_json(&format!(
+            r#"{{
+                "workspace": {{
+                    "ignoreDir": [{}],
+                    "library": [{}]
+                }}
+            }}"#,
+            json_string(&to_string(&workspace.path(".test-deps"))),
+            json_string(&to_string(&library_root)),
+        ));
+
+        let files = collect_workspace_files(
+            &vec![
+                WorkspaceFolder::new(workspace.root.clone(), false),
+                WorkspaceFolder::new(library_root.clone(), true),
+            ],
+            &emmyrc,
+            None,
+            None,
+        );
+
+        let loaded = loaded_paths(files);
+        assert!(loaded.contains(&main_file));
+        assert!(loaded.contains(&library_file));
+    }
+
+    #[test]
+    fn library_specific_ignores_still_apply() {
+        let workspace = TestWorkspace::new();
+        let library_root = workspace.path(".test-deps/runtime/lua/vim");
+        let kept_file = workspace.write_file(".test-deps/runtime/lua/vim/keep.lua");
+        let ignored_dir_file = workspace.write_file(".test-deps/runtime/lua/vim/tests/spec.lua");
+        let ignored_glob_file = workspace.write_file(".test-deps/runtime/lua/vim/async.spec.lua");
+
+        let emmyrc = emmyrc_from_json(&format!(
+            r#"{{
+                "workspace": {{
+                    "ignoreDir": [{}],
+                    "library": [{{
+                        "path": {},
+                        "ignoreDir": [{}],
+                        "ignoreGlobs": ["**/*.spec.lua"]
+                    }}]
+                }}
+            }}"#,
+            json_string(&to_string(&workspace.path(".test-deps"))),
+            json_string(&to_string(&library_root)),
+            json_string(&to_string(&library_root.join("tests"))),
+        ));
+
+        let files = collect_workspace_files(
+            &vec![
+                WorkspaceFolder::new(workspace.root.clone(), false),
+                WorkspaceFolder::new(library_root.clone(), true),
+            ],
+            &emmyrc,
+            None,
+            None,
+        );
+
+        let loaded = loaded_paths(files);
+        assert!(loaded.contains(&kept_file));
+        assert!(!loaded.contains(&ignored_dir_file));
+        assert!(!loaded.contains(&ignored_glob_file));
+    }
+
+    #[test]
+    fn global_ignore_globs_still_apply_to_libraries() {
+        let workspace = TestWorkspace::new();
+        let library_root = workspace.path(".test-deps/runtime/lua/vim");
+        let kept_file = workspace.write_file(".test-deps/runtime/lua/vim/keep.lua");
+        let ignored_file = workspace.write_file(".test-deps/runtime/lua/vim/tests/spec.skip.lua");
+
+        let emmyrc = emmyrc_from_json(&format!(
+            r#"{{
+                "workspace": {{
+                    "ignoreDir": [{}],
+                    "ignoreGlobs": ["**/*.skip.lua"],
+                    "library": [{}]
+                }}
+            }}"#,
+            json_string(&to_string(&workspace.path(".test-deps"))),
+            json_string(&to_string(&library_root)),
+        ));
+
+        let files = collect_workspace_files(
+            &vec![
+                WorkspaceFolder::new(workspace.root.clone(), false),
+                WorkspaceFolder::new(library_root.clone(), true),
+            ],
+            &emmyrc,
+            None,
+            None,
+        );
+
+        let loaded = loaded_paths(files);
+        assert!(loaded.contains(&kept_file));
+        assert!(!loaded.contains(&ignored_file));
+    }
 }

--- a/crates/emmylua_ls/src/context/workspace_manager.rs
+++ b/crates/emmylua_ls/src/context/workspace_manager.rs
@@ -7,7 +7,7 @@ use super::{ClientProxy, FileDiagnostic, StatusBar};
 use crate::context::lsp_features::LspFeatures;
 use crate::handlers::{ClientConfig, init_analysis};
 use emmylua_code_analysis::{
-    EmmyLuaAnalysis, Emmyrc, WorkspaceFolder, WorkspaceImport, load_configs,
+    EmmyLibraryItem, EmmyLuaAnalysis, Emmyrc, WorkspaceFolder, WorkspaceImport, load_configs,
 };
 use emmylua_code_analysis::{update_code_style, uri_to_file_path};
 use log::{debug, info};
@@ -24,7 +24,10 @@ pub struct WorkspaceManager {
     file_diagnostic: Arc<FileDiagnostic>,
     lsp_features: Arc<LspFeatures>,
     pub client_config: ClientConfig,
+    /// Client-provided workspace roots used for config scope and reindexing.
     pub workspace_folders: Vec<WorkspaceFolder>,
+    /// Expanded workspace roots used only for file matching and watching.
+    match_workspace_folders: Vec<WorkspaceFolder>,
     pub watcher: Option<notify::RecommendedWatcher>,
     pub current_open_files: HashSet<Uri>,
     pub match_file_pattern: WorkspaceFileMatcher,
@@ -46,6 +49,7 @@ impl WorkspaceManager {
             status_bar,
             client_config: ClientConfig::default(),
             workspace_folders: Vec::new(),
+            match_workspace_folders: Vec::new(),
             update_token: Arc::new(Mutex::new(None)),
             file_diagnostic,
             lsp_features,
@@ -74,6 +78,18 @@ impl WorkspaceManager {
 
     pub fn get_workspace_version(&self) -> i64 {
         self.workspace_version.load(Ordering::Acquire)
+    }
+
+    pub fn set_match_workspace_folders(&mut self, workspaces: Vec<WorkspaceFolder>) {
+        self.match_workspace_folders = workspaces;
+    }
+
+    pub fn file_match_workspaces(&self) -> &[WorkspaceFolder] {
+        if self.match_workspace_folders.is_empty() {
+            &self.workspace_folders
+        } else {
+            &self.match_workspace_folders
+        }
     }
 
     pub async fn add_update_emmyrc_task(&self, file_dir: PathBuf) {
@@ -228,6 +244,8 @@ impl WorkspaceManager {
         Some(())
     }
 
+    /// Returns whether the URI resolves to a file owned by one of the current
+    /// workspaces after applying workspace-specific filters.
     pub fn is_workspace_file(&self, uri: &Uri) -> bool {
         if self.workspace_folders.is_empty() {
             return true;
@@ -237,29 +255,8 @@ impl WorkspaceManager {
             return true;
         };
 
-        let mut is_workspace_file = false;
-        for workspace in &self.workspace_folders {
-            if let Ok(relative) = file_path.strip_prefix(&workspace.root) {
-                let inside_import = match &workspace.import {
-                    WorkspaceImport::All => true,
-                    WorkspaceImport::SubPaths(paths) => {
-                        paths.iter().any(|p| relative.starts_with(p))
-                    }
-                };
-
-                if !inside_import {
-                    continue;
-                }
-
-                if self.match_file_pattern.is_match(&file_path, relative) {
-                    is_workspace_file = true;
-                } else {
-                    return false;
-                }
-            }
-        }
-
-        is_workspace_file
+        self.match_file_pattern
+            .is_match(self.file_match_workspaces(), &file_path)
     }
 
     pub async fn check_schema_update(&self) {
@@ -428,46 +425,344 @@ pub struct WorkspaceFileMatcher {
     include: Vec<String>,
     exclude: Vec<String>,
     exclude_dir: Vec<PathBuf>,
+    library_exclude: Vec<(PathBuf, Vec<String>, Vec<PathBuf>)>,
 }
 
 impl WorkspaceFileMatcher {
-    pub fn new(include: Vec<String>, exclude: Vec<String>, exclude_dir: Vec<PathBuf>) -> Self {
+    /// Precomputes the effective file patterns for each workspace root.
+    pub fn new(
+        include: Vec<String>,
+        exclude: Vec<String>,
+        exclude_dir: Vec<PathBuf>,
+        emmyrc: &Emmyrc,
+    ) -> Self {
+        let library_exclude = emmyrc
+            .workspace
+            .library
+            .iter()
+            .filter_map(|lib| {
+                if let EmmyLibraryItem::Config(config) = lib {
+                    let mut merged_exclude = exclude.clone();
+                    merged_exclude.extend(config.ignore_globs.clone());
+                    merged_exclude.sort();
+                    merged_exclude.dedup();
+
+                    Some((
+                        PathBuf::from(&config.path),
+                        merged_exclude,
+                        config.ignore_dir.iter().map(PathBuf::from).collect(),
+                    ))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
         Self {
             include,
             exclude,
             exclude_dir,
+            library_exclude,
         }
     }
-    pub fn is_match(&self, path: &Path, relative_path: &Path) -> bool {
-        if self.exclude_dir.iter().any(|dir| path.starts_with(dir)) {
+
+    /// Returns whether `path` belongs to any configured workspace after the
+    /// most specific workspace's include and exclude rules are applied.
+    pub fn is_match(&self, workspaces: &[WorkspaceFolder], path: &Path) -> bool {
+        let Some((workspace, relative_path)) = select_workspace(workspaces, path) else {
+            return false;
+        };
+
+        let (exclude, exclude_dir) = self.exclude_for_workspace(workspace);
+        if exclude_dir.iter().any(|dir| path.starts_with(dir)) {
             return false;
         }
 
-        // let path_str = path.to_string_lossy().to_string().replace("\\", "/");
-        let exclude_matcher = wax::any(self.exclude.iter().map(|s| s.as_str()));
-        if let Ok(exclude_set) = exclude_matcher {
-            if exclude_set.is_match(relative_path) {
-                return false;
+        if !exclude.is_empty() {
+            let exclude_matcher = wax::any(exclude.iter().map(|s| s.as_str()));
+            if let Ok(exclude_set) = exclude_matcher {
+                if exclude_set.is_match(relative_path.as_path()) {
+                    return false;
+                }
+            } else {
+                log::error!("Invalid exclude pattern");
             }
-        } else {
-            log::error!("Invalid exclude pattern");
         }
 
         let include_matcher = wax::any(self.include.iter().map(|s| s.as_str()));
         if let Ok(include_set) = include_matcher {
-            return include_set.is_match(relative_path);
+            return include_set.is_match(relative_path.as_path());
         } else {
             log::error!("Invalid include pattern");
         }
 
         true
     }
+
+    fn exclude_for_workspace(&self, workspace: &WorkspaceFolder) -> (&[String], &[PathBuf]) {
+        if workspace.is_library {
+            if let Some((_, exclude, exclude_dir)) = self
+                .library_exclude
+                .iter()
+                .find(|(root, _, _)| *root == workspace.root)
+            {
+                return (exclude, exclude_dir);
+            }
+
+            return (&self.exclude, &[]);
+        }
+
+        (&self.exclude, &self.exclude_dir)
+    }
 }
 
 impl Default for WorkspaceFileMatcher {
     fn default() -> Self {
-        let include_pattern = vec!["**/*.lua".to_string()];
-        Self::new(include_pattern, vec![], vec![])
+        Self {
+            include: vec!["**/*.lua".to_string()],
+            exclude: Vec::new(),
+            exclude_dir: Vec::new(),
+            library_exclude: Vec::new(),
+        }
+    }
+}
+
+fn select_workspace<'a>(
+    workspaces: &'a [WorkspaceFolder],
+    path: &Path,
+) -> Option<(&'a WorkspaceFolder, PathBuf)> {
+    let mut selected = None;
+
+    for workspace in workspaces {
+        let Ok(relative_path) = path.strip_prefix(&workspace.root) else {
+            continue;
+        };
+
+        let Some(import_depth) = workspace_import_depth(&workspace.import, relative_path) else {
+            continue;
+        };
+
+        let candidate = (
+            workspace.root.components().count(),
+            import_depth,
+            usize::from(workspace.is_library),
+        );
+
+        let is_better = selected
+            .as_ref()
+            .map(|(_, _, current_score)| candidate > *current_score)
+            .unwrap_or(true);
+
+        if is_better {
+            selected = Some((workspace, relative_path.to_path_buf(), candidate));
+        }
+    }
+
+    selected.map(|(workspace, relative_path, _)| (workspace, relative_path))
+}
+
+/// Returns the depth of the matching import path for a workspace, if the file
+/// is inside that workspace's import scope.
+fn workspace_import_depth(import: &WorkspaceImport, relative_path: &Path) -> Option<usize> {
+    match import {
+        WorkspaceImport::All => Some(0),
+        WorkspaceImport::SubPaths(paths) => paths
+            .iter()
+            .filter(|path| relative_path.starts_with(path))
+            .map(|path| path.components().count())
+            .max(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use emmylua_code_analysis::{Emmyrc, calculate_include_and_exclude};
+    use lsp_server::Connection;
+    use lsp_types::ClientCapabilities;
+    use std::{
+        fs,
+        sync::Arc,
+        sync::atomic::{AtomicU64, Ordering},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    static TEST_WORKSPACE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    struct TestWorkspace {
+        root: PathBuf,
+    }
+
+    impl TestWorkspace {
+        fn new() -> Self {
+            let unique = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let counter = TEST_WORKSPACE_COUNTER.fetch_add(1, Ordering::Relaxed);
+            let root = std::env::temp_dir().join(format!(
+                "emmylua-workspace-matcher-{}-{}-{}",
+                std::process::id(),
+                unique,
+                counter,
+            ));
+            fs::create_dir_all(&root).unwrap();
+            Self { root }
+        }
+
+        fn write_file(&self, relative_path: &str) -> PathBuf {
+            let path = self.root.join(relative_path);
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(&path, "return true\n").unwrap();
+            path
+        }
+
+        fn path(&self, relative_path: &str) -> PathBuf {
+            self.root.join(relative_path)
+        }
+    }
+
+    impl Drop for TestWorkspace {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn to_string(path: &Path) -> String {
+        path.to_string_lossy().to_string()
+    }
+
+    fn json_string(value: &str) -> String {
+        serde_json::to_string(value).unwrap()
+    }
+
+    fn emmyrc_from_json(json: &str) -> Emmyrc {
+        serde_json::from_str(json).unwrap()
+    }
+
+    fn new_workspace_manager() -> WorkspaceManager {
+        let (server, _client) = Connection::memory();
+        let client = Arc::new(ClientProxy::new(server));
+        let analysis = Arc::new(RwLock::new(EmmyLuaAnalysis::new()));
+        let status_bar = Arc::new(StatusBar::new(client.clone()));
+        let file_diagnostic = Arc::new(FileDiagnostic::new(
+            analysis.clone(),
+            status_bar.clone(),
+            client.clone(),
+        ));
+        let lsp_features = Arc::new(LspFeatures::new(ClientCapabilities::default()));
+
+        WorkspaceManager::new(analysis, client, status_bar, file_diagnostic, lsp_features)
+    }
+
+    #[test]
+    fn nested_library_overrides_parent_ignore_dir() {
+        let workspace = TestWorkspace::new();
+        let library_root = workspace.path(".test-deps/runtime/lua/vim");
+        let library_file = workspace.write_file(".test-deps/runtime/lua/vim/shared.lua");
+        let workspaces = vec![
+            WorkspaceFolder::new(workspace.root.clone(), false),
+            WorkspaceFolder::new(library_root.clone(), true),
+        ];
+
+        let emmyrc = emmyrc_from_json(&format!(
+            r#"{{
+                "workspace": {{
+                    "ignoreDir": [{}],
+                    "library": [{}]
+                }}
+            }}"#,
+            json_string(&to_string(&workspace.path(".test-deps"))),
+            json_string(&to_string(&library_root)),
+        ));
+        let (include, exclude, exclude_dir) = calculate_include_and_exclude(&emmyrc);
+
+        let matcher = WorkspaceFileMatcher::new(include, exclude, exclude_dir, &emmyrc);
+
+        assert!(matcher.is_match(&workspaces, &library_file));
+    }
+
+    #[test]
+    fn most_specific_workspace_can_still_exclude_a_library_file() {
+        let workspace = TestWorkspace::new();
+        let library_root = workspace.path(".test-deps/runtime/lua/vim");
+        let library_file = workspace.write_file(".test-deps/runtime/lua/vim/tests/spec.lua");
+        let workspaces = vec![
+            WorkspaceFolder::new(workspace.root.clone(), false),
+            WorkspaceFolder::new(library_root.clone(), true),
+        ];
+
+        let emmyrc = emmyrc_from_json(&format!(
+            r#"{{
+                "workspace": {{
+                    "ignoreDir": [{}],
+                    "library": [{{
+                        "path": {},
+                        "ignoreDir": [{}]
+                    }}]
+                }}
+            }}"#,
+            json_string(&to_string(&workspace.path(".test-deps"))),
+            json_string(&to_string(&library_root)),
+            json_string(&to_string(&library_root.join("tests"))),
+        ));
+        let (include, exclude, exclude_dir) = calculate_include_and_exclude(&emmyrc);
+
+        let matcher = WorkspaceFileMatcher::new(include, exclude, exclude_dir, &emmyrc);
+
+        assert!(!matcher.is_match(&workspaces, &library_file));
+    }
+
+    #[test]
+    fn real_workspaces_remain_separate_from_match_workspaces() {
+        let workspace = TestWorkspace::new();
+        let library_root = workspace.path(".test-deps/runtime/lua/vim");
+        let mut manager = new_workspace_manager();
+
+        manager.workspace_folders = vec![WorkspaceFolder::new(workspace.root.clone(), false)];
+        manager.set_match_workspace_folders(vec![
+            WorkspaceFolder::new(workspace.root.clone(), false),
+            WorkspaceFolder::new(library_root.clone(), true),
+        ]);
+
+        assert_eq!(manager.workspace_folders.len(), 1);
+        assert_eq!(manager.workspace_folders[0].root, workspace.root);
+        assert!(!manager.workspace_folders[0].is_library);
+        assert_eq!(manager.file_match_workspaces().len(), 2);
+        assert!(
+            manager
+                .file_match_workspaces()
+                .iter()
+                .any(|workspace| workspace.root == library_root && workspace.is_library)
+        );
+    }
+
+    #[test]
+    fn global_ignore_globs_still_apply_to_library_files() {
+        let workspace = TestWorkspace::new();
+        let library_root = workspace.path(".test-deps/runtime/lua/vim");
+        let library_file = workspace.write_file(".test-deps/runtime/lua/vim/tests/spec.skip.lua");
+        let workspaces = vec![
+            WorkspaceFolder::new(workspace.root.clone(), false),
+            WorkspaceFolder::new(library_root.clone(), true),
+        ];
+
+        let emmyrc = emmyrc_from_json(&format!(
+            r#"{{
+                "workspace": {{
+                    "ignoreDir": [{}],
+                    "ignoreGlobs": ["**/*.skip.lua"],
+                    "library": [{}]
+                }}
+            }}"#,
+            json_string(&to_string(&workspace.path(".test-deps"))),
+            json_string(&to_string(&library_root)),
+        ));
+        let (include, exclude, exclude_dir) = calculate_include_and_exclude(&emmyrc);
+
+        let matcher = WorkspaceFileMatcher::new(include, exclude, exclude_dir, &emmyrc);
+
+        assert!(!matcher.is_match(&workspaces, &library_file));
     }
 }
 

--- a/crates/emmylua_ls/src/handlers/initialized/mod.rs
+++ b/crates/emmylua_ls/src/handlers/initialized/mod.rs
@@ -59,6 +59,7 @@ pub async fn initialized_handler(
         log::info!("set workspace folders: {:?}", workspace_folders);
         let mut workspace_manager = context.workspace_manager().write().await;
         workspace_manager.workspace_folders = workspace_folders.clone();
+        workspace_manager.set_match_workspace_folders(workspace_folders.clone());
         log::info!("workspace folders set");
     }
 
@@ -81,9 +82,13 @@ pub async fn initialized_handler(
     {
         let mut workspace_manager = context.workspace_manager().write().await;
         workspace_manager.client_config = client_config.clone();
+        workspace_manager.set_match_workspace_folders(build_match_file_workspaces(
+            &workspace_folders,
+            emmyrc.as_ref(),
+        ));
         let (include, exclude, exclude_dir) = calculate_include_and_exclude(&emmyrc);
         workspace_manager.match_file_pattern =
-            WorkspaceFileMatcher::new(include, exclude, exclude_dir);
+            WorkspaceFileMatcher::new(include, exclude, exclude_dir, emmyrc.as_ref());
         log::info!("workspace manager updated with client config and watch file patterns")
     }
 
@@ -99,6 +104,39 @@ pub async fn initialized_handler(
 
     register_files_watch(context.clone(), &params.capabilities).await;
     Some(())
+}
+
+/// Builds the workspace list used by file matching, including configured
+/// libraries and package directories that are indexed as library roots.
+fn build_match_file_workspaces(
+    workspace_folders: &[WorkspaceFolder],
+    emmyrc: &Emmyrc,
+) -> Vec<WorkspaceFolder> {
+    let mut match_workspaces = workspace_folders.to_vec();
+
+    for lib in &emmyrc.workspace.library {
+        let lib_path = PathBuf::from(lib.get_path().clone());
+        match_workspaces.push(WorkspaceFolder::new(lib_path, true));
+    }
+
+    for package_dir in &emmyrc.workspace.package_dirs {
+        let package_path = PathBuf::from(package_dir);
+        if let Some(parent) = package_path.parent() {
+            if let Some(name) = package_path.file_name() {
+                match_workspaces.push(WorkspaceFolder::with_sub_paths(
+                    parent.to_path_buf(),
+                    vec![PathBuf::from(name)],
+                    true,
+                ));
+            } else {
+                log::warn!("package dir {:?} has no file name", package_path);
+            }
+        } else {
+            log::warn!("package dir {:?} has no parent", package_path);
+        }
+    }
+
+    match_workspaces
 }
 
 pub async fn init_analysis(

--- a/crates/emmylua_ls/src/handlers/text_document/register_file_watch.rs
+++ b/crates/emmylua_ls/src/handlers/text_document/register_file_watch.rs
@@ -5,7 +5,7 @@ use lsp_types::{
     FileEvent, FileSystemWatcher, GlobPattern, Registration, RegistrationParams, WatchKind,
 };
 use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
-use std::{sync::mpsc::channel, time::Duration};
+use std::{collections::HashSet, sync::mpsc::channel, time::Duration};
 
 use crate::{
     context::{ClientProxy, ServerContextSnapshot},
@@ -93,9 +93,15 @@ async fn register_files_watch_use_fsnotify(context: ServerContextSnapshot) -> Op
     };
 
     let mut workspace_manager = context.workspace_manager().write().await;
-    for workspace in &workspace_manager.workspace_folders {
-        if let Err(e) = watcher.watch(&workspace.root, RecursiveMode::Recursive) {
-            warn!("can not watch {:?}: {:?}", workspace.root, e);
+    let roots: HashSet<_> = workspace_manager
+        .file_match_workspaces()
+        .iter()
+        .map(|workspace| workspace.root.clone())
+        .collect();
+
+    for root in roots {
+        if let Err(e) = watcher.watch(&root, RecursiveMode::Recursive) {
+            warn!("can not watch {:?}: {:?}", root, e);
             return None;
         }
     }


### PR DESCRIPTION
Explicitly configured libraries and package directories should still be
indexed even when they live under paths excluded from the main
workspace.

Separate the expanded file-matching roots from the client workspace
roots so explicit library roots can bypass parent ignoreDir filtering
during collection and watched-file matching without being fed back into
init_analysis as main workspaces on reload.

Keep global ignore globs and library-specific ignore rules applying
inside those library roots, and add regression coverage for matching,
collection, and reload state.
