### PR TITLE
fix: resolve overload before generic constraint check

### DIFF
--- a/crates/emmylua_code_analysis/src/diagnostic/test/generic_constraint_mismatch_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/generic_constraint_mismatch_test.rs
@@ -377,4 +377,33 @@ mod test {
         "#
         ));
     }
+
+    #[test]
+    fn test_overload_generic_constraint_merged_params() {
+        // When a generic signature has overloads, the merged main signature
+        // unions parameter types from all overloads. Constraint checks must
+        // run against the resolved overload, not the merged signature.
+        let mut ws = VirtualWorkspace::new();
+        ws.def_file(
+            "mylib.lua",
+            r#"
+            ---@meta mylib
+            local M = {}
+
+            ---@generic T: table
+            ---@overload fun(a: string, b: T?): T
+            ---@overload fun(a: string, b: integer, c: T?): T
+            function M.decode(a, b_or_c, c) end
+
+            return M
+        "#,
+        );
+        assert!(ws.check_code_for(
+            DiagnosticCode::GenericConstraintMismatch,
+            r#"
+            local m = require("mylib")
+            local ret = m.decode("x", 42)
+        "#
+        ));
+    }
 }

--- a/crates/emmylua_code_analysis/src/semantic/generic/call_constraint.rs
+++ b/crates/emmylua_code_analysis/src/semantic/generic/call_constraint.rs
@@ -206,6 +206,15 @@ fn infer_call_doc_function(
                 .get_db()
                 .get_signature_index()
                 .get(&signature_id)?;
+            if !signature.overloads.is_empty() {
+                // When a signature has overloads, `to_doc_func_type()` merges all overload
+                // parameter types into unions on the main signature. This produces incorrect
+                // types for generic constraint checking (e.g. a merged `T | nil | integer`
+                // would falsely trigger a constraint mismatch).
+                // Instead, resolve the actual overload that matches the call arguments,
+                // so that constraint checking runs against the correct parameter types.
+                return semantic_model.infer_call_expr_func(call_expr.clone(), None);
+            }
             Some(signature.to_doc_func_type())
         }
         LuaType::DocFunction(func) => Some(func),


### PR DESCRIPTION
## Problem

When a function has multiple `@overload` signatures with a `@generic T: table` constraint, the generic constraint checker was producing false positive `generic-constraint-mismatch` warnings.

For example:

```lua
---@generic T: table
---@overload fun(a: string, b: T?): T
---@overload fun(a: string, b: integer, c: T?): T
function M.decode(a, b_or_c, c) end

local ret = M.decode("x", 42)  -- false warning: type 'integer' does not satisfy the constraint 'table'
```

## Root Cause

In `infer_call_doc_function` (used by the generic constraint checker), when the inferred type is a `Signature`, it called `signature.to_doc_func_type()` which merges all overload parameter types into a union. This caused the constraint checker to see `integer | T` as the type for the second parameter, and then incorrectly check the `integer` argument against the `table` constraint of `T`.

## Fix

When the signature has overloads, use `semantic_model.infer_call_expr_func()` to resolve the matching overload first, then perform the generic constraint check on the correctly matched signature.

## Test

Added a regression test `test_overload_generic_constraint_merged_params` that reproduces the false positive scenario.