### PR TITLE
fix(type): canonicalize identical callable unions

### DIFF
--- a/crates/emmylua_code_analysis/src/compilation/test/pcall_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/pcall_test.rs
@@ -199,4 +199,40 @@ mod test {
         assert_eq!(ws.expr_ty("success"), ws.ty("unknown"));
         assert_eq!(ws.expr_ty("failure"), ws.ty("string"));
     }
+
+    #[test]
+    fn test_issue_1020_pcall_preserves_pairs_value_function_return() {
+        let mut ws = VirtualWorkspace::new_with_init_std_lib();
+
+        ws.def(
+            r#"
+        local t = {
+            { id = 1, func = function() return a > 0 end },
+            { id = 2, func = function() return a > 0 end },
+            { id = 3, func = function() return a > 0 end },
+        }
+
+        for _, v in pairs(t) do
+            local f = v.func
+            captured_f = f
+            local success, result = pcall(f)
+            outside = result
+            if success then
+                success_result = result
+            else
+                failure_result = result
+            end
+        end
+        "#,
+        );
+
+        let captured_f = ws.expr_ty("captured_f");
+        let outside = ws.expr_ty("outside");
+        let success_result = ws.expr_ty("success_result");
+        let failure_result = ws.expr_ty("failure_result");
+        assert_eq!(ws.humanize_type(captured_f), "fun() -> boolean");
+        assert_eq!(ws.humanize_type(outside), "(boolean|string)");
+        assert_eq!(ws.humanize_type(success_result), "boolean");
+        assert_eq!(ws.humanize_type(failure_result), "string");
+    }
 }

--- a/crates/emmylua_code_analysis/src/db_index/type/type_ops/test.rs
+++ b/crates/emmylua_code_analysis/src/db_index/type/type_ops/test.rs
@@ -181,6 +181,30 @@ mod tests {
     }
 
     #[test]
+    fn test_union_collapses_equivalent_callable_variants() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+        ---@return boolean
+        function foo()
+            return true
+        end
+        "#,
+        );
+
+        let doc = ws.ty("fun(): boolean");
+        let sig = ws.expr_ty("foo");
+        let doc_first = TypeOps::Union.apply(ws.get_db_mut(), &doc, &sig);
+        assert!(!doc_first.is_union());
+        assert_eq!(ws.humanize_type(doc_first), "fun() -> boolean");
+
+        let sig_first = TypeOps::Union.apply(ws.get_db_mut(), &sig, &doc);
+        assert!(!sig_first.is_union());
+        assert_eq!(ws.humanize_type(sig_first), "fun() -> boolean");
+    }
+
+    #[test]
     fn test_remove_type() {
         let mut ws = VirtualWorkspace::new();
         assert!(ws.check_code_for(

--- a/crates/emmylua_code_analysis/src/db_index/type/type_ops/union_type.rs
+++ b/crates/emmylua_code_analysis/src/db_index/type/type_ops/union_type.rs
@@ -1,12 +1,12 @@
-use std::ops::Deref;
+use std::{ops::Deref, sync::Arc};
 
-use crate::{DbIndex, LuaType, LuaUnionType, get_real_type};
+use crate::{DbIndex, LuaFunctionType, LuaType, LuaUnionType, get_real_type};
 
 pub fn union_type(db: &DbIndex, source: LuaType, target: LuaType) -> LuaType {
     let match_source = get_real_type(db, &source)
         .cloned()
         .unwrap_or_else(|| source.clone());
-    union_type_impl(&match_source, source, target)
+    canonicalize_callable_union(db, union_type_impl(&match_source, source, target))
 }
 
 pub(crate) fn union_type_shallow(source: LuaType, target: LuaType) -> LuaType {
@@ -106,15 +106,55 @@ fn union_type_impl(match_source: &LuaType, source: LuaType, target: LuaType) -> 
         }
         // two union
         (LuaType::Union(left), LuaType::Union(right)) => {
-            let mut left = left.into_vec();
-            let right = right.into_vec();
-            left.extend(right);
+            if left == right {
+                return source.clone();
+            }
 
-            LuaType::from_vec(left)
+            let mut merged = left.into_vec();
+            merged.extend(right.into_vec());
+
+            LuaType::from_vec(merged)
         }
 
         // same type
         (left, right) if *left == *right => source.clone(),
         _ => LuaType::from_vec(vec![source, target]),
+    }
+}
+
+// `Signature` and `DocFunction` carry the same callable shape through different variants.
+// Collapse them after the normal union merge so the core merge logic stays simple.
+fn canonicalize_callable_union(db: &DbIndex, ty: LuaType) -> LuaType {
+    let LuaType::Union(union) = ty else {
+        return ty;
+    };
+
+    let mut types = Vec::new();
+    for member in union.into_vec() {
+        let member_callable = as_callable_type(db, &member);
+        if types.iter().any(|existing| {
+            existing == &member
+                || as_callable_type(db, existing)
+                    .as_ref()
+                    .zip(member_callable.as_ref())
+                    .is_some_and(|(existing, member)| existing == member)
+        }) {
+            continue;
+        }
+        types.push(member);
+    }
+
+    LuaType::from_vec(types)
+}
+
+fn as_callable_type(db: &DbIndex, ty: &LuaType) -> Option<Arc<LuaFunctionType>> {
+    match ty {
+        LuaType::DocFunction(func) => Some(func.clone()),
+        LuaType::Signature(signature_id) => db
+            .get_signature_index()
+            .get(signature_id)
+            .filter(|signature| signature.is_resolve_return())
+            .map(|signature| signature.to_doc_func_type()),
+        _ => None,
     }
 }


### PR DESCRIPTION
## Summary
- deduplicate semantically identical callable members when building unions
- keep v.func from pairs(t) from reaching pcall as a raw callable union
- add the exact #1020 regression

## Testing
- cargo test -p emmylua_code_analysis pcall_test
- cargo test -p emmylua_code_analysis member_infer_test
- cargo test -p emmylua_code_analysis for_range_var_infer_test

Fixes #1020