### PR TITLE
fix: use intersection type for table.pack return type

### DIFF
--- a/crates/emmylua_code_analysis/resources/std/table.lua
+++ b/crates/emmylua_code_analysis/resources/std/table.lua
@@ -119,7 +119,7 @@ function table.unpack(list, i, j) end
 ---
 ---@generic T
 ---@param ... T...
----@return [T...] | { n: integer }
+---@return [T...] & { n: integer }
 ---@nodiscard
 function table.pack(...) end
 


### PR DESCRIPTION
## Problem

The return type of `table.pack` was defined as `[T...] | { n: integer }`, which uses a **union** type. This implies the return value is *either* a tuple *or* a table with an `n` field — but in reality, `table.pack` always returns a table that has **both** integer-indexed elements and the `n` field simultaneously.

## Solution

Changed the return type from union (`|`) to intersection (`&`):

```lua
-- Before
---@return [T...] | { n: integer }

-- After
---@return [T...] & { n: integer }
```

This correctly expresses that the returned table has both tuple elements and the `n` field at the same time, which:
- Preserves per-element type inference from `[T...]`
- Makes the `n` field visible alongside array index members
- Matches the actual runtime behavior of `table.pack`