### PR TITLE
fix: block forever when using a related path

### DIFF
--- a/crates/emmylua_check/src/lib.rs
+++ b/crates/emmylua_check/src/lib.rs
@@ -18,11 +18,14 @@ pub async fn run_check(cmd_args: CmdArgs) -> Result<(), Box<dyn Error + Sync + S
         .workspace
         .into_iter()
         .map(|workspace| {
-            if workspace.is_absolute() {
+            let path = if workspace.is_absolute() {
                 workspace
             } else {
                 cwd.join(workspace)
-            }
+            };
+            // Canonicalize to resolve ".." components so the path matches
+            // the workspace root registered via add_main_workspace.
+            path.canonicalize().unwrap_or(path)
         })
         .collect();
     let main_path = workspaces
@@ -59,6 +62,9 @@ pub async fn run_check(cmd_args: CmdArgs) -> Result<(), Box<dyn Error + Sync + S
             sender.send((file_id, diagnostics)).await.unwrap();
         });
     }
+    // Drop the original sender so the receiver can detect when all spawned
+    // tasks have finished and their cloned senders are dropped.
+    drop(sender);
 
     let exit_code = output_result(
         need_check_files.len(),


### PR DESCRIPTION
复现场景：

```bash
cd crates/emmylua_check && cargo run ../../some.lua
```

进程会一直卡住不退出

两个问题：
1. 没处理相对路径，导致找不到 workspace
2. 由于第一个问题引起，need_check_files 为空，tokio 不退出