### PR TITLE
fix: skip redundant-parameter check when last arg is multi-return call

### DIFF
--- a/crates/emmylua_code_analysis/src/diagnostic/checker/check_param_count.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/check_param_count.rs
@@ -182,6 +182,19 @@ fn check_call_expr(
             min_call_args_count = min_call_args_count.saturating_sub(1);
         }
 
+        // 检查最后一个参数是否是多返回值函数调用（如 table.unpack()）
+        // 多返回值调用在最后一个参数位置时可能展开为 0 个或多个值
+        let last_arg_is_multi_return = if let Some(last_arg) = call_args.last()
+            && !last_arg_is_dots
+            && matches!(last_arg, LuaExpr::CallExpr(_))
+            && let Ok(LuaType::Variadic(_)) = semantic_model.infer_expr(last_arg.clone())
+        {
+            min_call_args_count = min_call_args_count.saturating_sub(1);
+            true
+        } else {
+            false
+        };
+
         if min_call_args_count <= fake_params.len() {
             return Some(());
         }
@@ -199,7 +212,7 @@ fn check_call_expr(
         }
 
         for (i, arg) in call_args.iter().enumerate() {
-            if last_arg_is_dots && i + 1 == call_args.len() {
+            if (last_arg_is_dots || last_arg_is_multi_return) && i + 1 == call_args.len() {
                 continue;
             }
 

--- a/crates/emmylua_code_analysis/src/diagnostic/test/redundant_parameter_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/redundant_parameter_test.rs
@@ -176,4 +176,42 @@ mod test {
         "#
         ));
     }
+
+    #[test]
+    fn test_last_arg_multi_return_call() {
+        let mut ws = VirtualWorkspace::new_with_init_std_lib();
+
+        // last arg is a multi-return function call (table.unpack), should not report redundant-parameter
+        assert!(ws.check_code_for(
+            DiagnosticCode::RedundantParameter,
+            r#"
+            ---@param args table
+            local function f(args) end
+
+            ---@type any[]
+            local cmds = {}
+            f(cmds, table.unpack(cmds))
+        "#
+        ));
+    }
+
+    #[test]
+    fn test_last_arg_multi_return_call_with_alias() {
+        let mut ws = VirtualWorkspace::new_with_init_std_lib();
+
+        // table.unpack aliased to a local variable, should not report redundant-parameter
+        assert!(ws.check_code_for(
+            DiagnosticCode::RedundantParameter,
+            r#"
+            local tunpack = table.unpack
+
+            ---@param args table
+            local function f(args) end
+
+            ---@type any[]
+            local cmds = {}
+            f(cmds, tunpack(cmds, 2))
+        "#
+        ));
+    }
 }


### PR DESCRIPTION
Skip the redundant-parameter diagnostic when the last argument is a multi-return function call (e.g. `table.unpack`), avoiding false positives.