### PR TITLE
fix(generic): stabilize higher-order callable overload inference

### DIFF
--- a/crates/emmylua_code_analysis/src/compilation/test/callable_return_infer_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/callable_return_infer_test.rs
@@ -85,4 +85,333 @@ mod test {
 
         assert_eq!(ws.expr_ty("result"), ws.ty("string"));
     }
+
+    #[test]
+    fn test_apply_return_infer_prefers_structural_callback_over_function_fallback() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@generic A, R
+            ---@param f fun(x: A): R
+            ---@param x A
+            ---@return R
+            local function apply(f, x)
+                return f(x)
+            end
+
+            ---@overload fun<T>(cb: fun(): T): T
+            ---@param cb function
+            ---@return boolean
+            local function run(cb) end
+
+            ---@overload fun<T>(cb: fun(x: integer): T): integer
+            ---@overload fun<T>(cb: fun(x: string): T): string
+            ---@overload fun(cb: function): boolean
+            local function classify(cb) end
+
+            ---@overload fun<T>(cb: fun(): T): { value: T }
+            ---@overload fun(cb: function): boolean
+            local function wrap(cb) end
+
+            local source ---@type table
+
+            ---@return integer
+            local function cb_concrete()
+                return 1
+            end
+
+            ---@type fun(): unknown
+            local cb_unknown
+
+            ---@type fun(x: integer): unknown
+            local cb_param_unknown
+
+            ---@type fun(x: string): unknown
+            local cb_param_unknown_string
+
+            ---@param x integer
+            local function cb_param_unresolved(x)
+                return source.missing
+            end
+
+            ---@param x string
+            local function cb_param_unresolved_string(x)
+                return source.missing
+            end
+
+            local function cb_named_unresolved()
+                return source.missing
+            end
+
+            run_concrete = apply(run, cb_concrete)
+
+            run_unknown = apply(run, cb_unknown)
+
+            run_unresolved = apply(run, function()
+                return source.missing
+            end)
+
+            run_named_unresolved = apply(run, cb_named_unresolved)
+
+            wrap_named_unresolved = apply(wrap, cb_named_unresolved)
+
+            classify_unknown = apply(classify, cb_param_unknown)
+
+            classify_unresolved = apply(classify, cb_param_unresolved)
+
+            classify_string_unknown = apply(classify, cb_param_unknown_string)
+
+            classify_string_unresolved = apply(classify, cb_param_unresolved_string)
+            "#,
+        );
+
+        // The callback return is concrete, so `T` is inferred as `integer` and the generic
+        // overload is more informative than the `function -> boolean` fallback.
+        assert_eq!(ws.expr_ty("run_concrete"), ws.ty("integer"));
+
+        // `function` is an erased fallback. A structural `fun(): unknown` callback should keep
+        // the generic overload and preserve the unknown return.
+        assert_eq!(ws.expr_ty("run_unknown"), ws.ty("unknown"));
+
+        // An unresolved closure return is treated the same as an explicit `unknown` return.
+        assert_eq!(ws.expr_ty("run_unresolved"), ws.ty("unknown"));
+
+        // The named-callback path should stay aligned with the inline unresolved callback case.
+        assert_eq!(ws.expr_ty("run_named_unresolved"), ws.ty("unknown"));
+
+        // The structural overload still wins when the unknown is nested in the return shape.
+        assert_eq!(
+            ws.expr_ty("wrap_named_unresolved"),
+            ws.ty("{ value: unknown }")
+        );
+
+        // The callback's parameter type is known, so the generic `fun(x: integer): T` overload
+        // should still win even though the callback return is only `unknown`.
+        assert_eq!(ws.expr_ty("classify_unknown"), ws.ty("integer"));
+
+        // The callback return is unresolved, but its parameter is still `integer`, so overload
+        // ranking should keep using that known shape and pick the generic integer branch.
+        assert_eq!(ws.expr_ty("classify_unresolved"), ws.ty("integer"));
+
+        // The callback's parameter type is `string`, so overload selection should not fall back
+        // to the first generic branch when the callback return is only `unknown`.
+        assert_eq!(ws.expr_ty("classify_string_unknown"), ws.ty("string"));
+
+        // The same `string`-parameter branch should still win when the callback return is
+        // unresolved and carried through a named callback value.
+        assert_eq!(ws.expr_ty("classify_string_unresolved"), ws.ty("string"));
+    }
+
+    #[test]
+    fn test_apply_return_infer_leaves_result_unknown_when_no_callable_member_matches_arg_shape() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@generic A, R
+            ---@param f fun(x: A): R
+            ---@param x A
+            ---@return R
+            local function apply(f, x)
+                return f(x)
+            end
+
+            ---@alias FnInt fun(x: integer): integer
+            ---@alias FnString fun(x: string): string
+
+            ---@type FnInt | FnString
+            local run
+
+            ---@type boolean
+            local b
+
+            result = apply(run, b)
+            "#,
+        );
+
+        let result_ty = ws.expr_ty("result");
+        assert_eq!(result_ty, ws.ty("unknown"));
+    }
+
+    #[test]
+    fn test_apply_return_infer_uses_function_fallback_when_no_structural_overload_matches() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@generic A, R
+            ---@param f fun(x: A): R
+            ---@param x A
+            ---@return R
+            local function apply(f, x)
+                return f(x)
+            end
+
+            ---@param cb function
+            ---@return boolean
+            local function run(cb) end
+
+            ---@type fun(): unknown
+            local cb
+
+            result = apply(run, cb)
+            "#,
+        );
+
+        assert_eq!(ws.expr_ty("result"), ws.ty("boolean"));
+    }
+
+    #[test]
+    fn test_apply_return_infer_keeps_only_arity_compatible_fallbacks() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@generic A, B, R
+            ---@param f fun(x: A, y: B): R
+            ---@param x A
+            ---@param y B
+            ---@return R
+            local function apply2(f, x, y)
+                return f(x, y)
+            end
+
+            ---@overload fun(x: integer): integer
+            ---@param x integer
+            ---@param y string
+            ---@return string
+            local function run(x, y) end
+
+            local source ---@type table
+
+            result = apply2(run, 1, source.missing)
+            "#,
+        );
+
+        let result_ty = ws.expr_ty("result");
+        assert_eq!(ws.humanize_type(result_ty), "string");
+    }
+
+    #[test]
+    fn test_apply_return_infer_keeps_same_arity_overload_returns_when_tail_is_unknown() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@generic A, B, R
+            ---@param f fun(x: A, y: B): R
+            ---@param x A
+            ---@param y B
+            ---@return R
+            local function apply2(f, x, y)
+                return f(x, y)
+            end
+
+            ---@overload fun(x: integer, y: number): number
+            ---@param x integer
+            ---@param y string
+            ---@return string
+            local function run(x, y) end
+
+            local source ---@type table
+
+            result = apply2(run, 1, source.missing)
+            "#,
+        );
+
+        let result_ty = ws.expr_ty("result");
+        assert_eq!(result_ty, ws.ty("number|string"));
+    }
+
+    #[test]
+    fn test_apply_return_infer_keeps_unknown_return_when_arg_shape_is_unknown() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@generic A, R
+            ---@param f fun(x: A): R
+            ---@param x A
+            ---@return R
+            local function apply(f, x)
+                return f(x)
+            end
+
+            ---@overload fun(x: integer): unknown
+            ---@param x string
+            ---@return string
+            local function run(x) end
+
+            local source ---@type table
+
+            result = apply(run, source.missing)
+            "#,
+        );
+
+        let result_ty = ws.expr_ty("result");
+        assert_eq!(result_ty, ws.ty("unknown|string"));
+    }
+
+    #[test]
+    fn test_union_call_ignores_non_matching_generic_callable_member() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@type (fun<T: string>(x: T): T) | fun(x: integer): integer
+            local run
+
+            result = run(1)
+            "#,
+        );
+
+        let result_ty = ws.expr_ty("result");
+        assert_eq!(ws.humanize_type(result_ty), "integer");
+    }
+
+    #[test]
+    fn test_union_call_ignores_non_matching_generic_alias_member() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@alias GenericStr<T: string> fun(x: T): T
+
+            ---@type GenericStr | fun(x: integer): integer
+            local run
+
+            result = run(1)
+            "#,
+        );
+
+        let result_ty = ws.expr_ty("result");
+        assert_eq!(ws.humanize_type(result_ty), "integer");
+    }
+
+    #[test]
+    fn test_direct_callable_union_unions_same_domain_returns() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@alias FnA fun(x: integer): integer
+            ---@alias FnB fun(x: integer): boolean
+
+            ---@type FnA | FnB
+            local run
+
+            result = run(1)
+            "#,
+        );
+
+        assert_eq!(ws.expr_ty("result"), ws.ty("integer|boolean"));
+    }
+
+    #[test]
+    fn test_plain_function_call_returns_unknown_values() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@type function
+            local f
+
+            a, b = f(1)
+            "#,
+        );
+
+        assert_eq!(ws.expr_ty("a"), ws.ty("unknown"));
+        assert_eq!(ws.expr_ty("b"), ws.ty("unknown"));
+    }
 }

