### PR TITLE
fix(call): support callable intersection types

### DIFF
--- a/crates/emmylua_code_analysis/src/diagnostic/checker/call_non_callable.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/call_non_callable.rs
@@ -160,6 +160,10 @@ fn has_non_callable_member(db: &DbIndex, typ: &LuaType) -> bool {
             .into_vec()
             .iter()
             .any(|t| has_non_callable_member(db, t)),
+        LuaType::Intersection(intersection) => intersection
+            .get_types()
+            .iter()
+            .all(|t| has_non_callable_member(db, t)),
         LuaType::MultiLineUnion(union) => union
             .get_unions()
             .iter()

--- a/crates/emmylua_code_analysis/src/diagnostic/test/call_non_callable_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/call_non_callable_test.rs
@@ -67,6 +67,14 @@ mod test {
             "#
         ));
 
+        assert!(ws.check_code_for(
+            DiagnosticCode::CallNonCallable,
+            r#"
+                local f ---@type { field: string } & fun()
+                f()
+            "#
+        ));
+
         // nil is covered by need-check-nil instead of call-non-callable
         assert!(ws.check_code_for(
             DiagnosticCode::CallNonCallable,

--- a/crates/emmylua_code_analysis/src/semantic/infer/infer_call/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/infer_call/mod.rs
@@ -9,8 +9,8 @@ use super::{
 };
 use crate::{
     CacheEntry, DbIndex, InFiled, LuaFunctionType, LuaGenericType, LuaInstanceType,
-    LuaOperatorMetaMethod, LuaOperatorOwner, LuaSignature, LuaSignatureId, LuaType, LuaTypeDeclId,
-    LuaUnionType, TypeVisitTrait,
+    LuaIntersectionType, LuaOperatorMetaMethod, LuaOperatorOwner, LuaSignature, LuaSignatureId,
+    LuaType, LuaTypeDeclId, LuaUnionType, TypeVisitTrait,
 };
 use crate::{
     InferGuardRef,
@@ -86,6 +86,14 @@ pub fn infer_call_expr_func(
             cache,
             call_expr.clone(),
             &call_expr_type,
+            infer_guard,
+            args_count,
+        ),
+        LuaType::Intersection(intersection) => infer_intersection(
+            db,
+            cache,
+            intersection,
+            call_expr.clone(),
             infer_guard,
             args_count,
         ),
@@ -545,6 +553,48 @@ fn infer_union(
         return Err(InferFailReason::None);
     }
     resolve_signature(db, cache, all_overloads, call_expr, false, args_count)
+}
+
+fn infer_intersection(
+    db: &DbIndex,
+    cache: &mut LuaInferCache,
+    intersection: &LuaIntersectionType,
+    call_expr: LuaCallExpr,
+    infer_guard: &InferGuardRef,
+    args_count: Option<usize>,
+) -> InferCallFuncResult {
+    let mut overloads = Vec::new();
+    let mut need_resolve = None;
+
+    for ty in intersection.get_types() {
+        match infer_call_expr_func(
+            db,
+            cache,
+            call_expr.clone(),
+            ty.clone(),
+            infer_guard,
+            args_count,
+        ) {
+            Ok(func) => overloads.push(func),
+            Err(InferFailReason::RecursiveInfer) => return Err(InferFailReason::RecursiveInfer),
+            Err(reason) if reason.is_need_resolve() => {
+                if need_resolve.is_none() {
+                    need_resolve = Some(reason);
+                }
+            }
+            Err(_) => {}
+        }
+    }
+
+    if overloads.is_empty() {
+        return Err(need_resolve.unwrap_or(InferFailReason::None));
+    }
+
+    if overloads.len() == 1 {
+        return Ok(overloads.pop().expect("single callable member"));
+    }
+
+    resolve_signature(db, cache, overloads, call_expr, false, args_count)
 }
 
 pub(crate) fn unwrapp_return_type(

--- a/crates/emmylua_code_analysis/src/semantic/infer/test.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/test.rs
@@ -70,6 +70,19 @@ mod test {
     }
 
     #[test]
+    fn test_intersection_call_infers_return_type() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@type { field: string } & fun(): string
+            F = nil
+        "#,
+        );
+
+        assert_eq!(ws.expr_ty("F()"), ws.ty("string"));
+    }
+
+    #[test]
     fn test_infer_expr_list_types_tolerates_infer_failures() {
         let mut ws = VirtualWorkspace::new();
         let code = r#"


### PR DESCRIPTION
Treat intersections with callable members as callable during call
inference, so values like `{ field: string } & fun(): string` resolve
correctly.