--- a/crates/emmylua_code_analysis/src/compilation/test/pcall_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/pcall_test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod test {
-    use crate::{DiagnosticCode, VirtualWorkspace};
+    use crate::{DiagnosticCode, LuaType, VirtualWorkspace};
 
     const STACKED_PCALL_ALIAS_GUARDS: usize = 180;
 
@@ -234,5 +234,109 @@ mod test {
         assert_eq!(ws.humanize_type(outside), "(boolean|string)");
         assert_eq!(ws.humanize_type(success_result), "boolean");
         assert_eq!(ws.humanize_type(failure_result), "string");
+    }
+
+    #[test]
+    fn test_return_overload_unions_callable_union_members_with_same_domain() {
+        let mut ws = VirtualWorkspace::new_with_init_std_lib();
+
+        ws.def(
+            r#"
+        ---@alias FnA fun(x: integer): integer
+        ---@alias FnB fun(x: integer): boolean
+
+        ---@type FnA | FnB
+        local run
+
+        _, a = pcall(run, 1)
+        "#,
+        );
+
+        assert_eq!(
+            ws.expr_ty("a"),
+            LuaType::from_vec(vec![LuaType::Integer, LuaType::Boolean, LuaType::String])
+        );
+    }
+
+    #[test]
+    fn test_return_overload_callable_union_is_not_order_dependent() {
+        let mut ws = VirtualWorkspace::new_with_init_std_lib();
+
+        ws.def(
+            r#"
+        ---@alias FnA fun(x: integer): integer
+        ---@alias FnB fun(x: integer): boolean
+
+        ---@type FnB | FnA
+        local run
+
+        _, a = pcall(run, 1)
+        "#,
+        );
+
+        assert_eq!(
+            ws.expr_ty("a"),
+            LuaType::from_vec(vec![LuaType::Integer, LuaType::Boolean, LuaType::String])
+        );
+    }
+
+    #[test]
+    fn test_return_overload_unions_callable_intersection_members_with_same_domain() {
+        let mut ws = VirtualWorkspace::new_with_init_std_lib();
+
+        ws.def(
+            r#"
+        ---@alias FnA fun(x: integer): integer
+        ---@alias FnB fun(x: integer): boolean
+
+        ---@type FnA & FnB
+        local run
+
+        _, a = pcall(run, 1)
+        "#,
+        );
+
+        assert_eq!(
+            ws.expr_ty("a"),
+            LuaType::from_vec(vec![LuaType::Integer, LuaType::Boolean, LuaType::String])
+        );
+    }
+
+    #[test]
+    fn test_return_overload_narrows_callable_union_member_by_arg_shape() {
+        let mut ws = VirtualWorkspace::new_with_init_std_lib();
+
+        ws.def(
+            r#"
+        ---@alias FnA fun(x: integer): integer
+        ---@alias FnB fun(x: string): integer
+
+        ---@type FnA | FnB
+        local run
+
+        _, a = pcall(run, 1)
+        "#,
+        );
+
+        assert_eq!(ws.expr_ty("a"), ws.ty("integer|string"));
+    }
+
+    #[test]
+    fn test_return_overload_narrows_callable_intersection_member_by_arg_shape() {
+        let mut ws = VirtualWorkspace::new_with_init_std_lib();
+
+        ws.def(
+            r#"
+        ---@alias FnA fun(x: integer): integer
+        ---@alias FnB fun(x: string): boolean
+
+        ---@type FnA & FnB
+        local run
+
+        _, a = pcall(run, 1)
+        "#,
+        );
+
+        assert_eq!(ws.expr_ty("a"), ws.ty("integer|string"));
     }
 }

--- a/crates/emmylua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
+++ b/crates/emmylua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
@@ -7,7 +7,7 @@ use std::{ops::Deref, sync::Arc};
 use crate::semantic::infer::infer_expr_list_types;
 use crate::{
     DocTypeInferContext, FileId, GenericTpl, GenericTplId, LuaFunctionType, LuaGenericType,
-    LuaTypeNode,
+    LuaTypeNode, TypeVisitTrait,
     db_index::{DbIndex, LuaType},
     infer_doc_type,
     semantic::{
@@ -22,14 +22,15 @@ use crate::{
         },
         infer::InferFailReason,
         infer_expr,
+        overload_resolve::{callable_accepts_args, resolve_signature_by_args},
     },
 };
 use crate::{
     LuaMemberOwner, LuaSemanticDeclId, SemanticDeclLevel, infer_node_semantic_decl,
-    tpl_pattern_match_args,
+    tpl_pattern_match_args_skip_unknown,
 };
 
-use super::TypeSubstitutor;
+use super::{TypeSubstitutor, collect_callable_overload_groups};
 
 pub fn instantiate_func_generic(
     db: &DbIndex,
@@ -119,16 +120,80 @@ pub fn as_doc_function_type(
     })
 }
 
-fn infer_return_from_callable(
-    db: &DbIndex,
-    callable: &Arc<LuaFunctionType>,
-    substitutor: &TypeSubstitutor,
-) -> LuaType {
-    let instantiated = instantiate_doc_function(db, callable, substitutor);
-    match instantiated {
-        LuaType::DocFunction(func) => func.get_ret().clone(),
-        _ => callable.get_ret().clone(),
+fn infer_callable_return_from_arg_types(
+    context: &mut TplContext,
+    callable_type: &LuaType,
+    call_arg_types: &[LuaType],
+) -> Result<Option<LuaType>, InferFailReason> {
+    let mut overload_groups = Vec::new();
+    collect_callable_overload_groups(context.db, callable_type, &mut overload_groups)?;
+    if overload_groups.is_empty() {
+        return Ok(None);
     }
+
+    let mut member_returns = Vec::new();
+    for overloads in &overload_groups {
+        let instantiated_overloads = overloads
+            .iter()
+            .filter_map(|callable| {
+                instantiate_callable_from_arg_types(context, callable, call_arg_types)
+            })
+            .collect::<Vec<_>>();
+        if instantiated_overloads.is_empty() {
+            continue;
+        }
+
+        let structural_overloads = instantiated_overloads
+            .iter()
+            .filter(|callable| !uses_erased_function_param(callable, call_arg_types))
+            .cloned()
+            .collect::<Vec<_>>();
+        let overloads_to_resolve = if structural_overloads.is_empty() {
+            &instantiated_overloads
+        } else {
+            &structural_overloads
+        };
+
+        let unresolved_arg_match = overloads_to_resolve.len() > 1
+            && call_arg_types
+                .iter()
+                .any(|arg_type| arg_type.is_any() || arg_type.is_unknown());
+        if unresolved_arg_match {
+            member_returns.push(LuaType::from_vec(
+                overloads_to_resolve
+                    .iter()
+                    .map(|callable| callable.get_ret().clone())
+                    .collect(),
+            ));
+            continue;
+        }
+
+        let callable = resolve_signature_by_args(
+            context.db,
+            overloads_to_resolve,
+            call_arg_types,
+            false,
+            None,
+        );
+        member_returns.push(callable?.get_ret().clone());
+    }
+    if member_returns.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(LuaType::from_vec(member_returns)))
+}
+
+fn uses_erased_function_param(callable: &LuaFunctionType, call_arg_types: &[LuaType]) -> bool {
+    callable
+        .get_params()
+        .iter()
+        .zip(call_arg_types)
+        .any(|((_, param_type), arg_type)| {
+            matches!(param_type, Some(LuaType::Function))
+                && arg_type
+                    .any_type(|ty| matches!(ty, LuaType::DocFunction(_) | LuaType::Signature(_)))
+        })
 }
 
 pub fn infer_callable_return_from_remaining_args(
@@ -140,9 +205,35 @@ pub fn infer_callable_return_from_remaining_args(
         return Ok(None);
     }
 
-    let Some(callable) = as_doc_function_type(context.db, callable_type)? else {
+    let call_arg_types =
+        match infer_expr_list_types(context.db, context.cache, arg_exprs, None, infer_expr) {
+            Ok(types) => types.into_iter().map(|(ty, _)| ty).collect::<Vec<_>>(),
+            Err(_) => arg_exprs
+                .iter()
+                .map(|arg_expr| {
+                    infer_expr(context.db, context.cache, arg_expr.clone())
+                        .unwrap_or(LuaType::Unknown)
+                })
+                .collect::<Vec<_>>(),
+        };
+    if call_arg_types.is_empty() {
         return Ok(None);
-    };
+    }
+
+    // Preserve any known remaining-arg shape, including arity, even when some later arguments
+    // collapse to `unknown`. This avoids unioning returns from overloads that are impossible
+    // for the current call.
+    infer_callable_return_from_arg_types(context, callable_type, &call_arg_types)
+}
+
+fn instantiate_callable_from_arg_types(
+    context: &mut TplContext,
+    callable: &Arc<LuaFunctionType>,
+    call_arg_types: &[LuaType],
+) -> Option<Arc<LuaFunctionType>> {
+    if !callable_accepts_args(context.db, callable, call_arg_types, false, None) {
+        return None;
+    }
 
     let mut callable_tpls = HashSet::new();
     callable.visit_nested_types(&mut |ty| {
@@ -151,20 +242,7 @@ pub fn infer_callable_return_from_remaining_args(
         }
     });
     if callable_tpls.is_empty() {
-        return Ok(Some(callable.get_ret().clone()));
-    }
-
-    let mut callable_substitutor = TypeSubstitutor::new();
-    callable_substitutor.add_need_infer_tpls(callable_tpls);
-    let fallback_return = infer_return_from_callable(context.db, &callable, &callable_substitutor);
-
-    let call_arg_types =
-        match infer_expr_list_types(context.db, context.cache, arg_exprs, None, infer_expr) {
-            Ok(types) => types.into_iter().map(|(ty, _)| ty).collect::<Vec<_>>(),
-            Err(_) => return Ok(Some(fallback_return)),
-        };
-    if call_arg_types.is_empty() {
-        return Ok(None);
+        return Some(callable.clone());
     }
 
     let callable_param_types = callable
@@ -172,28 +250,112 @@ pub fn infer_callable_return_from_remaining_args(
         .iter()
         .map(|(_, ty)| ty.clone().unwrap_or(LuaType::Unknown))
         .collect::<Vec<_>>();
-
+    let mut callable_substitutor = TypeSubstitutor::new();
+    callable_substitutor.add_need_infer_tpls(callable_tpls.clone());
     let mut callable_context = TplContext {
         db: context.db,
         cache: context.cache,
         substitutor: &mut callable_substitutor,
         call_expr: context.call_expr.clone(),
     };
-    if tpl_pattern_match_args(
+    if tpl_pattern_match_args_skip_unknown(
         &mut callable_context,
         &callable_param_types,
-        &call_arg_types,
+        call_arg_types,
     )
     .is_err()
     {
-        return Ok(Some(fallback_return));
+        return None;
     }
 
-    Ok(Some(infer_return_from_callable(
+    let instantiated = match instantiate_doc_function(context.db, callable, &callable_substitutor) {
+        LuaType::DocFunction(func) => func,
+        _ => callable.clone(),
+    };
+    let unresolved_return_tpls = {
+        let mut tpl_ids = HashSet::new();
+        instantiated.get_ret().visit_type(&mut |ty| {
+            if let LuaType::TplRef(generic_tpl) | LuaType::ConstTplRef(generic_tpl) = ty
+                && callable_tpls.contains(&generic_tpl.get_tpl_id())
+            {
+                tpl_ids.insert(generic_tpl.get_tpl_id());
+            }
+        });
+        if tpl_ids.is_empty() {
+            return Some(instantiated);
+        }
+        tpl_ids
+    };
+
+    let callback_return_tpls = collect_callback_return_tpls(
         context.db,
-        &callable,
-        &callable_substitutor,
-    )))
+        &callable_param_types,
+        call_arg_types,
+        &unresolved_return_tpls,
+    );
+    if callback_return_tpls != unresolved_return_tpls {
+        return None;
+    }
+
+    for tpl_id in callback_return_tpls {
+        callable_substitutor.insert_type(tpl_id, LuaType::Unknown, true);
+    }
+    match instantiate_doc_function(context.db, callable, &callable_substitutor) {
+        LuaType::DocFunction(func) => Some(func),
+        _ => None,
+    }
+}
+
+/// Finds callback return templates that are unresolved for this call.
+///
+/// ```lua
+/// ---@generic A, R
+/// ---@param f fun(x: A): R
+/// ---@param x A
+/// ---@return R
+/// local function apply(f, x) end
+///
+/// ---@type table
+/// local source
+/// apply(function(x) return source.missing end, 1)
+/// ```
+///
+/// In this call, the callback return is unresolved, so this returns `R` from
+/// the `f` parameter.
+fn collect_callback_return_tpls(
+    db: &DbIndex,
+    callable_param_types: &[LuaType],
+    call_arg_types: &[LuaType],
+    unresolved_return_tpls: &HashSet<GenericTplId>,
+) -> HashSet<GenericTplId> {
+    let mut callback_return_tpls = HashSet::new();
+    for (param_type, arg_type) in callable_param_types.iter().zip(call_arg_types) {
+        let arg_return_unresolved = arg_type.any_type(|ty| {
+            let LuaType::Signature(signature_id) = ty else {
+                return false;
+            };
+            db.get_signature_index()
+                .get(signature_id)
+                .is_some_and(|signature| !signature.is_resolve_return())
+        });
+        if !arg_return_unresolved {
+            continue;
+        }
+
+        let Ok(Some(param_func)) = as_doc_function_type(db, param_type) else {
+            continue;
+        };
+        param_func.get_ret().visit_type(&mut |ty| {
+            if let LuaType::TplRef(generic_tpl) | LuaType::ConstTplRef(generic_tpl) = ty {
+                let tpl_id = generic_tpl.get_tpl_id();
+                if unresolved_return_tpls.contains(&tpl_id) {
+                    callback_return_tpls.insert(tpl_id);
+                }
+            }
+        });
+    }
+
+    callback_return_tpls
 }
 
 fn collect_func_tpl_ids(func: &LuaFunctionType) -> (HashSet<GenericTplId>, bool) {

--- a/crates/emmylua_code_analysis/src/semantic/generic/instantiate_type/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/generic/instantiate_type/mod.rs
@@ -2,7 +2,7 @@ mod instantiate_func_generic;
 mod instantiate_special_generic;
 
 use hashbrown::{HashMap, HashSet};
-use std::ops::Deref;
+use std::{ops::Deref, sync::Arc};
 
 use crate::{
     DbIndex, GenericTpl, GenericTplId, LuaAliasCallKind, LuaArrayType, LuaConditionalType,
@@ -12,7 +12,10 @@ use crate::{
         LuaFunctionType, LuaGenericType, LuaIntersectionType, LuaObjectType, LuaTupleType, LuaType,
         LuaUnionType, VariadicType,
     },
-    semantic::type_check::{TypeCheckCheckLevel, check_type_compact_with_level},
+    semantic::{
+        infer::InferFailReason,
+        type_check::{TypeCheckCheckLevel, check_type_compact_with_level},
+    },
 };
 
 use super::type_substitutor::{SubstitutorValue, TypeSubstitutor};
@@ -21,6 +24,84 @@ use crate::semantic::member::find_members_with_key;
 pub use instantiate_func_generic::{build_self_type, infer_self_type, instantiate_func_generic};
 pub use instantiate_special_generic::get_keyof_members;
 pub use instantiate_special_generic::instantiate_alias_call;
+
+pub(crate) fn collect_callable_overload_groups(
+    db: &DbIndex,
+    callable_type: &LuaType,
+    groups: &mut Vec<Vec<Arc<LuaFunctionType>>>,
+) -> Result<(), InferFailReason> {
+    let mut visiting_aliases = HashSet::new();
+    collect_callable_overload_groups_inner(db, callable_type, groups, &mut visiting_aliases)
+}
+
+fn collect_callable_overload_groups_inner(
+    db: &DbIndex,
+    callable_type: &LuaType,
+    groups: &mut Vec<Vec<Arc<LuaFunctionType>>>,
+    visiting_aliases: &mut HashSet<LuaTypeDeclId>,
+) -> Result<(), InferFailReason> {
+    match callable_type {
+        LuaType::Ref(type_id) | LuaType::Def(type_id) => {
+            let Some(type_decl) = db.get_type_index().get_type_decl(type_id) else {
+                return Ok(());
+            };
+            if !visiting_aliases.insert(type_id.clone()) {
+                return Ok(());
+            }
+
+            let result = if let Some(origin_type) = type_decl.get_alias_origin(db, None) {
+                collect_callable_overload_groups_inner(db, &origin_type, groups, visiting_aliases)
+            } else {
+                Ok(())
+            };
+            visiting_aliases.remove(type_id);
+            result?;
+        }
+        LuaType::Generic(generic) => {
+            let type_id = generic.get_base_type_id();
+            if !visiting_aliases.insert(type_id.clone()) {
+                return Ok(());
+            }
+            let substitutor = TypeSubstitutor::from_type_array(generic.get_params().to_vec());
+            let Some(type_decl) = db.get_type_index().get_type_decl(&type_id) else {
+                visiting_aliases.remove(&type_id);
+                return Ok(());
+            };
+
+            let result = if let Some(origin_type) =
+                type_decl.get_alias_origin(db, Some(&substitutor))
+            {
+                collect_callable_overload_groups_inner(db, &origin_type, groups, visiting_aliases)
+            } else {
+                Ok(())
+            };
+            visiting_aliases.remove(&type_id);
+            result?;
+        }
+        LuaType::Union(union) => {
+            for member in union.into_vec() {
+                collect_callable_overload_groups_inner(db, &member, groups, visiting_aliases)?;
+            }
+        }
+        LuaType::Intersection(intersection) => {
+            for member in intersection.get_types() {
+                collect_callable_overload_groups_inner(db, member, groups, visiting_aliases)?;
+            }
+        }
+        LuaType::DocFunction(doc_func) => groups.push(vec![doc_func.clone()]),
+        LuaType::Signature(sig_id) => {
+            let Some(signature) = db.get_signature_index().get(sig_id) else {
+                return Ok(());
+            };
+            let mut overloads = signature.overloads.to_vec();
+            overloads.push(signature.to_doc_func_type());
+            groups.push(overloads);
+        }
+        _ => {}
+    }
+
+    Ok(())
+}
 
 pub fn instantiate_type_generic(
     db: &DbIndex,

--- a/crates/emmylua_code_analysis/src/semantic/generic/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/generic/mod.rs
@@ -10,10 +10,12 @@ pub use call_constraint::{
 };
 use emmylua_parser::LuaAstNode;
 use emmylua_parser::LuaExpr;
+pub(crate) use instantiate_type::collect_callable_overload_groups;
 pub use instantiate_type::*;
 use rowan::NodeOrToken;
 pub use tpl_context::TplContext;
 pub use tpl_pattern::tpl_pattern_match_args;
+pub use tpl_pattern::tpl_pattern_match_args_skip_unknown;
 pub use type_substitutor::TypeSubstitutor;
 
 use crate::DbIndex;

--- a/crates/emmylua_code_analysis/src/semantic/generic/tpl_pattern/lambda_tpl_pattern.rs
+++ b/crates/emmylua_code_analysis/src/semantic/generic/tpl_pattern/lambda_tpl_pattern.rs
@@ -1,25 +1,22 @@
-use emmylua_parser::LuaAstNode;
-
 use crate::{
-    InferFailReason, LuaFunctionType, LuaSignatureId, TplContext,
+    InferFailReason, LuaSignatureId, LuaType, TplContext, infer_expr,
     semantic::generic::tpl_pattern::TplPatternMatchResult,
 };
 
 pub fn check_lambda_tpl_pattern(
     context: &mut TplContext,
-    _tpl_func: &LuaFunctionType,
     signature_id: LuaSignatureId,
 ) -> TplPatternMatchResult {
     let call_expr = context.call_expr.clone().ok_or(InferFailReason::None)?;
     let call_arg_list = call_expr.get_args_list().ok_or(InferFailReason::None)?;
-    let closure_position = signature_id.get_position();
-    let closure_expr = call_arg_list
-        .get_args()
-        .find(|arg| arg.get_position() == closure_position);
-
-    if closure_expr.is_none() {
-        return Err(InferFailReason::UnResolveSignatureReturn(signature_id));
+    for arg in call_arg_list.get_args() {
+        if let Ok(LuaType::Signature(arg_signature_id)) =
+            infer_expr(context.db, context.cache, arg.clone())
+            && arg_signature_id == signature_id
+        {
+            return Ok(());
+        }
     }
 
-    Ok(())
+    Err(InferFailReason::UnResolveSignatureReturn(signature_id))
 }

--- a/crates/emmylua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
@@ -33,6 +33,23 @@ pub fn tpl_pattern_match_args(
     func_param_types: &[LuaType],
     call_arg_types: &[LuaType],
 ) -> TplPatternMatchResult {
+    tpl_pattern_match_args_inner(context, func_param_types, call_arg_types, false)
+}
+
+pub fn tpl_pattern_match_args_skip_unknown(
+    context: &mut TplContext,
+    func_param_types: &[LuaType],
+    call_arg_types: &[LuaType],
+) -> TplPatternMatchResult {
+    tpl_pattern_match_args_inner(context, func_param_types, call_arg_types, true)
+}
+
+fn tpl_pattern_match_args_inner(
+    context: &mut TplContext,
+    func_param_types: &[LuaType],
+    call_arg_types: &[LuaType],
+    skip_unknown_tpl: bool,
+) -> TplPatternMatchResult {
     for i in 0..func_param_types.len() {
         if i >= call_arg_types.len() {
             break;
@@ -54,6 +71,9 @@ pub fn tpl_pattern_match_args(
                 )?;
                 break;
             }
+            _ if skip_unknown_tpl
+                && func_param_type.contain_tpl()
+                && (call_arg_type.is_any() || call_arg_type.is_unknown()) => {}
             _ => {
                 tpl_pattern_match(context, func_param_type, call_arg_type)?;
             }

--- a/crates/emmylua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
@@ -591,11 +591,7 @@ fn func_tpl_pattern_match(
                 .get(signature_id)
                 .ok_or(InferFailReason::None)?;
             if !signature.is_resolve_return() {
-                return lambda_tpl_pattern::check_lambda_tpl_pattern(
-                    context,
-                    tpl_func,
-                    *signature_id,
-                );
+                return lambda_tpl_pattern::check_lambda_tpl_pattern(context, *signature_id);
             }
             let fake_doc_func = signature.to_doc_func_type();
             func_tpl_pattern_match_doc_func(context, tpl_func, &fake_doc_func)?;

--- a/crates/emmylua_code_analysis/src/semantic/infer/infer_call/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/infer_call/mod.rs
@@ -1,21 +1,26 @@
 use std::sync::Arc;
 
 use emmylua_parser::{LuaAstNode, LuaCallExpr, LuaExpr, LuaSyntaxKind};
+use hashbrown::HashSet;
 use rowan::TextRange;
 
 use super::{
     super::{InferGuard, LuaInferCache, instantiate_type_generic, resolve_signature},
     InferFailReason, InferResult,
 };
+use crate::semantic::overload_resolve::callable_accepts_args;
 use crate::{
     CacheEntry, DbIndex, InFiled, LuaFunctionType, LuaGenericType, LuaInstanceType,
     LuaIntersectionType, LuaOperatorMetaMethod, LuaOperatorOwner, LuaSignature, LuaSignatureId,
-    LuaType, LuaTypeDeclId, LuaUnionType, TypeVisitTrait,
+    LuaType, LuaTypeDeclId, LuaUnionType, TypeVisitTrait, VariadicType,
 };
 use crate::{
     InferGuardRef,
     semantic::{
-        generic::{TypeSubstitutor, get_tpl_ref_extend_type, instantiate_doc_function},
+        generic::{
+            TypeSubstitutor, collect_callable_overload_groups, get_tpl_ref_extend_type,
+            instantiate_doc_function,
+        },
         infer::narrow::get_type_at_call_expr_inline_cast,
     },
 };
@@ -89,6 +94,13 @@ pub fn infer_call_expr_func(
             infer_guard,
             args_count,
         ),
+        LuaType::Function => Ok(Arc::new(LuaFunctionType::new(
+            crate::AsyncState::None,
+            false,
+            true,
+            vec![("...".to_string(), Some(LuaType::Unknown))],
+            LuaType::Variadic(VariadicType::Base(LuaType::Unknown).into()),
+        ))),
         LuaType::Intersection(intersection) => infer_intersection(
             db,
             cache,
@@ -97,18 +109,7 @@ pub fn infer_call_expr_func(
             infer_guard,
             args_count,
         ),
-        LuaType::Union(union) => {
-            // 此时我们将其视为泛型实例化联合体
-            if union
-                .into_vec()
-                .iter()
-                .all(|t| matches!(t, LuaType::DocFunction(_)))
-            {
-                infer_generic_doc_function_union(db, cache, union, call_expr.clone(), args_count)
-            } else {
-                infer_union(db, cache, union, call_expr.clone(), args_count)
-            }
-        }
+        LuaType::Union(union) => infer_union(db, cache, union, call_expr.clone(), args_count),
         _ => Err(InferFailReason::None),
     };
 
@@ -191,23 +192,60 @@ fn infer_doc_function(
     Ok(func.clone().into())
 }
 
-fn infer_generic_doc_function_union(
+fn filter_callable_overloads_by_call_args(
     db: &DbIndex,
     cache: &mut LuaInferCache,
-    union: &LuaUnionType,
-    call_expr: LuaCallExpr,
+    overloads: Vec<Arc<LuaFunctionType>>,
+    call_expr: &LuaCallExpr,
     args_count: Option<usize>,
-) -> InferCallFuncResult {
-    let overloads = union
-        .into_vec()
-        .iter()
-        .filter_map(|typ| match typ {
-            LuaType::DocFunction(f) => Some(f.clone()),
-            _ => None,
-        })
-        .collect::<Vec<_>>();
+    strict_arg_filter: bool,
+) -> Result<Vec<Arc<LuaFunctionType>>, InferFailReason> {
+    let args = call_expr.get_args_list().ok_or(InferFailReason::None)?;
+    let expr_types = super::infer_expr_list_types(
+        db,
+        cache,
+        &args.get_args().collect::<Vec<_>>(),
+        args_count,
+        |db, cache, expr| Ok(infer_expr(db, cache, expr).unwrap_or(LuaType::Unknown)),
+    )?
+    .into_iter()
+    .map(|(ty, _)| ty)
+    .collect::<Vec<_>>();
+    let is_colon_call = call_expr.is_colon_call();
 
-    resolve_signature(db, cache, overloads, call_expr.clone(), false, args_count)
+    Ok(overloads
+        .into_iter()
+        .filter(|func| {
+            let mut callable_tpls = HashSet::new();
+            func.visit_type(&mut |ty| match ty {
+                LuaType::TplRef(generic_tpl) | LuaType::ConstTplRef(generic_tpl) => {
+                    callable_tpls.insert(generic_tpl.get_tpl_id());
+                }
+                LuaType::StrTplRef(str_tpl) => {
+                    callable_tpls.insert(str_tpl.get_tpl_id());
+                }
+                _ => {}
+            });
+
+            if callable_tpls.is_empty() && !strict_arg_filter {
+                return true;
+            }
+
+            let has_tpls = !callable_tpls.is_empty();
+            let mut substitutor = TypeSubstitutor::new();
+            substitutor.add_need_infer_tpls(callable_tpls);
+            let match_func = if has_tpls {
+                match instantiate_doc_function(db, func, &substitutor) {
+                    LuaType::DocFunction(doc_func) => doc_func,
+                    _ => func.clone(),
+                }
+            } else {
+                func.clone()
+            };
+
+            callable_accepts_args(db, &match_func, &expr_types, is_colon_call, args_count)
+        })
+        .collect())
 }
 
 fn infer_signature_doc_function(
@@ -225,40 +263,11 @@ fn infer_signature_doc_function(
         return Err(InferFailReason::UnResolveSignatureReturn(signature_id));
     }
     let is_generic = signature_is_generic(db, cache, &signature, &call_expr).unwrap_or(false);
-    let overloads = &signature.overloads;
-    if overloads.is_empty() {
-        let mut fake_doc_function = LuaFunctionType::new(
-            signature.async_state,
-            signature.is_colon_define,
-            signature.is_vararg,
-            signature.get_type_params(),
-            signature.get_return_type(),
-        );
-        if is_generic {
-            fake_doc_function = instantiate_func_generic(db, cache, &fake_doc_function, call_expr)?;
-        }
+    let mut overload_groups = Vec::new();
+    collect_callable_overload_groups(db, &LuaType::Signature(signature_id), &mut overload_groups)?;
+    let overloads = overload_groups.into_iter().flatten().collect::<Vec<_>>();
 
-        Ok(fake_doc_function.into())
-    } else {
-        let mut new_overloads = signature.overloads.clone();
-        let fake_doc_function = Arc::new(LuaFunctionType::new(
-            signature.async_state,
-            signature.is_colon_define,
-            signature.is_vararg,
-            signature.get_type_params(),
-            signature.get_return_type(),
-        ));
-        new_overloads.push(fake_doc_function);
-
-        resolve_signature(
-            db,
-            cache,
-            new_overloads,
-            call_expr.clone(),
-            is_generic,
-            args_count,
-        )
-    }
+    resolve_signature(db, cache, overloads, call_expr, is_generic, args_count)
 }
 
 fn infer_type_doc_function(
@@ -485,74 +494,87 @@ fn infer_union(
     call_expr: LuaCallExpr,
     args_count: Option<usize>,
 ) -> InferCallFuncResult {
-    // 此时一般是 signature + doc_function 的联合体
-    let mut all_overloads = Vec::new();
-    let mut base_signatures = Vec::new();
+    let mut returns = Vec::new();
+    let mut first_func = None;
+    let mut fallback_overloads = Vec::new();
+    let mut need_resolve = None;
 
     for ty in union.into_vec() {
-        match ty {
-            LuaType::Signature(signature_id) => {
-                if let Some(signature) = db.get_signature_index().get(&signature_id) {
-                    // 处理 overloads
-                    let overloads = if signature.is_generic() {
-                        signature
-                            .overloads
-                            .iter()
-                            .map(|func| {
-                                Ok(Arc::new(instantiate_func_generic(
-                                    db,
-                                    cache,
-                                    func,
-                                    call_expr.clone(),
-                                )?))
-                            })
-                            .collect::<Result<Vec<_>, _>>()?
-                    } else {
-                        signature.overloads.clone()
-                    };
-                    all_overloads.extend(overloads);
+        let mut overload_groups = Vec::new();
+        collect_callable_overload_groups(db, &ty, &mut overload_groups)?;
+        for overloads in overload_groups {
+            let compatible_overloads = filter_callable_overloads_by_call_args(
+                db,
+                cache,
+                overloads.clone(),
+                &call_expr,
+                args_count,
+                true,
+            )?;
+            if compatible_overloads.is_empty() {
+                fallback_overloads.extend(overloads);
+                continue;
+            }
 
-                    // 处理 signature 本身的函数类型
-                    let mut fake_doc_function = LuaFunctionType::new(
-                        signature.async_state,
-                        signature.is_colon_define,
-                        signature.is_vararg,
-                        signature.get_type_params(),
-                        signature.get_return_type(),
-                    );
-                    if signature.is_generic() {
-                        fake_doc_function = instantiate_func_generic(
-                            db,
-                            cache,
-                            &fake_doc_function,
-                            call_expr.clone(),
-                        )?;
+            let contains_tpl = compatible_overloads.iter().any(|func| func.contain_tpl());
+            match resolve_signature(
+                db,
+                cache,
+                compatible_overloads,
+                call_expr.clone(),
+                contains_tpl,
+                args_count,
+            ) {
+                Ok(func) => {
+                    returns.push(func.get_ret().clone());
+                    if first_func.is_none() {
+                        first_func = Some(func);
                     }
-                    base_signatures.push(Arc::new(fake_doc_function));
                 }
+                Err(InferFailReason::RecursiveInfer) => {
+                    return Err(InferFailReason::RecursiveInfer);
+                }
+                Err(reason) if reason.is_need_resolve() => {
+                    if need_resolve.is_none() {
+                        need_resolve = Some(reason);
+                    }
+                }
+                Err(_) => {}
             }
-            LuaType::DocFunction(func) => {
-                let func_to_push = if func.contain_tpl() {
-                    Arc::new(instantiate_func_generic(
-                        db,
-                        cache,
-                        &func,
-                        call_expr.clone(),
-                    )?)
-                } else {
-                    func.clone()
-                };
-                base_signatures.push(func_to_push);
-            }
-            _ => {}
         }
     }
 
-    all_overloads.extend(base_signatures);
-    if all_overloads.is_empty() {
-        return Err(InferFailReason::None);
-    }
-    resolve_signature(db, cache, all_overloads, call_expr, false, args_count)
+    let Some(first_func) = first_func else {
+        if !fallback_overloads.is_empty() {
+            let contains_tpl = fallback_overloads.iter().any(|func| func.contain_tpl());
+            let fallback_overloads = filter_callable_overloads_by_call_args(
+                db,
+                cache,
+                fallback_overloads,
+                &call_expr,
+                args_count,
+                false,
+            )?;
+            return resolve_signature(
+                db,
+                cache,
+                fallback_overloads,
+                call_expr,
+                contains_tpl,
+                args_count,
+            );
+        }
+
+        return Err(need_resolve.unwrap_or(InferFailReason::None));
+    };
+
+    Ok(Arc::new(LuaFunctionType::new(
+        first_func.get_async_state(),
+        first_func.is_colon_define(),
+        first_func.is_variadic(),
+        first_func.get_params().to_vec(),
+        LuaType::from_vec(returns),
+    )))
 }
 
 fn infer_intersection(
@@ -840,5 +862,36 @@ mod tests {
 
         assert_eq!(ws.expr_ty("ok"), ws.ty("boolean"));
         assert_eq!(ws.expr_ty("payload"), ws.ty("string"));
+    }
+
+    #[test]
+    fn test_union_call_ignores_unresolved_alias_member() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@type MissingAlias | fun(): integer
+            local run
+
+            result = run()
+            "#,
+        );
+
+        assert_eq!(ws.expr_ty("result"), ws.ty("integer"));
+    }
+
+    #[test]
+    fn test_union_call_breaks_recursive_alias_cycle() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@alias A A | fun(): integer
+            ---@type A
+            local run
+
+            result = run()
+            "#,
+        );
+
+        assert_eq!(ws.expr_ty("result"), ws.ty("integer"));
     }
 }

--- a/crates/emmylua_code_analysis/src/semantic/overload_resolve/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/overload_resolve/mod.rs
@@ -16,7 +16,7 @@ use super::{
     infer::{InferCallFuncResult, InferFailReason},
 };
 
-use resolve_signature_by_args::resolve_signature_by_args;
+pub(crate) use resolve_signature_by_args::{callable_accepts_args, resolve_signature_by_args};
 
 pub fn resolve_signature(
     db: &DbIndex,

--- a/crates/emmylua_code_analysis/src/semantic/overload_resolve/resolve_signature_by_args.rs
+++ b/crates/emmylua_code_analysis/src/semantic/overload_resolve/resolve_signature_by_args.rs
@@ -6,6 +6,33 @@ use crate::{
     semantic::infer::InferCallFuncResult,
 };
 
+pub(crate) fn callable_accepts_args(
+    db: &DbIndex,
+    func: &LuaFunctionType,
+    expr_types: &[LuaType],
+    is_colon_call: bool,
+    arg_count: Option<usize>,
+) -> bool {
+    let arg_count = arg_count.unwrap_or(expr_types.len());
+    if func.get_params().len() < arg_count && !is_func_last_param_variadic(func) {
+        return false;
+    }
+
+    for (arg_index, expr_type) in expr_types.iter().enumerate() {
+        let param_type = match get_call_arg_param(func, arg_index, is_colon_call) {
+            CallArgParam::Skip => continue,
+            CallArgParam::Present { param_type, .. } => param_type,
+            CallArgParam::Missing => return false,
+        };
+
+        if !param_type.is_any() && check_type_compact(db, &param_type, expr_type).is_err() {
+            return false;
+        }
+    }
+
+    true
+}
+
 pub fn resolve_signature_by_args(
     db: &DbIndex,
     overloads: &[Arc<LuaFunctionType>],
@@ -43,41 +70,22 @@ pub fn resolve_signature_by_args(
                 None => continue,
                 Some(func) => func,
             };
-            let param_len = func.get_params().len();
-            if param_len < arg_count && !is_func_last_param_variadic(func) {
+            if func.get_params().len() < arg_count && !is_func_last_param_variadic(func) {
                 *opt_func = None;
                 continue;
             }
 
-            let colon_define = func.is_colon_define();
-            let mut param_index = arg_index;
-            match (colon_define, is_colon_call) {
-                (true, false) => {
-                    if param_index == 0 {
-                        continue;
-                    }
-                    param_index -= 1;
-                }
-                (false, true) => {
-                    param_index += 1;
-                }
-                _ => {}
-            }
-            let param_type = if param_index < param_len {
-                let param_info = func.get_params().get(param_index);
-                param_info
-                    .map(|it| it.1.clone().unwrap_or(LuaType::Any))
-                    .unwrap_or(LuaType::Any)
-            } else if let Some(last_param_info) = func.get_params().last() {
-                if last_param_info.0 == "..." {
-                    last_param_info.1.clone().unwrap_or(LuaType::Any)
-                } else {
+            let (param_index, param_type) = match get_call_arg_param(func, arg_index, is_colon_call)
+            {
+                CallArgParam::Skip => continue,
+                CallArgParam::Present {
+                    param_index,
+                    param_type,
+                } => (param_index, param_type),
+                CallArgParam::Missing => {
                     *opt_func = None;
                     continue;
                 }
-            } else {
-                *opt_func = None;
-                continue;
             };
 
             let match_result = if param_type.is_any() {
@@ -144,35 +152,15 @@ pub fn resolve_signature_by_args(
                 None => continue,
                 Some(func) => func,
             };
-            let param_len = func.get_params().len();
-            let colon_define = func.is_colon_define();
-            let mut param_index = param_index;
-            match (colon_define, is_colon_call) {
-                (true, false) => {
-                    if param_index == 0 {
-                        continue;
-                    }
-                    param_index -= 1;
-                }
-                (false, true) => {
-                    param_index += 1;
-                }
-                _ => {}
-            }
-            let param_type = if param_index < param_len {
-                let param_info = func.get_params().get(param_index);
-                param_info
-                    .map(|it| it.1.clone().unwrap_or(LuaType::Any))
-                    .unwrap_or(LuaType::Any)
-            } else if let Some(last_param_info) = func.get_params().last() {
-                if last_param_info.0 == "..." {
-                    last_param_info.1.clone().unwrap_or(LuaType::Any)
-                } else {
-                    return Ok(func.clone());
-                }
-            } else {
-                return Ok(func.clone());
-            };
+            let (param_index, param_type) =
+                match get_call_arg_param(func, param_index, is_colon_call) {
+                    CallArgParam::Skip => continue,
+                    CallArgParam::Present {
+                        param_index,
+                        param_type,
+                    } => (param_index, param_type),
+                    CallArgParam::Missing => return Ok(func.clone()),
+                };
 
             let match_result = if param_type.is_any() {
                 ParamMatchResult::Any
@@ -208,6 +196,44 @@ pub fn resolve_signature_by_args(
     Ok(best_match_result)
 }
 
+fn get_call_arg_param(
+    func: &LuaFunctionType,
+    arg_index: usize,
+    is_colon_call: bool,
+) -> CallArgParam {
+    let mut param_index = arg_index;
+    match (func.is_colon_define(), is_colon_call) {
+        (true, false) => {
+            if param_index == 0 {
+                return CallArgParam::Skip;
+            }
+            param_index -= 1;
+        }
+        (false, true) => {
+            param_index += 1;
+        }
+        _ => {}
+    }
+
+    if let Some((_, ty)) = func.get_params().get(param_index) {
+        return CallArgParam::Present {
+            param_index,
+            param_type: ty.clone().unwrap_or(LuaType::Any),
+        };
+    }
+
+    if let Some((name, ty)) = func.get_params().last()
+        && name == "..."
+    {
+        return CallArgParam::Present {
+            param_index,
+            param_type: ty.clone().unwrap_or(LuaType::Any),
+        };
+    }
+
+    CallArgParam::Missing
+}
+
 fn is_func_last_param_variadic(func: &LuaFunctionType) -> bool {
     if let Some(last_param) = func.get_params().last() {
         last_param.0 == "..."
@@ -221,4 +247,13 @@ enum ParamMatchResult {
     Not,
     Any,
     Type,
+}
+
+enum CallArgParam {
+    Skip,
+    Present {
+        param_index: usize,
+        param_type: LuaType,
+    },
+    Missing,
 }


### PR DESCRIPTION
Improve overload inference for callable values.

The main rule is: match callable candidates by the actual argument shape before using their return types. That makes higher-order callback inference and direct callable-union calls less order-dependent.

This also clarifies the broad callable cases:
- `unknown` returns stay unknown instead of falling through to a concrete overload.
- bare `function` is treated as an erased callable fallback.
- compatible callable union/intersection members contribute a union of returns.

Regression tests cover `apply`-style callbacks, direct callable unions, and `pcall` return overloads.
