### PR TITLE
fix(semantic): make flow narrowing iterative

### DIFF
--- a/crates/emmylua_code_analysis/src/compilation/analyzer/lua/stats.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/lua/stats.rs
@@ -480,82 +480,79 @@ pub fn analyze_local_func_stat(
     Some(())
 }
 
-fn register_expr_key_member(analyzer: &mut LuaAnalyzer, field: &LuaTableField) {
-    // Register expression-key members early so table-decl inference (and pairs)
-    // can see them even when the table itself has no explicit generic type.
-    let Some(field_key) = field.get_field_key() else {
-        return;
-    };
-    let LuaIndexKey::Expr(_) = &field_key else {
-        return;
-    };
-    let member_id = LuaMemberId::new(field.get_syntax_id(), analyzer.file_id);
-    if analyzer
-        .db
-        .get_member_index()
-        .get_member(&member_id)
-        .is_some()
-    {
-        return;
-    }
-    let cache = analyzer
-        .context
-        .infer_manager
-        .get_infer_cache(analyzer.file_id);
-    let Ok(member_key) = LuaMemberKey::from_index_key(analyzer.db, cache, &field_key) else {
-        return;
-    };
-    if matches!(member_key, LuaMemberKey::ExprType(ref typ) if typ.is_unknown()) {
-        return;
-    }
-    let Some(table_expr) = field.get_parent::<LuaTableExpr>() else {
-        return;
-    };
-    let owner_id = LuaMemberOwner::Element(InFiled::new(analyzer.file_id, table_expr.get_range()));
-    let decl_feature = if analyzer.context.metas.contains(&analyzer.file_id) {
-        LuaMemberFeature::MetaDefine
-    } else {
-        LuaMemberFeature::FileDefine
-    };
-    let member = LuaMember::new(member_id, member_key, decl_feature, None);
-    analyzer
-        .db
-        .get_member_index_mut()
-        .add_member(owner_id, member);
-}
-
+/// Analyzes an assignment-style table field.
+///
+/// Table-declaration analysis already registers static keys and value fields, for
+/// example `{ name = value }`, `{ ["name"] = value }`, `{ [1] = value }`, and
+/// `{ value1, value2 }`.
+///
+/// This pass binds the field value type and eagerly materializes resolved
+/// bracket-key members such as `{ [key] = value }`, `{ [true] = value }`, or
+/// `{ [SomeEnum.A] = value }` so later consumers like table inference and
+/// `pairs` can see them before the unresolved table-field pass runs.
 pub fn analyze_table_field(analyzer: &mut LuaAnalyzer, field: LuaTableField) -> Option<()> {
-    register_expr_key_member(analyzer, &field);
-
-    if field.is_assign_field() {
-        let value_expr = field.get_value_expr()?;
-        let member_id = LuaMemberId::new(field.get_syntax_id(), analyzer.file_id);
-        let value_type = match analyzer.infer_expr(&value_expr.clone()) {
-            Ok(value_type) => match value_type {
-                LuaType::Def(ref_id) => LuaType::Ref(ref_id),
-                _ => value_type,
-            },
-            Err(InferFailReason::None) => LuaType::Unknown,
-            Err(reason) => {
-                let unresolve = UnResolveMember {
-                    file_id: analyzer.file_id,
-                    member_id,
-                    expr: Some(value_expr.clone()),
-                    prefix: None,
-                    ret_idx: 0,
-                };
-
-                analyzer.context.add_unresolve(unresolve.into(), reason);
-                return None;
-            }
-        };
-
-        bind_type(
-            analyzer.db,
-            member_id.into(),
-            LuaTypeCache::InferType(value_type),
-        );
+    if !field.is_assign_field() {
+        return Some(());
     }
+
+    if let Some(field_key) = field.get_field_key() {
+        if let LuaIndexKey::Expr(_) = &field_key {
+            // Decl analysis leaves `[expr] = value` fields unresolved. If the key
+            // already resolves here, materialize the member now.
+            let db = &mut *analyzer.db;
+            let member_id = LuaMemberId::new(field.get_syntax_id(), analyzer.file_id);
+            if db.get_member_index().get_member(&member_id).is_none() {
+                let cache = analyzer
+                    .context
+                    .infer_manager
+                    .get_infer_cache(analyzer.file_id);
+                if let Ok(member_key) = LuaMemberKey::from_index_key(db, cache, &field_key) {
+                    if !matches!(member_key, LuaMemberKey::ExprType(ref typ) if typ.is_unknown()) {
+                        if let Some(table_expr) = field.get_parent::<LuaTableExpr>() {
+                            let owner_id = LuaMemberOwner::Element(InFiled::new(
+                                analyzer.file_id,
+                                table_expr.get_range(),
+                            ));
+                            let decl_feature = if analyzer.context.metas.contains(&analyzer.file_id)
+                            {
+                                LuaMemberFeature::MetaDefine
+                            } else {
+                                LuaMemberFeature::FileDefine
+                            };
+                            let member = LuaMember::new(member_id, member_key, decl_feature, None);
+                            db.get_member_index_mut().add_member(owner_id, member);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let value_expr = field.get_value_expr()?;
+    let member_id = LuaMemberId::new(field.get_syntax_id(), analyzer.file_id);
+    let value_type = match analyzer.infer_expr(&value_expr.clone()) {
+        Ok(value_type) => match value_type {
+            LuaType::Def(ref_id) => LuaType::Ref(ref_id),
+            _ => value_type,
+        },
+        Err(InferFailReason::None) => LuaType::Unknown,
+        Err(reason) => {
+            let unresolve = UnResolveMember {
+                file_id: analyzer.file_id,
+                member_id,
+                expr: Some(value_expr.clone()),
+                prefix: None,
+                ret_idx: 0,
+            };
+
+            analyzer.context.add_unresolve(unresolve.into(), reason);
+            return None;
+        }
+    };
+
+    let cache = LuaTypeCache::InferType(value_type);
+    bind_type(analyzer.db, member_id.into(), cache);
+
     Some(())
 }
 

--- a/crates/emmylua_code_analysis/src/compilation/test/flow.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/flow.rs
@@ -1,9 +1,11 @@
 #[cfg(test)]
 mod test {
     use crate::{DiagnosticCode, LuaType, VirtualWorkspace};
+    use emmylua_parser::{LuaAstToken, LuaLocalName};
 
     const STACKED_TYPE_GUARDS: usize = 180;
     const LARGE_LINEAR_ASSIGNMENT_STEPS: usize = 2048;
+    const MAXWELLHOME_ARRAY_VALUES: usize = 2048;
 
     #[test]
     fn test_closure_return() {
@@ -386,6 +388,47 @@ mod test {
         );
         let after_assign = ws.expr_ty("after_assign");
         assert_eq!(ws.humanize_type(after_assign), "integer");
+    }
+
+    #[test]
+    fn test_issue_1028_maxwellhome_like_large_array_builds_semantic_model() {
+        let mut ws = VirtualWorkspace::new();
+        let mut block = String::from(
+            r#"
+        ---@type integer
+        local tile = ({
+            layers = {
+                {
+                    data = {
+        "#,
+        );
+
+        for i in 0..MAXWELLHOME_ARRAY_VALUES {
+            block.push_str(&format!("                        {},\n", i % 3));
+        }
+
+        block.push_str(
+            r#"
+                    },
+                },
+            },
+        }).layers[1].data[1024]
+        "#,
+        );
+
+        let file_id = ws.def_file("maxwellhome.lua", &block);
+        let semantic_model = ws
+            .analysis
+            .compilation
+            .get_semantic_model(file_id)
+            .expect("expected semantic model for maxwellhome-like large array stress case");
+        let local_name = ws.get_node::<LuaLocalName>(file_id);
+        let token = local_name.get_name_token().expect("name token must exist");
+        let info = semantic_model
+            .get_semantic_info(token.syntax().clone().into())
+            .expect("semantic info must exist");
+
+        assert_eq!(ws.humanize_type(info.typ), "integer");
     }
 
     #[test]

--- a/crates/emmylua_code_analysis/src/compilation/test/flow.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/flow.rs
@@ -1867,6 +1867,27 @@ end
     }
 
     #[test]
+    fn test_feature_const_local_alias_chain_does_not_inherit_flow() {
+        let mut ws = VirtualWorkspace::new_with_init_std_lib();
+
+        ws.def(
+            r#"
+            local ret --- @type string | nil
+
+            local is_string = type(ret) == "string"
+            local ok = is_string
+            if ok then
+                a = ret
+            end
+            "#,
+        );
+
+        let a = ws.expr_ty("a");
+        let a_expected = ws.ty("string?");
+        assert_eq!(a, a_expected);
+    }
+
+    #[test]
     fn test_feature_generic_type_guard() {
         let mut ws = VirtualWorkspace::new();
 

--- a/crates/emmylua_code_analysis/src/compilation/test/for_range_var_infer_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/for_range_var_infer_test.rs
@@ -169,6 +169,49 @@ mod test {
     }
 
     #[test]
+    fn test_pairs_value_field_integer_keys() {
+        let mut ws = VirtualWorkspace::new_with_init_std_lib();
+
+        ws.def(
+            r#"
+            local t = { 10, 20, 30 }
+
+            for k, v in pairs(t) do
+                key_out = k
+                value_out = v
+            end
+        "#,
+        );
+
+        let key_out = ws.expr_ty("key_out");
+        let value_out = ws.expr_ty("value_out");
+        let LuaType::Union(key_union) = key_out else {
+            panic!("expected integer key union, got {:?}", key_out);
+        };
+        let LuaType::Union(value_union) = value_out else {
+            panic!("expected value union, got {:?}", value_out);
+        };
+
+        let expected_keys: HashSet<_> = vec![
+            LuaType::IntegerConst(1),
+            LuaType::IntegerConst(2),
+            LuaType::IntegerConst(3),
+        ]
+        .into_iter()
+        .collect();
+        let expected_values: HashSet<_> = vec![
+            LuaType::DocIntegerConst(10),
+            LuaType::DocIntegerConst(20),
+            LuaType::DocIntegerConst(30),
+        ]
+        .into_iter()
+        .collect();
+
+        assert_eq!(key_union.into_set(), expected_keys);
+        assert_eq!(value_union.into_set(), expected_values);
+    }
+
+    #[test]
     fn test_issue_291() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 

--- a/crates/emmylua_code_analysis/src/compilation/test/member_infer_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/member_infer_test.rs
@@ -368,4 +368,99 @@ mod test {
 
         assert_eq!(ws.expr_ty("result"), ws.ty("never"));
     }
+
+    #[test]
+    fn test_rawget_guard_narrows_matching_index_expr() {
+        let mut ws = VirtualWorkspace::new_with_init_std_lib();
+
+        ws.def(
+            r#"
+        ---@class T
+        ---@field x? integer
+
+        ---@type T
+        local t = {}
+
+        if rawget(t, "x") then
+            result = t.x
+        end
+        "#,
+        );
+
+        assert_eq!(ws.expr_ty("result"), LuaType::Integer);
+    }
+
+    #[test]
+    fn test_type_guard_call_narrows_matching_index_expr() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+        ---@generic T
+        ---@param inst any
+        ---@param type `T`
+        ---@return TypeGuard<T>
+        local function instance_of(inst, type)
+            return true
+        end
+
+        ---@class T
+        ---@field x? string|integer
+
+        ---@type T
+        local t = {}
+
+        if instance_of(t.x, "string") then
+            result = t.x
+        end
+        "#,
+        );
+
+        assert_eq!(ws.expr_ty("result"), LuaType::String);
+    }
+
+    #[test]
+    fn test_alias_predicate_guard_narrows_matching_index_expr() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+        ---@class T
+        ---@field x? integer
+
+        ---@type T
+        local t = {}
+
+        local ok = t.x ~= nil
+        if ok then
+            result = t.x
+        end
+        "#,
+        );
+
+        assert_eq!(ws.expr_ty("result"), LuaType::Integer);
+    }
+
+    #[test]
+    fn test_alias_chain_predicate_guard_keeps_matching_index_expr_wide() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+        ---@class T
+        ---@field x? integer
+
+        ---@type T
+        local t = {}
+
+        local has_x = t.x ~= nil
+        local ok = has_x
+        if ok then
+            result = t.x
+        end
+        "#,
+        );
+
+        assert_eq!(ws.expr_ty("result"), ws.ty("integer?"));
+    }
 }

--- a/crates/emmylua_code_analysis/src/semantic/cache/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/cache/mod.rs
@@ -1,22 +1,52 @@
 mod cache_options;
 
 pub use cache_options::{CacheOptions, LuaAnalysisPhase};
-use emmylua_parser::LuaSyntaxId;
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use emmylua_parser::{LuaExpr, LuaSyntaxId, LuaVarExpr};
+use hashbrown::{HashMap, HashSet};
+use std::{rc::Rc, sync::Arc};
 
 use crate::{
     FileId, FlowId, LuaFunctionType,
     db_index::LuaType,
-    semantic::infer::{ConditionFlowAction, VarRefId},
+    semantic::infer::{ConditionFlowAction, InferConditionFlow, VarRefId},
 };
 
 #[derive(Debug)]
 pub enum CacheEntry<T> {
     Ready,
     Cache(T),
+}
+
+#[derive(Debug, Clone)]
+pub(in crate::semantic) struct FlowConditionInfo {
+    pub expr: LuaExpr,
+    pub index_var_ref_id: Option<VarRefId>,
+    pub index_prefix_var_ref_id: Option<VarRefId>,
+}
+
+#[derive(Debug, Clone)]
+pub(in crate::semantic) struct FlowAssignmentInfo {
+    pub vars: Vec<LuaVarExpr>,
+    pub exprs: Vec<LuaExpr>,
+    pub var_ref_ids: Vec<Option<VarRefId>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(in crate::semantic) enum FlowMode {
+    WithConditions,
+    WithoutConditions,
+}
+
+impl FlowMode {
+    pub fn uses_conditions(self) -> bool {
+        matches!(self, Self::WithConditions)
+    }
+}
+
+#[derive(Debug, Default)]
+pub(in crate::semantic) struct FlowVarCache {
+    pub type_cache: HashMap<(FlowId, FlowMode), CacheEntry<LuaType>>,
+    pub condition_cache: HashMap<(FlowId, InferConditionFlow), CacheEntry<ConditionFlowAction>>,
 }
 
 #[derive(Debug)]
@@ -26,9 +56,12 @@ pub struct LuaInferCache {
     pub expr_cache: HashMap<LuaSyntaxId, CacheEntry<LuaType>>,
     pub call_cache:
         HashMap<(LuaSyntaxId, Option<usize>, LuaType), CacheEntry<Arc<LuaFunctionType>>>,
-    pub(crate) flow_node_cache: HashMap<(VarRefId, FlowId, bool), CacheEntry<LuaType>>,
-    pub(in crate::semantic) condition_flow_cache:
-        HashMap<(VarRefId, FlowId, bool), CacheEntry<ConditionFlowAction>>,
+    pub(in crate::semantic) flow_cache_var_ref_ids: HashMap<VarRefId, u32>,
+    pub(in crate::semantic) next_flow_cache_var_ref_id: u32,
+    pub(in crate::semantic) flow_var_caches: Vec<FlowVarCache>,
+    pub(in crate::semantic) flow_branch_inputs_cache: Vec<Option<Arc<[FlowId]>>>,
+    pub(in crate::semantic) flow_condition_info_cache: Vec<Option<Rc<FlowConditionInfo>>>,
+    pub(in crate::semantic) flow_assignment_info_cache: Vec<Option<Rc<FlowAssignmentInfo>>>,
     pub index_ref_origin_type_cache: HashMap<VarRefId, CacheEntry<LuaType>>,
     pub expr_var_ref_id_cache: HashMap<LuaSyntaxId, VarRefId>,
     pub narrow_by_literal_stop_position_cache: HashSet<LuaSyntaxId>,
@@ -41,8 +74,12 @@ impl LuaInferCache {
             config,
             expr_cache: HashMap::new(),
             call_cache: HashMap::new(),
-            flow_node_cache: HashMap::new(),
-            condition_flow_cache: HashMap::new(),
+            flow_cache_var_ref_ids: HashMap::new(),
+            next_flow_cache_var_ref_id: 0,
+            flow_var_caches: Vec::new(),
+            flow_branch_inputs_cache: Vec::new(),
+            flow_condition_info_cache: Vec::new(),
+            flow_assignment_info_cache: Vec::new(),
             index_ref_origin_type_cache: HashMap::new(),
             expr_var_ref_id_cache: HashMap::new(),
             narrow_by_literal_stop_position_cache: HashSet::new(),
@@ -64,8 +101,12 @@ impl LuaInferCache {
     pub fn clear(&mut self) {
         self.expr_cache.clear();
         self.call_cache.clear();
-        self.flow_node_cache.clear();
-        self.condition_flow_cache.clear();
+        self.flow_cache_var_ref_ids.clear();
+        self.next_flow_cache_var_ref_id = 0;
+        self.flow_var_caches.clear();
+        self.flow_branch_inputs_cache.clear();
+        self.flow_condition_info_cache.clear();
+        self.flow_assignment_info_cache.clear();
         self.index_ref_origin_type_cache.clear();
         self.expr_var_ref_id_cache.clear();
     }

--- a/crates/emmylua_code_analysis/src/semantic/infer/infer_index/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/infer_index/mod.rs
@@ -1,10 +1,9 @@
 mod infer_array;
 
-use std::collections::HashSet;
-
 use emmylua_parser::{
     LuaExpr, LuaIndexExpr, LuaIndexKey, LuaIndexMemberExpr, NumberResult, PathTrait,
 };
+use hashbrown::HashSet;
 use internment::ArcIntern;
 use rowan::TextRange;
 use smol_str::SmolStr;
@@ -107,6 +106,7 @@ fn infer_member_type_pass_flow(
     cache
         .index_ref_origin_type_cache
         .insert(var_ref_id.clone(), CacheEntry::Cache(member_type.clone()));
+
     let result = infer_expr_narrow_type(db, cache, LuaExpr::IndexExpr(index_expr), var_ref_id);
     match &result {
         Err(InferFailReason::None) => Ok(member_type.clone()),

--- a/crates/emmylua_code_analysis/src/semantic/infer/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/mod.rs
@@ -26,8 +26,8 @@ pub use infer_name::{find_self_decl_or_member_id, infer_param};
 use infer_table::infer_table_expr;
 pub use infer_table::{infer_table_field_value_should_be, infer_table_should_be};
 use infer_unary::infer_unary_expr;
-pub(in crate::semantic) use narrow::ConditionFlowAction;
 pub use narrow::VarRefId;
+pub(in crate::semantic) use narrow::{ConditionFlowAction, InferConditionFlow};
 
 use rowan::TextRange;
 use smol_str::SmolStr;

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/binary_flow.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/binary_flow.rs
@@ -4,21 +4,16 @@ use emmylua_parser::{
 };
 
 use crate::{
-    DbIndex, FlowNode, FlowTree, InferFailReason, InferGuard, LuaArrayLen, LuaArrayType,
-    LuaInferCache, LuaType, TypeOps, infer_expr,
+    DbIndex, FlowNode, FlowTree, InferFailReason, LuaInferCache, LuaType, TypeOps, infer_expr,
     semantic::infer::{
         VarRefId,
-        infer_index::infer_member_by_member_key,
         narrow::{
-            ResultTypeOrContinue,
             condition_flow::{
-                ConditionFlowAction, InferConditionFlow, PendingConditionNarrow,
-                always_literal_equal, call_flow::get_type_at_call_expr,
-                correlated_flow::prepare_var_from_return_overload_condition,
+                ConditionFlowAction, ConditionSubquery, CorrelatedDiscriminantNarrow,
+                InferConditionFlow, PendingConditionNarrow, always_literal_equal,
+                call_flow::get_type_at_call_expr,
             },
-            get_single_antecedent,
-            get_type_at_flow::get_type_at_flow,
-            get_var_ref_type, narrow_down_type,
+            get_single_antecedent, get_var_ref_type,
             var_ref_id::get_var_expr_var_ref_id,
         },
     },
@@ -64,34 +59,31 @@ pub fn get_type_at_binary_expr(
             flow_node,
             left_expr,
             right_expr,
-            condition_flow.get_negated(),
+            match condition_flow {
+                InferConditionFlow::TrueCondition => InferConditionFlow::FalseCondition,
+                InferConditionFlow::FalseCondition => InferConditionFlow::TrueCondition,
+            },
         ),
         BinaryOperator::OpGt => try_get_at_gt_or_ge_expr(
             db,
-            tree,
             cache,
-            root,
             var_ref_id,
             flow_node,
             left_expr,
             right_expr,
             condition_flow,
             true,
-        )
-        .map(Into::into),
+        ),
         BinaryOperator::OpGe => try_get_at_gt_or_ge_expr(
             db,
-            tree,
             cache,
-            root,
             var_ref_id,
             flow_node,
             left_expr,
             right_expr,
             condition_flow,
             false,
-        )
-        .map(Into::into),
+        ),
         _ => Ok(ConditionFlowAction::Continue),
     }
 }
@@ -136,9 +128,7 @@ fn try_get_at_eq_or_neq_expr(
 
     if let Some(action) = maybe_field_literal_eq_action(
         db,
-        tree,
         cache,
-        root,
         var_ref_id,
         flow_node,
         left_expr.clone(),
@@ -152,7 +142,6 @@ fn try_get_at_eq_or_neq_expr(
         db,
         tree,
         cache,
-        root,
         var_ref_id,
         flow_node,
         left_expr,
@@ -164,66 +153,51 @@ fn try_get_at_eq_or_neq_expr(
 #[allow(clippy::too_many_arguments)]
 fn try_get_at_gt_or_ge_expr(
     db: &DbIndex,
-    tree: &FlowTree,
     cache: &mut LuaInferCache,
-    root: &LuaChunk,
     var_ref_id: &VarRefId,
     flow_node: &FlowNode,
     left_expr: LuaExpr,
     right_expr: LuaExpr,
     condition_flow: InferConditionFlow,
     gt: bool,
-) -> Result<ResultTypeOrContinue, InferFailReason> {
+) -> Result<ConditionFlowAction, InferFailReason> {
     match left_expr {
         LuaExpr::UnaryExpr(unary_expr) => {
             let Some(op) = unary_expr.get_op_token() else {
-                return Ok(ResultTypeOrContinue::Continue);
+                return Ok(ConditionFlowAction::Continue);
             };
 
             match op.get_op() {
                 UnaryOperator::OpLen => {}
-                _ => return Ok(ResultTypeOrContinue::Continue),
+                _ => return Ok(ConditionFlowAction::Continue),
             };
 
             let Some(expr) = unary_expr.get_expr() else {
-                return Ok(ResultTypeOrContinue::Continue);
+                return Ok(ConditionFlowAction::Continue);
             };
 
             let Some(maybe_ref_id) = get_var_expr_var_ref_id(db, cache, expr) else {
-                return Ok(ResultTypeOrContinue::Continue);
+                return Ok(ConditionFlowAction::Continue);
             };
 
             if maybe_ref_id != *var_ref_id {
                 // If the reference declaration ID does not match, we cannot narrow it
-                return Ok(ResultTypeOrContinue::Continue);
+                return Ok(ConditionFlowAction::Continue);
             }
 
             let right_expr_type = infer_expr(db, cache, right_expr)?;
             let antecedent_flow_id = get_single_antecedent(flow_node)?;
-            let antecedent_type =
-                get_type_at_flow(db, tree, cache, root, var_ref_id, antecedent_flow_id)?;
-            match (&antecedent_type, &right_expr_type) {
-                (
-                    LuaType::Array(array_type),
-                    LuaType::IntegerConst(i) | LuaType::DocIntegerConst(i),
-                ) => {
-                    let add = if gt { 1 } else { 0 };
-                    if condition_flow.is_true() {
-                        let new_array_type = LuaArrayType::new(
-                            array_type.get_base().clone(),
-                            LuaArrayLen::Max(*i + add),
-                        );
-                        return Ok(ResultTypeOrContinue::Result(LuaType::Array(
-                            new_array_type.into(),
-                        )));
-                    }
-                }
-                _ => return Ok(ResultTypeOrContinue::Continue),
-            }
-
-            Ok(ResultTypeOrContinue::Continue)
+            Ok(ConditionFlowAction::NeedSubquery(
+                ConditionSubquery::ArrayLen {
+                    var_ref_id: var_ref_id.clone(),
+                    antecedent_flow_id,
+                    subquery_condition_flow: condition_flow,
+                    right_expr_type,
+                    max_adjustment: if gt { 1 } else { 0 },
+                },
+            ))
         }
-        _ => Ok(ResultTypeOrContinue::Continue),
+        _ => Ok(ConditionFlowAction::Continue),
     }
 }
 
@@ -289,7 +263,7 @@ fn maybe_type_guard_binary_action(
     };
 
     if maybe_var_ref_id == *var_ref_id {
-        return Ok(Some(ConditionFlowAction::pending(
+        return Ok(Some(ConditionFlowAction::Pending(
             PendingConditionNarrow::TypeGuard {
                 narrow,
                 condition_flow,
@@ -310,28 +284,17 @@ fn maybe_type_guard_binary_action(
     }
 
     let antecedent_flow_id = get_single_antecedent(flow_node)?;
-    let antecedent_type =
-        get_type_at_flow(db, tree, cache, root, &maybe_var_ref_id, antecedent_flow_id)?;
-    let narrowed_discriminant_type = match condition_flow {
-        InferConditionFlow::TrueCondition => {
-            narrow_down_type(db, antecedent_type, narrow.clone(), None).unwrap_or(narrow.clone())
-        }
-        InferConditionFlow::FalseCondition => TypeOps::Remove.apply(db, &antecedent_type, &narrow),
-    };
-
-    Ok(prepare_var_from_return_overload_condition(
-        db,
-        tree,
-        cache,
-        root,
-        var_ref_id,
-        flow_node,
-        discriminant_decl_id,
-        type_guard_expr.get_position(),
-        &narrowed_discriminant_type,
-    )?
-    .map(PendingConditionNarrow::Correlated)
-    .map(ConditionFlowAction::pending))
+    Ok(Some(ConditionFlowAction::NeedSubquery(
+        ConditionSubquery::Correlated {
+            var_ref_id: maybe_var_ref_id,
+            antecedent_flow_id,
+            subquery_condition_flow: condition_flow,
+            discriminant_decl_id,
+            condition_position: type_guard_expr.get_position(),
+            narrow: CorrelatedDiscriminantNarrow::TypeGuard { narrow },
+            fallback_expr: None,
+        },
+    )))
 }
 
 /// Maps the string result of Lua's builtin `type()` call to the corresponding `LuaType`.
@@ -349,7 +312,7 @@ fn type_call_name_to_type(literal_string: &str) -> Option<LuaType> {
     })
 }
 
-fn narrow_eq_condition(
+pub(super) fn narrow_eq_condition(
     db: &DbIndex,
     antecedent_type: LuaType,
     right_expr_type: LuaType,
@@ -395,7 +358,6 @@ fn get_var_eq_condition_action(
     db: &DbIndex,
     tree: &FlowTree,
     cache: &mut LuaInferCache,
-    root: &LuaChunk,
     var_ref_id: &VarRefId,
     flow_node: &FlowNode,
     left_expr: LuaExpr,
@@ -425,24 +387,20 @@ fn get_var_eq_condition_action(
                 }
                 let antecedent_flow_id = get_single_antecedent(flow_node)?;
                 let right_expr_type = infer_expr(db, cache, right_expr)?;
-                let antecedent_type =
-                    get_type_at_flow(db, tree, cache, root, &maybe_ref_id, antecedent_flow_id)?;
-                let narrowed_discriminant_type =
-                    narrow_eq_condition(db, antecedent_type, right_expr_type, condition_flow, true);
-                return Ok(prepare_var_from_return_overload_condition(
-                    db,
-                    tree,
-                    cache,
-                    root,
-                    var_ref_id,
-                    flow_node,
-                    discriminant_decl_id,
-                    left_name_expr.get_position(),
-                    &narrowed_discriminant_type,
-                )?
-                .map(PendingConditionNarrow::Correlated)
-                .map(ConditionFlowAction::pending)
-                .unwrap_or(ConditionFlowAction::Continue));
+                return Ok(ConditionFlowAction::NeedSubquery(
+                    ConditionSubquery::Correlated {
+                        var_ref_id: maybe_ref_id,
+                        antecedent_flow_id,
+                        subquery_condition_flow: condition_flow,
+                        discriminant_decl_id,
+                        condition_position: left_name_expr.get_position(),
+                        narrow: CorrelatedDiscriminantNarrow::Eq {
+                            right_expr_type,
+                            allow_literal_equivalence: true,
+                        },
+                        fallback_expr: None,
+                    },
+                ));
             }
 
             let right_expr_type = infer_expr(db, cache, right_expr)?;
@@ -452,14 +410,14 @@ fn get_var_eq_condition_action(
                     if var_ref_id.is_self_ref() && !right_expr_type.is_nil() {
                         TypeOps::Remove.apply(db, &right_expr_type, &LuaType::Nil)
                     } else {
-                        return Ok(ConditionFlowAction::pending(PendingConditionNarrow::Eq {
+                        return Ok(ConditionFlowAction::Pending(PendingConditionNarrow::Eq {
                             right_expr_type,
                             condition_flow,
                         }));
                     }
                 }
                 InferConditionFlow::FalseCondition => {
-                    return Ok(ConditionFlowAction::pending(PendingConditionNarrow::Eq {
+                    return Ok(ConditionFlowAction::Pending(PendingConditionNarrow::Eq {
                         right_expr_type,
                         condition_flow,
                     }));
@@ -474,7 +432,14 @@ fn get_var_eq_condition_action(
                         let flow = if b.is_true() {
                             condition_flow
                         } else {
-                            condition_flow.get_negated()
+                            match condition_flow {
+                                InferConditionFlow::TrueCondition => {
+                                    InferConditionFlow::FalseCondition
+                                }
+                                InferConditionFlow::FalseCondition => {
+                                    InferConditionFlow::TrueCondition
+                                }
+                            }
                         };
 
                         return get_type_at_call_expr(db, cache, var_ref_id, left_call_expr, flow);
@@ -498,8 +463,8 @@ fn get_var_eq_condition_action(
             }
 
             let right_expr_type = infer_expr(db, cache, right_expr)?;
-            if condition_flow.is_false() {
-                return Ok(ConditionFlowAction::pending(PendingConditionNarrow::Eq {
+            if matches!(condition_flow, InferConditionFlow::FalseCondition) {
+                return Ok(ConditionFlowAction::Pending(PendingConditionNarrow::Eq {
                     right_expr_type,
                     condition_flow,
                 }));
@@ -532,25 +497,15 @@ fn get_var_eq_condition_action(
 
             let right_expr_type = infer_expr(db, cache, right_expr)?;
             let antecedent_flow_id = get_single_antecedent(flow_node)?;
-            let antecedent_type =
-                get_type_at_flow(db, tree, cache, root, var_ref_id, antecedent_flow_id)?;
-            match (&antecedent_type, &right_expr_type) {
-                (
-                    LuaType::Array(array_type),
-                    LuaType::IntegerConst(i) | LuaType::DocIntegerConst(i),
-                ) => {
-                    if condition_flow.is_true() {
-                        let new_array_type =
-                            LuaArrayType::new(array_type.get_base().clone(), LuaArrayLen::Max(*i));
-                        return Ok(ConditionFlowAction::Result(LuaType::Array(
-                            new_array_type.into(),
-                        )));
-                    }
-                }
-                _ => return Ok(ConditionFlowAction::Continue),
-            }
-
-            Ok(ConditionFlowAction::Continue)
+            Ok(ConditionFlowAction::NeedSubquery(
+                ConditionSubquery::ArrayLen {
+                    var_ref_id: var_ref_id.clone(),
+                    antecedent_flow_id,
+                    subquery_condition_flow: condition_flow,
+                    right_expr_type,
+                    max_adjustment: 0,
+                },
+            ))
         }
         _ => {
             // If the left expression is not a name or call expression, we cannot narrow it
@@ -559,12 +514,9 @@ fn get_var_eq_condition_action(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 fn maybe_field_literal_eq_action(
     db: &DbIndex,
-    tree: &FlowTree,
     cache: &mut LuaInferCache,
-    root: &LuaChunk,
     var_ref_id: &VarRefId,
     flow_node: &FlowNode,
     left_expr: LuaExpr,
@@ -582,6 +534,9 @@ fn maybe_field_literal_eq_action(
         }
         _ => return Ok(None),
     };
+    if matches!(literal_expr.get_literal(), Some(LuaLiteralToken::Nil(_))) {
+        return Ok(None);
+    }
 
     let Some(prefix_expr) = index_expr.get_prefix_expr() else {
         return Ok(None);
@@ -607,51 +562,17 @@ fn maybe_field_literal_eq_action(
     }
 
     let antecedent_flow_id = get_single_antecedent(flow_node)?;
-    let left_type = get_type_at_flow(db, tree, cache, root, var_ref_id, antecedent_flow_id)?;
-    let LuaType::Union(union_type) = left_type else {
-        return Ok(None);
-    };
-
     cache
         .narrow_by_literal_stop_position_cache
         .insert(syntax_id);
-
     let right_type = infer_expr(db, cache, LuaExpr::LiteralExpr(literal_expr))?;
-    let index = LuaIndexMemberExpr::IndexExpr(index_expr);
-    let mut opt_result = None;
-    let mut union_types = union_type.into_vec();
-    for (i, sub_type) in union_types.iter().enumerate() {
-        let member_type = match infer_member_by_member_key(
-            db,
-            cache,
-            sub_type,
-            index.clone(),
-            &InferGuard::new(),
-        ) {
-            Ok(member_type) => member_type,
-            Err(_) => continue, // If we cannot infer the member type, skip this type
-        };
-        if always_literal_equal(&member_type, &right_type) {
-            // If the right type matches the member type, we can narrow it
-            opt_result = Some(i);
-        }
-    }
-
-    match condition_flow {
-        InferConditionFlow::TrueCondition => {
-            if let Some(i) = opt_result {
-                return Ok(Some(ConditionFlowAction::Result(union_types[i].clone())));
-            }
-        }
-        InferConditionFlow::FalseCondition => {
-            if let Some(i) = opt_result {
-                union_types.remove(i);
-                return Ok(Some(ConditionFlowAction::Result(LuaType::from_vec(
-                    union_types,
-                ))));
-            }
-        }
-    }
-
-    Ok(None)
+    Ok(Some(ConditionFlowAction::NeedSubquery(
+        ConditionSubquery::FieldLiteralEq {
+            var_ref_id: var_ref_id.clone(),
+            antecedent_flow_id,
+            subquery_condition_flow: condition_flow,
+            idx: LuaIndexMemberExpr::IndexExpr(index_expr),
+            right_expr_type: right_type,
+        },
+    )))
 }

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/call_flow.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/call_flow.rs
@@ -9,7 +9,6 @@ use crate::{
         VarRefId,
         infer_index::infer_member_by_member_key,
         narrow::{
-            ResultTypeOrContinue,
             condition_flow::{ConditionFlowAction, InferConditionFlow, PendingConditionNarrow},
             get_var_ref_type, narrow_false_or_nil, remove_false_or_nil,
             var_ref_id::get_var_expr_var_ref_id,
@@ -47,9 +46,9 @@ pub fn get_type_at_call_expr(
                     if needs_antecedent_same_var_colon_lookup(&member_type) {
                         // Keep the dedicated pending case here: replay needs the antecedent type
                         // for member lookup itself, not just for applying a cast after lookup.
-                        return Ok(ConditionFlowAction::pending(
+                        return Ok(ConditionFlowAction::Pending(
                             PendingConditionNarrow::SameVarColonCall {
-                                index: LuaIndexMemberExpr::IndexExpr(index_expr.clone()),
+                                idx: LuaIndexMemberExpr::IndexExpr(index_expr.clone()),
                                 condition_flow,
                             },
                         ));
@@ -98,15 +97,14 @@ pub fn get_type_at_call_expr(
                     );
                 }
                 LuaType::Call(call) => {
-                    return Ok(get_type_at_call_expr_by_call(
+                    return get_type_at_call_expr_by_call(
                         db,
                         cache,
                         var_ref_id,
                         call_expr,
                         &call,
                         condition_flow,
-                    )?
-                    .into());
+                    );
                 }
                 _ => {}
             }
@@ -216,7 +214,7 @@ fn get_type_at_call_expr_by_type_guard(
         return Ok(ConditionFlowAction::Continue);
     }
 
-    Ok(ConditionFlowAction::pending(
+    Ok(ConditionFlowAction::Pending(
         PendingConditionNarrow::TypeGuard {
             narrow: guard_type,
             condition_flow,
@@ -248,7 +246,12 @@ fn get_type_at_call_expr_by_signature_self(
         return Ok(ConditionFlowAction::Continue);
     }
 
-    Ok(get_signature_cast_pending(signature_id, condition_flow))
+    Ok(ConditionFlowAction::Pending(
+        PendingConditionNarrow::SignatureCast {
+            signature_id,
+            condition_flow,
+        },
+    ))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -301,17 +304,12 @@ fn get_type_at_call_expr_by_signature_param_name(
         return Ok(ConditionFlowAction::Continue);
     }
 
-    Ok(get_signature_cast_pending(signature_id, condition_flow))
-}
-
-fn get_signature_cast_pending(
-    signature_id: LuaSignatureId,
-    condition_flow: InferConditionFlow,
-) -> ConditionFlowAction {
-    ConditionFlowAction::pending(PendingConditionNarrow::SignatureCast {
-        signature_id,
-        condition_flow,
-    })
+    Ok(ConditionFlowAction::Pending(
+        PendingConditionNarrow::SignatureCast {
+            signature_id,
+            condition_flow,
+        },
+    ))
 }
 
 fn get_type_at_call_expr_by_call(
@@ -321,15 +319,15 @@ fn get_type_at_call_expr_by_call(
     call_expr: LuaCallExpr,
     alias_call_type: &Arc<LuaAliasCallType>,
     condition_flow: InferConditionFlow,
-) -> Result<ResultTypeOrContinue, InferFailReason> {
+) -> Result<ConditionFlowAction, InferFailReason> {
     let Some(maybe_ref_id) =
         get_var_expr_var_ref_id(db, cache, LuaExpr::CallExpr(call_expr.clone()))
     else {
-        return Ok(ResultTypeOrContinue::Continue);
+        return Ok(ConditionFlowAction::Continue);
     };
 
     if maybe_ref_id != *var_ref_id {
-        return Ok(ResultTypeOrContinue::Continue);
+        return Ok(ConditionFlowAction::Continue);
     }
 
     if alias_call_type.get_call_kind() == LuaAliasCallKind::RawGet {
@@ -338,8 +336,8 @@ fn get_type_at_call_expr_by_call(
             InferConditionFlow::FalseCondition => narrow_false_or_nil(db, antecedent_type),
             InferConditionFlow::TrueCondition => remove_false_or_nil(antecedent_type),
         };
-        return Ok(ResultTypeOrContinue::Result(result_type));
+        return Ok(ConditionFlowAction::Result(result_type));
     };
 
-    Ok(ResultTypeOrContinue::Continue)
+    Ok(ConditionFlowAction::Continue)
 }

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/correlated_flow.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/correlated_flow.rs
@@ -1,15 +1,14 @@
-use std::collections::HashSet;
+use std::{collections::HashSet, rc::Rc};
 
 use emmylua_parser::{LuaAstPtr, LuaCallExpr, LuaChunk};
 
 use crate::{
-    DbIndex, FlowId, FlowNode, FlowTree, InferFailReason, LuaDeclId, LuaFunctionType,
-    LuaInferCache, LuaSignature, LuaType, TypeOps, infer_expr, instantiate_func_generic,
-    semantic::infer::{
-        VarRefId,
-        narrow::{get_single_antecedent, get_type_at_flow::get_type_at_flow, narrow_down_type},
-    },
+    DbIndex, FlowId, FlowTree, InferFailReason, LuaDeclId, LuaFunctionType, LuaInferCache,
+    LuaSignature, LuaType, TypeOps, infer_expr, instantiate_func_generic,
+    semantic::infer::{InferResult, VarRefId, narrow::narrow_down_type},
 };
+
+use super::{ConditionFlowAction, PendingConditionNarrow};
 
 #[derive(Debug, Clone)]
 pub(in crate::semantic) struct CorrelatedConditionNarrowing {
@@ -30,6 +29,24 @@ struct CollectedCorrelatedTypes {
     unmatched_target_types: Vec<LuaType>,
     has_unmatched_discriminant_origin: bool,
     has_opaque_target_origin: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(in crate::semantic) struct PendingCorrelatedCondition {
+    search_root_states: Vec<PendingSearchRootState>,
+    next_pending_index: usize,
+    pub(in crate::semantic::infer::narrow) current_search_root_flow_id: FlowId,
+}
+
+#[derive(Debug, Clone)]
+enum PendingSearchRootState {
+    Ready(SearchRootCorrelatedTypes),
+    NeedRootType {
+        flow_id: FlowId,
+        matching_target_types: Vec<LuaType>,
+        uncorrelated_target_types: Vec<LuaType>,
+        known_call_target_types: Vec<LuaType>,
+    },
 }
 
 impl CorrelatedConditionNarrowing {
@@ -118,37 +135,35 @@ pub(in crate::semantic::infer::narrow) fn prepare_var_from_return_overload_condi
     cache: &mut LuaInferCache,
     root: &LuaChunk,
     var_ref_id: &VarRefId,
-    flow_node: &FlowNode,
     discriminant_decl_id: LuaDeclId,
     condition_position: rowan::TextSize,
+    antecedent_flow_id: FlowId,
     narrowed_discriminant_type: &LuaType,
-) -> Result<Option<CorrelatedConditionNarrowing>, InferFailReason> {
+) -> Result<ConditionFlowAction, InferFailReason> {
     let Some(target_decl_id) = var_ref_id.get_decl_id_ref() else {
-        return Ok(None);
+        return Ok(ConditionFlowAction::Continue);
     };
     if !tree.has_decl_multi_return_refs(&discriminant_decl_id)
         || !tree.has_decl_multi_return_refs(&target_decl_id)
     {
-        return Ok(None);
+        return Ok(ConditionFlowAction::Continue);
     }
 
-    let antecedent_flow_id = get_single_antecedent(flow_node)?;
     let search_root_flow_ids = tree.get_decl_multi_return_search_roots(
         &discriminant_decl_id,
         &target_decl_id,
         condition_position,
         antecedent_flow_id,
     );
-    let root_correlated_types = search_root_flow_ids
+    let search_root_states = search_root_flow_ids
         .iter()
         .copied()
         .map(|search_root_flow_id| {
-            collect_correlated_types_from_search_root(
+            prepare_search_root_correlated_types(
                 db,
                 tree,
                 cache,
                 root,
-                var_ref_id,
                 discriminant_decl_id,
                 target_decl_id,
                 condition_position,
@@ -159,32 +174,35 @@ pub(in crate::semantic::infer::narrow) fn prepare_var_from_return_overload_condi
         })
         .collect::<Result<Vec<_>, _>>()?;
 
-    if root_correlated_types
+    if let Some(next_pending_index) = search_root_states
         .iter()
-        .all(|root_types| root_types.matching_target_types.is_empty())
+        .position(|root_state| matches!(root_state, PendingSearchRootState::NeedRootType { .. }))
     {
-        return Ok(None);
+        Ok(ConditionFlowAction::NeedCorrelated(
+            PendingCorrelatedCondition {
+                search_root_states,
+                next_pending_index,
+                current_search_root_flow_id: search_root_flow_ids[next_pending_index],
+            },
+        ))
+    } else {
+        Ok(finish_correlated_condition(search_root_states))
     }
-
-    Ok(Some(CorrelatedConditionNarrowing {
-        search_root_correlated_types: root_correlated_types,
-    }))
 }
 
 #[allow(clippy::too_many_arguments)]
-fn collect_correlated_types_from_search_root(
+fn prepare_search_root_correlated_types(
     db: &DbIndex,
     tree: &FlowTree,
     cache: &mut LuaInferCache,
     root: &LuaChunk,
-    var_ref_id: &VarRefId,
     discriminant_decl_id: LuaDeclId,
     target_decl_id: LuaDeclId,
     condition_position: rowan::TextSize,
     antecedent_flow_id: FlowId,
     search_root_flow_id: FlowId,
     narrowed_discriminant_type: &LuaType,
-) -> Result<SearchRootCorrelatedTypes, InferFailReason> {
+) -> Result<PendingSearchRootState, InferFailReason> {
     let (discriminant_refs, discriminant_has_non_reference_origin) = tree
         .get_decl_multi_return_ref_summary_at(
             &discriminant_decl_id,
@@ -211,47 +229,115 @@ fn collect_correlated_types_from_search_root(
         narrowed_discriminant_type,
     )?;
 
-    let mut root_uncorrelated_target_types = root_unmatched_target_types;
     let has_uncorrelated_origin = discriminant_has_non_reference_origin
         || target_has_non_reference_origin
         || has_opaque_target_origin
         || has_unmatched_discriminant_origin;
-    let correlated_candidate_types_is_empty = root_correlated_candidate_types.is_empty();
-    let deferred_known_call_target_types =
-        if has_uncorrelated_origin && search_root_flow_id == antecedent_flow_id {
-            let mut known_call_target_types = root_correlated_candidate_types.clone();
-            known_call_target_types.extend(root_uncorrelated_target_types.iter().cloned());
-            Some(known_call_target_types)
-        } else {
-            None
-        };
-    if has_uncorrelated_origin && deferred_known_call_target_types.is_none() {
-        if correlated_candidate_types_is_empty && root_uncorrelated_target_types.is_empty() {
-            if let Ok(root_type) =
-                get_type_at_flow(db, tree, cache, root, var_ref_id, search_root_flow_id)
-            {
-                root_uncorrelated_target_types.push(root_type);
-            }
-        } else {
-            let mut known_call_target_types = root_correlated_candidate_types.clone();
-            known_call_target_types.extend(root_uncorrelated_target_types.iter().cloned());
-            if let Some(remaining_root_type) =
-                get_type_at_flow(db, tree, cache, root, var_ref_id, search_root_flow_id)
-                    .ok()
-                    .and_then(|root_type| {
-                        subtract_correlated_candidate_types(db, root_type, &known_call_target_types)
-                    })
-            {
-                root_uncorrelated_target_types.push(remaining_root_type);
-            }
-        }
+    if !has_uncorrelated_origin {
+        return Ok(PendingSearchRootState::Ready(SearchRootCorrelatedTypes {
+            matching_target_types: root_matching_target_types,
+            uncorrelated_target_types: root_unmatched_target_types,
+            deferred_known_call_target_types: None,
+        }));
     }
 
-    Ok(SearchRootCorrelatedTypes {
+    let mut known_call_target_types = root_correlated_candidate_types;
+    known_call_target_types.extend(root_unmatched_target_types.iter().cloned());
+    if search_root_flow_id == antecedent_flow_id {
+        return Ok(PendingSearchRootState::Ready(SearchRootCorrelatedTypes {
+            matching_target_types: root_matching_target_types,
+            uncorrelated_target_types: root_unmatched_target_types,
+            deferred_known_call_target_types: Some(known_call_target_types),
+        }));
+    }
+
+    Ok(PendingSearchRootState::NeedRootType {
+        flow_id: search_root_flow_id,
         matching_target_types: root_matching_target_types,
-        uncorrelated_target_types: root_uncorrelated_target_types,
-        deferred_known_call_target_types,
+        uncorrelated_target_types: root_unmatched_target_types,
+        known_call_target_types,
     })
+}
+
+pub(in crate::semantic::infer::narrow) fn advance_pending_correlated_condition(
+    db: &DbIndex,
+    mut pending: PendingCorrelatedCondition,
+    root_result: InferResult,
+) -> ConditionFlowAction {
+    let next_pending_index = pending.next_pending_index;
+    let root_state = std::mem::replace(
+        &mut pending.search_root_states[next_pending_index],
+        PendingSearchRootState::Ready(SearchRootCorrelatedTypes {
+            matching_target_types: Vec::new(),
+            uncorrelated_target_types: Vec::new(),
+            deferred_known_call_target_types: None,
+        }),
+    );
+    let PendingSearchRootState::NeedRootType {
+        matching_target_types,
+        mut uncorrelated_target_types,
+        known_call_target_types,
+        ..
+    } = root_state
+    else {
+        unreachable!();
+    };
+
+    if let Ok(root_type) = root_result
+        && let Some(remaining_root_type) =
+            subtract_correlated_candidate_types(db, root_type, &known_call_target_types)
+    {
+        uncorrelated_target_types.push(remaining_root_type);
+    }
+
+    pending.search_root_states[next_pending_index] =
+        PendingSearchRootState::Ready(SearchRootCorrelatedTypes {
+            matching_target_types,
+            uncorrelated_target_types,
+            deferred_known_call_target_types: None,
+        });
+
+    if let Some(next_pending_index) = pending.search_root_states[next_pending_index + 1..]
+        .iter()
+        .position(|root_state| matches!(root_state, PendingSearchRootState::NeedRootType { .. }))
+        .map(|idx| idx + next_pending_index + 1)
+    {
+        pending.next_pending_index = next_pending_index;
+        pending.current_search_root_flow_id = match &pending.search_root_states[next_pending_index]
+        {
+            PendingSearchRootState::NeedRootType { flow_id, .. } => *flow_id,
+            PendingSearchRootState::Ready(_) => unreachable!(),
+        };
+        ConditionFlowAction::NeedCorrelated(pending)
+    } else {
+        finish_correlated_condition(pending.search_root_states)
+    }
+}
+
+fn finish_correlated_condition(
+    search_root_states: Vec<PendingSearchRootState>,
+) -> ConditionFlowAction {
+    let search_root_correlated_types = search_root_states
+        .into_iter()
+        .map(|root_state| match root_state {
+            PendingSearchRootState::Ready(root_types) => root_types,
+            PendingSearchRootState::NeedRootType { .. } => unreachable!(),
+        })
+        .collect::<Vec<_>>();
+
+    if search_root_correlated_types
+        .iter()
+        .all(|root_types| root_types.matching_target_types.is_empty())
+    {
+        return ConditionFlowAction::Continue;
+    }
+
+    // Correlated narrows can hold large per-root type sets, so keep cache hits cheap.
+    ConditionFlowAction::Pending(PendingConditionNarrow::Correlated(Rc::new(
+        CorrelatedConditionNarrowing {
+            search_root_correlated_types,
+        },
+    )))
 }
 
 fn subtract_correlated_candidate_types(

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/index_flow.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/index_flow.rs
@@ -25,7 +25,7 @@ pub fn get_type_at_index_expr(
     };
 
     if name_var_ref_id == *var_ref_id {
-        return Ok(ConditionFlowAction::pending(
+        return Ok(ConditionFlowAction::Pending(
             PendingConditionNarrow::Truthiness(condition_flow),
         ));
     }
@@ -43,9 +43,9 @@ pub fn get_type_at_index_expr(
         return Ok(ConditionFlowAction::Continue);
     }
 
-    Ok(ConditionFlowAction::pending(
+    Ok(ConditionFlowAction::Pending(
         PendingConditionNarrow::FieldTruthy {
-            index: LuaIndexMemberExpr::IndexExpr(index_expr),
+            idx: LuaIndexMemberExpr::IndexExpr(index_expr),
             condition_flow,
         },
     ))

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/mod.rs
@@ -6,90 +6,96 @@ mod index_flow;
 use std::rc::Rc;
 
 use self::{
-    binary_flow::get_type_at_binary_expr,
-    correlated_flow::{CorrelatedConditionNarrowing, prepare_var_from_return_overload_condition},
+    binary_flow::{get_type_at_binary_expr, narrow_eq_condition},
+    correlated_flow::{
+        CorrelatedConditionNarrowing, PendingCorrelatedCondition,
+        prepare_var_from_return_overload_condition,
+    },
 };
-use emmylua_parser::{
-    LuaAstNode, LuaChunk, LuaExpr, LuaIndexMemberExpr, LuaNameExpr, LuaUnaryExpr, UnaryOperator,
-};
+use emmylua_parser::{LuaAstNode, LuaChunk, LuaExpr, LuaIndexMemberExpr, UnaryOperator};
 
 use crate::{
-    DbIndex, FlowNode, FlowTree, InferFailReason, InferGuard, LuaInferCache, LuaSignatureCast,
-    LuaSignatureId, LuaType,
+    DbIndex, FlowId, FlowNode, FlowTree, InferFailReason, InferGuard, LuaArrayLen, LuaArrayType,
+    LuaDeclId, LuaInferCache, LuaSignatureCast, LuaSignatureId, LuaType, TypeOps,
     semantic::infer::{
         VarRefId,
         infer_index::infer_member_by_member_key,
         narrow::{
-            ResultTypeOrContinue,
             condition_flow::{
                 call_flow::get_type_at_call_expr, index_flow::get_type_at_index_expr,
             },
             get_single_antecedent,
             get_type_at_cast_flow::cast_type,
-            get_type_at_flow::get_type_at_flow,
             narrow_down_type, narrow_false_or_nil, remove_false_or_nil,
             var_ref_id::get_var_expr_var_ref_id,
         },
     },
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum InferConditionFlow {
     TrueCondition,
     FalseCondition,
 }
 
-impl InferConditionFlow {
-    pub fn get_negated(&self) -> Self {
-        match self {
-            InferConditionFlow::TrueCondition => InferConditionFlow::FalseCondition,
-            InferConditionFlow::FalseCondition => InferConditionFlow::TrueCondition,
-        }
-    }
+#[derive(Debug, Clone)]
+pub(in crate::semantic) enum ConditionSubquery {
+    ArrayLen {
+        var_ref_id: VarRefId,
+        antecedent_flow_id: FlowId,
+        // This is the effective narrowing polarity after rewrites like `not` and `~=`.
+        subquery_condition_flow: InferConditionFlow,
+        right_expr_type: LuaType,
+        max_adjustment: i64,
+    },
+    FieldLiteralEq {
+        var_ref_id: VarRefId,
+        antecedent_flow_id: FlowId,
+        subquery_condition_flow: InferConditionFlow,
+        idx: LuaIndexMemberExpr,
+        right_expr_type: LuaType,
+    },
+    Correlated {
+        var_ref_id: VarRefId,
+        antecedent_flow_id: FlowId,
+        subquery_condition_flow: InferConditionFlow,
+        discriminant_decl_id: LuaDeclId,
+        condition_position: rowan::TextSize,
+        narrow: CorrelatedDiscriminantNarrow,
+        fallback_expr: Option<LuaExpr>,
+    },
+}
 
-    #[allow(unused)]
-    pub fn is_true(&self) -> bool {
-        matches!(self, InferConditionFlow::TrueCondition)
-    }
-
-    pub fn is_false(&self) -> bool {
-        matches!(self, InferConditionFlow::FalseCondition)
-    }
+#[derive(Debug, Clone)]
+pub(in crate::semantic) enum CorrelatedDiscriminantNarrow {
+    Truthiness,
+    TypeGuard {
+        narrow: LuaType,
+    },
+    Eq {
+        right_expr_type: LuaType,
+        allow_literal_equivalence: bool,
+    },
 }
 
 #[derive(Debug, Clone)]
 pub(in crate::semantic) enum ConditionFlowAction {
     Continue,
     Result(LuaType),
-    Pending(Rc<PendingConditionNarrow>),
-}
-
-impl From<ResultTypeOrContinue> for ConditionFlowAction {
-    fn from(result_or_continue: ResultTypeOrContinue) -> Self {
-        match result_or_continue {
-            ResultTypeOrContinue::Continue => ConditionFlowAction::Continue,
-            ResultTypeOrContinue::Result(result_type) => ConditionFlowAction::Result(result_type),
-        }
-    }
-}
-
-impl ConditionFlowAction {
-    pub(in crate::semantic::infer::narrow) fn pending(
-        pending_condition_narrow: PendingConditionNarrow,
-    ) -> Self {
-        ConditionFlowAction::Pending(Rc::new(pending_condition_narrow))
-    }
+    Pending(PendingConditionNarrow),
+    NeedSubquery(ConditionSubquery),
+    NeedCorrelated(PendingCorrelatedCondition),
 }
 
 #[derive(Debug, Clone)]
 pub(in crate::semantic) enum PendingConditionNarrow {
     Truthiness(InferConditionFlow),
     FieldTruthy {
-        index: LuaIndexMemberExpr,
+        idx: LuaIndexMemberExpr,
         condition_flow: InferConditionFlow,
     },
     SameVarColonCall {
-        index: LuaIndexMemberExpr,
+        idx: LuaIndexMemberExpr,
         condition_flow: InferConditionFlow,
     },
     SignatureCast {
@@ -104,7 +110,7 @@ pub(in crate::semantic) enum PendingConditionNarrow {
         narrow: LuaType,
         condition_flow: InferConditionFlow,
     },
-    Correlated(CorrelatedConditionNarrowing),
+    Correlated(Rc<CorrelatedConditionNarrowing>),
 }
 
 impl PendingConditionNarrow {
@@ -120,7 +126,7 @@ impl PendingConditionNarrow {
                 InferConditionFlow::TrueCondition => remove_false_or_nil(antecedent_type),
             },
             PendingConditionNarrow::FieldTruthy {
-                index,
+                idx,
                 condition_flow,
             } => {
                 let LuaType::Union(union_type) = &antecedent_type else {
@@ -134,7 +140,7 @@ impl PendingConditionNarrow {
                         db,
                         cache,
                         sub_type,
-                        index.clone(),
+                        idx.clone(),
                         &InferGuard::new(),
                     ) {
                         Ok(member_type) => member_type,
@@ -159,14 +165,14 @@ impl PendingConditionNarrow {
                 }
             }
             PendingConditionNarrow::SameVarColonCall {
-                index,
+                idx,
                 condition_flow,
             } => {
                 let Ok(member_type) = infer_member_by_member_key(
                     db,
                     cache,
                     &antecedent_type,
-                    index.clone(),
+                    idx.clone(),
                     &InferGuard::new(),
                 ) else {
                     return antecedent_type;
@@ -288,7 +294,7 @@ fn apply_signature_cast(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn get_type_at_condition_flow(
+pub(super) fn get_type_at_condition_flow(
     db: &DbIndex,
     tree: &FlowTree,
     cache: &mut LuaInferCache,
@@ -298,50 +304,239 @@ pub fn get_type_at_condition_flow(
     condition: LuaExpr,
     condition_flow: InferConditionFlow,
 ) -> Result<ConditionFlowAction, InferFailReason> {
-    match condition {
-        LuaExpr::NameExpr(name_expr) => get_type_at_name_expr(
-            db,
-            tree,
-            cache,
-            root,
-            var_ref_id,
-            flow_node,
-            name_expr,
-            condition_flow,
-        ),
-        LuaExpr::CallExpr(call_expr) => {
-            get_type_at_call_expr(db, cache, var_ref_id, call_expr, condition_flow)
+    let mut condition = condition;
+    let mut condition_flow = condition_flow;
+
+    loop {
+        match condition {
+            LuaExpr::NameExpr(name_expr) => {
+                let Some(name_var_ref_id) =
+                    get_var_expr_var_ref_id(db, cache, LuaExpr::NameExpr(name_expr.clone()))
+                else {
+                    return Ok(ConditionFlowAction::Continue);
+                };
+
+                if name_var_ref_id == *var_ref_id {
+                    return Ok(ConditionFlowAction::Pending(
+                        PendingConditionNarrow::Truthiness(condition_flow),
+                    ));
+                }
+
+                let Some(decl_id) = db
+                    .get_reference_index()
+                    .get_var_reference_decl(&cache.get_file_id(), name_expr.get_range())
+                else {
+                    return Ok(ConditionFlowAction::Continue);
+                };
+
+                if let Some(target_decl_id) = var_ref_id.get_decl_id_ref()
+                    && tree.has_decl_multi_return_refs(&decl_id)
+                    && tree.has_decl_multi_return_refs(&target_decl_id)
+                {
+                    let antecedent_flow_id = get_single_antecedent(flow_node)?;
+                    let fallback_expr = tree
+                        .get_decl_ref_expr(&decl_id)
+                        .and_then(|expr_ptr| expr_ptr.to_node(root));
+                    return Ok(ConditionFlowAction::NeedSubquery(
+                        ConditionSubquery::Correlated {
+                            var_ref_id: VarRefId::VarRef(decl_id),
+                            antecedent_flow_id,
+                            subquery_condition_flow: condition_flow,
+                            discriminant_decl_id: decl_id,
+                            condition_position: name_expr.get_position(),
+                            narrow: CorrelatedDiscriminantNarrow::Truthiness,
+                            fallback_expr,
+                        },
+                    ));
+                }
+
+                let Some(expr_ptr) = tree.get_decl_ref_expr(&decl_id) else {
+                    return Ok(ConditionFlowAction::Continue);
+                };
+                let Some(expr) = expr_ptr.to_node(root) else {
+                    return Ok(ConditionFlowAction::Continue);
+                };
+                condition = expr;
+                continue;
+            }
+            LuaExpr::CallExpr(call_expr) => {
+                return get_type_at_call_expr(db, cache, var_ref_id, call_expr, condition_flow);
+            }
+            LuaExpr::IndexExpr(index_expr) => {
+                return get_type_at_index_expr(db, cache, var_ref_id, index_expr, condition_flow);
+            }
+            LuaExpr::TableExpr(_) | LuaExpr::LiteralExpr(_) | LuaExpr::ClosureExpr(_) => {
+                return Ok(ConditionFlowAction::Continue);
+            }
+            LuaExpr::BinaryExpr(binary_expr) => {
+                return get_type_at_binary_expr(
+                    db,
+                    tree,
+                    cache,
+                    root,
+                    var_ref_id,
+                    flow_node,
+                    binary_expr,
+                    condition_flow,
+                );
+            }
+            LuaExpr::UnaryExpr(unary_expr) => {
+                let Some(inner_expr) = unary_expr.get_expr() else {
+                    return Ok(ConditionFlowAction::Continue);
+                };
+                let Some(op) = unary_expr.get_op_token() else {
+                    return Ok(ConditionFlowAction::Continue);
+                };
+                if op.get_op() != UnaryOperator::OpNot {
+                    return Ok(ConditionFlowAction::Continue);
+                }
+
+                condition = inner_expr;
+                condition_flow = match condition_flow {
+                    InferConditionFlow::TrueCondition => InferConditionFlow::FalseCondition,
+                    InferConditionFlow::FalseCondition => InferConditionFlow::TrueCondition,
+                };
+                continue;
+            }
+            LuaExpr::ParenExpr(paren_expr) => {
+                let Some(inner_expr) = paren_expr.get_expr() else {
+                    return Ok(ConditionFlowAction::Continue);
+                };
+                condition = inner_expr;
+                continue;
+            }
         }
-        LuaExpr::IndexExpr(index_expr) => {
-            get_type_at_index_expr(db, cache, var_ref_id, index_expr, condition_flow)
-        }
-        LuaExpr::TableExpr(_) | LuaExpr::LiteralExpr(_) | LuaExpr::ClosureExpr(_) => {
-            Ok(ConditionFlowAction::Continue)
-        }
-        LuaExpr::BinaryExpr(binary_expr) => get_type_at_binary_expr(
-            db,
-            tree,
-            cache,
-            root,
-            var_ref_id,
-            flow_node,
-            binary_expr,
-            condition_flow,
-        ),
-        LuaExpr::UnaryExpr(unary_expr) => get_type_at_unary_flow(
-            db,
-            tree,
-            cache,
-            root,
-            var_ref_id,
-            flow_node,
-            unary_expr,
-            condition_flow,
-        ),
-        LuaExpr::ParenExpr(paren_expr) => {
-            let Some(inner_expr) = paren_expr.get_expr() else {
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(in crate::semantic::infer::narrow) fn resolve_condition_subquery(
+    db: &DbIndex,
+    tree: &FlowTree,
+    cache: &mut LuaInferCache,
+    root: &LuaChunk,
+    var_ref_id: &VarRefId,
+    flow_node: &FlowNode,
+    subquery: ConditionSubquery,
+    antecedent_type: LuaType,
+) -> Result<ConditionFlowAction, InferFailReason> {
+    match subquery {
+        ConditionSubquery::ArrayLen {
+            subquery_condition_flow,
+            right_expr_type,
+            max_adjustment,
+            ..
+        } => match (&antecedent_type, &right_expr_type) {
+            (
+                LuaType::Array(array_type),
+                LuaType::IntegerConst(i) | LuaType::DocIntegerConst(i),
+            ) if matches!(subquery_condition_flow, InferConditionFlow::TrueCondition) => {
+                let new_array_type = LuaArrayType::new(
+                    array_type.get_base().clone(),
+                    LuaArrayLen::Max(*i + max_adjustment),
+                );
+                Ok(ConditionFlowAction::Result(LuaType::Array(
+                    new_array_type.into(),
+                )))
+            }
+            _ => Ok(ConditionFlowAction::Continue),
+        },
+        ConditionSubquery::FieldLiteralEq {
+            subquery_condition_flow,
+            idx,
+            right_expr_type,
+            ..
+        } => {
+            let LuaType::Union(union_type) = antecedent_type else {
                 return Ok(ConditionFlowAction::Continue);
             };
+
+            let mut opt_result = None;
+            let mut union_types = union_type.into_vec();
+            for (i, sub_type) in union_types.iter().enumerate() {
+                let member_type = match infer_member_by_member_key(
+                    db,
+                    cache,
+                    sub_type,
+                    idx.clone(),
+                    &InferGuard::new(),
+                ) {
+                    Ok(member_type) => member_type,
+                    Err(_) => continue,
+                };
+                if always_literal_equal(&member_type, &right_expr_type) {
+                    opt_result = Some(i);
+                }
+            }
+
+            let action = match subquery_condition_flow {
+                InferConditionFlow::TrueCondition => opt_result
+                    .map(|i| ConditionFlowAction::Result(union_types[i].clone()))
+                    .unwrap_or(ConditionFlowAction::Continue),
+                InferConditionFlow::FalseCondition => opt_result
+                    .map(|i| {
+                        union_types.remove(i);
+                        ConditionFlowAction::Result(LuaType::from_vec(union_types))
+                    })
+                    .unwrap_or(ConditionFlowAction::Continue),
+            };
+            Ok(action)
+        }
+        ConditionSubquery::Correlated {
+            antecedent_flow_id,
+            subquery_condition_flow,
+            discriminant_decl_id,
+            condition_position,
+            narrow,
+            fallback_expr,
+            ..
+        } => {
+            let narrowed_discriminant_type = match narrow {
+                CorrelatedDiscriminantNarrow::Truthiness => match subquery_condition_flow {
+                    InferConditionFlow::FalseCondition => narrow_false_or_nil(db, antecedent_type),
+                    InferConditionFlow::TrueCondition => remove_false_or_nil(antecedent_type),
+                },
+                CorrelatedDiscriminantNarrow::TypeGuard { narrow } => match subquery_condition_flow
+                {
+                    InferConditionFlow::TrueCondition => {
+                        narrow_down_type(db, antecedent_type, narrow.clone(), None)
+                            .unwrap_or(narrow)
+                    }
+                    InferConditionFlow::FalseCondition => {
+                        TypeOps::Remove.apply(db, &antecedent_type, &narrow)
+                    }
+                },
+                CorrelatedDiscriminantNarrow::Eq {
+                    right_expr_type,
+                    allow_literal_equivalence,
+                } => narrow_eq_condition(
+                    db,
+                    antecedent_type,
+                    right_expr_type,
+                    subquery_condition_flow,
+                    allow_literal_equivalence,
+                ),
+            };
+
+            let action = prepare_var_from_return_overload_condition(
+                db,
+                tree,
+                cache,
+                root,
+                var_ref_id,
+                discriminant_decl_id,
+                condition_position,
+                antecedent_flow_id,
+                &narrowed_discriminant_type,
+            )?;
+
+            let Some(fallback_expr) = fallback_expr else {
+                return Ok(action);
+            };
+
+            if !matches!(action, ConditionFlowAction::Continue) {
+                return Ok(action);
+            }
 
             get_type_at_condition_flow(
                 db,
@@ -350,121 +545,11 @@ pub fn get_type_at_condition_flow(
                 root,
                 var_ref_id,
                 flow_node,
-                inner_expr,
-                condition_flow,
+                fallback_expr,
+                subquery_condition_flow,
             )
         }
     }
-}
-
-#[allow(clippy::too_many_arguments)]
-fn get_type_at_name_expr(
-    db: &DbIndex,
-    tree: &FlowTree,
-    cache: &mut LuaInferCache,
-    root: &LuaChunk,
-    var_ref_id: &VarRefId,
-    flow_node: &FlowNode,
-    name_expr: LuaNameExpr,
-    condition_flow: InferConditionFlow,
-) -> Result<ConditionFlowAction, InferFailReason> {
-    let Some(name_var_ref_id) =
-        get_var_expr_var_ref_id(db, cache, LuaExpr::NameExpr(name_expr.clone()))
-    else {
-        return Ok(ConditionFlowAction::Continue);
-    };
-
-    if name_var_ref_id != *var_ref_id {
-        return get_type_at_name_ref(
-            db,
-            tree,
-            cache,
-            root,
-            var_ref_id,
-            flow_node,
-            name_expr,
-            condition_flow,
-        );
-    }
-
-    Ok(ConditionFlowAction::pending(
-        PendingConditionNarrow::Truthiness(condition_flow),
-    ))
-}
-
-#[allow(clippy::too_many_arguments)]
-fn get_type_at_name_ref(
-    db: &DbIndex,
-    tree: &FlowTree,
-    cache: &mut LuaInferCache,
-    root: &LuaChunk,
-    var_ref_id: &VarRefId,
-    flow_node: &FlowNode,
-    name_expr: LuaNameExpr,
-    condition_flow: InferConditionFlow,
-) -> Result<ConditionFlowAction, InferFailReason> {
-    let Some(decl_id) = db
-        .get_reference_index()
-        .get_var_reference_decl(&cache.get_file_id(), name_expr.get_range())
-    else {
-        return Ok(ConditionFlowAction::Continue);
-    };
-
-    if let Some(target_decl_id) = var_ref_id.get_decl_id_ref()
-        && tree.has_decl_multi_return_refs(&decl_id)
-        && tree.has_decl_multi_return_refs(&target_decl_id)
-    {
-        let antecedent_flow_id = get_single_antecedent(flow_node)?;
-        let antecedent_discriminant_type = get_type_at_flow(
-            db,
-            tree,
-            cache,
-            root,
-            &VarRefId::VarRef(decl_id),
-            antecedent_flow_id,
-        )?;
-        let narrowed_discriminant_type = match condition_flow {
-            InferConditionFlow::FalseCondition => {
-                narrow_false_or_nil(db, antecedent_discriminant_type)
-            }
-            InferConditionFlow::TrueCondition => remove_false_or_nil(antecedent_discriminant_type),
-        };
-
-        if let Some(correlated_narrowing) = prepare_var_from_return_overload_condition(
-            db,
-            tree,
-            cache,
-            root,
-            var_ref_id,
-            flow_node,
-            decl_id,
-            name_expr.get_position(),
-            &narrowed_discriminant_type,
-        )? {
-            return Ok(ConditionFlowAction::pending(
-                PendingConditionNarrow::Correlated(correlated_narrowing),
-            ));
-        }
-    }
-
-    let Some(expr_ptr) = tree.get_decl_ref_expr(&decl_id) else {
-        return Ok(ConditionFlowAction::Continue);
-    };
-
-    let Some(expr) = expr_ptr.to_node(root) else {
-        return Ok(ConditionFlowAction::Continue);
-    };
-
-    get_type_at_condition_flow(
-        db,
-        tree,
-        cache,
-        root,
-        var_ref_id,
-        flow_node,
-        expr,
-        condition_flow,
-    )
 }
 
 pub(super) fn always_literal_equal(left: &LuaType, right: &LuaType) -> bool {
@@ -491,42 +576,4 @@ pub(super) fn always_literal_equal(left: &LuaType, right: &LuaType) -> bool {
         ) => l == r,
         _ => left == right,
     }
-}
-
-#[allow(clippy::too_many_arguments)]
-fn get_type_at_unary_flow(
-    db: &DbIndex,
-    tree: &FlowTree,
-    cache: &mut LuaInferCache,
-    root: &LuaChunk,
-    var_ref_id: &VarRefId,
-    flow_node: &FlowNode,
-    unary_expr: LuaUnaryExpr,
-    condition_flow: InferConditionFlow,
-) -> Result<ConditionFlowAction, InferFailReason> {
-    let Some(inner_expr) = unary_expr.get_expr() else {
-        return Ok(ConditionFlowAction::Continue);
-    };
-
-    let Some(op) = unary_expr.get_op_token() else {
-        return Ok(ConditionFlowAction::Continue);
-    };
-
-    match op.get_op() {
-        UnaryOperator::OpNot => {}
-        _ => {
-            return Ok(ConditionFlowAction::Continue);
-        }
-    }
-
-    get_type_at_condition_flow(
-        db,
-        tree,
-        cache,
-        root,
-        var_ref_id,
-        flow_node,
-        inner_expr,
-        condition_flow.get_negated(),
-    )
 }

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/get_type_at_cast_flow.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/get_type_at_cast_flow.rs
@@ -1,93 +1,9 @@
-use emmylua_parser::{
-    BinaryOperator, LuaAstNode, LuaCallExpr, LuaChunk, LuaDocOpType, LuaDocTagCast, LuaExpr,
-};
+use emmylua_parser::{BinaryOperator, LuaAstNode, LuaCallExpr, LuaChunk, LuaDocOpType};
 
 use crate::{
-    DbIndex, FileId, FlowId, FlowNode, FlowNodeKind, FlowTree, InFiled, InferFailReason,
-    LuaInferCache, LuaType, LuaTypeOwner, TypeOps,
-    semantic::infer::{
-        VarRefId,
-        narrow::{
-            ResultTypeOrContinue, condition_flow::InferConditionFlow, get_single_antecedent,
-            get_type_at_flow::get_type_at_flow, var_ref_id::get_var_expr_var_ref_id,
-        },
-    },
+    DbIndex, FileId, FlowId, FlowNodeKind, FlowTree, InFiled, InferFailReason, LuaInferCache,
+    LuaType, LuaTypeOwner, TypeOps, semantic::infer::narrow::condition_flow::InferConditionFlow,
 };
-
-pub fn get_type_at_cast_flow(
-    db: &DbIndex,
-    tree: &FlowTree,
-    cache: &mut LuaInferCache,
-    root: &LuaChunk,
-    var_ref_id: &VarRefId,
-    flow_node: &FlowNode,
-    tag_cast: LuaDocTagCast,
-) -> Result<ResultTypeOrContinue, InferFailReason> {
-    match tag_cast.get_key_expr() {
-        Some(expr) => {
-            get_type_at_cast_expr(db, tree, cache, root, var_ref_id, flow_node, tag_cast, expr)
-        }
-        None => get_type_at_inline_cast(db, tree, cache, root, var_ref_id, flow_node, tag_cast),
-    }
-}
-
-#[allow(clippy::too_many_arguments)]
-fn get_type_at_cast_expr(
-    db: &DbIndex,
-    tree: &FlowTree,
-    cache: &mut LuaInferCache,
-    root: &LuaChunk,
-    var_ref_id: &VarRefId,
-    flow_node: &FlowNode,
-    tag_cast: LuaDocTagCast,
-    key_expr: LuaExpr,
-) -> Result<ResultTypeOrContinue, InferFailReason> {
-    let Some(maybe_ref_id) = get_var_expr_var_ref_id(db, cache, key_expr) else {
-        return Ok(ResultTypeOrContinue::Continue);
-    };
-
-    if maybe_ref_id != *var_ref_id {
-        return Ok(ResultTypeOrContinue::Continue);
-    }
-
-    let antecedent_flow_id = get_single_antecedent(flow_node)?;
-    let mut antecedent_type =
-        get_type_at_flow(db, tree, cache, root, var_ref_id, antecedent_flow_id)?;
-    for cast_op_type in tag_cast.get_op_types() {
-        antecedent_type = cast_type(
-            db,
-            cache.get_file_id(),
-            cast_op_type,
-            antecedent_type,
-            InferConditionFlow::TrueCondition,
-        )?;
-    }
-    Ok(ResultTypeOrContinue::Result(antecedent_type))
-}
-
-fn get_type_at_inline_cast(
-    db: &DbIndex,
-    tree: &FlowTree,
-    cache: &mut LuaInferCache,
-    root: &LuaChunk,
-    var_ref_id: &VarRefId,
-    flow_node: &FlowNode,
-    tag_cast: LuaDocTagCast,
-) -> Result<ResultTypeOrContinue, InferFailReason> {
-    let antecedent_flow_id = get_single_antecedent(flow_node)?;
-    let mut antecedent_type =
-        get_type_at_flow(db, tree, cache, root, var_ref_id, antecedent_flow_id)?;
-    for cast_op_type in tag_cast.get_op_types() {
-        antecedent_type = cast_type(
-            db,
-            cache.get_file_id(),
-            cast_op_type,
-            antecedent_type,
-            InferConditionFlow::TrueCondition,
-        )?;
-    }
-    Ok(ResultTypeOrContinue::Result(antecedent_type))
-}
 
 pub fn get_type_at_call_expr_inline_cast(
     db: &DbIndex,
@@ -127,16 +43,6 @@ enum CastAction {
     Force,
 }
 
-impl CastAction {
-    fn get_negative(&self) -> Self {
-        match self {
-            CastAction::Add => CastAction::Remove,
-            CastAction::Remove => CastAction::Add,
-            CastAction::Force => CastAction::Remove,
-        }
-    }
-}
-
 pub fn cast_type(
     db: &DbIndex,
     file_id: FileId,
@@ -155,8 +61,12 @@ pub fn cast_type(
         None => CastAction::Force,
     };
 
-    if condition_flow.is_false() {
-        action = action.get_negative();
+    if matches!(condition_flow, InferConditionFlow::FalseCondition) {
+        action = match action {
+            CastAction::Add => CastAction::Remove,
+            CastAction::Remove => CastAction::Add,
+            CastAction::Force => CastAction::Remove,
+        };
     }
 
     if cast_op_type.is_nullable() {

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/get_type_at_flow.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/get_type_at_flow.rs
@@ -1,21 +1,27 @@
-use std::rc::Rc;
-
-use emmylua_parser::{LuaAssignStat, LuaAstNode, LuaChunk, LuaExpr, LuaVarExpr};
+use emmylua_parser::{
+    LuaAssignStat, LuaAstNode, LuaChunk, LuaDocOpType, LuaExpr, LuaVarExpr, UnaryOperator,
+};
+use hashbrown::HashSet;
+use std::{rc::Rc, sync::Arc};
 
 use crate::{
     CacheEntry, DbIndex, FlowId, FlowNode, FlowNodeKind, FlowTree, InferFailReason, LuaDeclId,
     LuaInferCache, LuaMemberId, LuaSignatureId, LuaType, TypeOps, check_type_compact, infer_expr,
     semantic::{
+        cache::{FlowAssignmentInfo, FlowConditionInfo, FlowMode, FlowVarCache},
         infer::{
             InferResult, VarRefId, infer_expr_list_value_type_at,
             narrow::{
-                ResultTypeOrContinue,
                 condition_flow::{
-                    ConditionFlowAction, InferConditionFlow, PendingConditionNarrow,
-                    get_type_at_condition_flow,
+                    ConditionFlowAction, ConditionSubquery, InferConditionFlow,
+                    PendingConditionNarrow,
+                    correlated_flow::{
+                        PendingCorrelatedCondition, advance_pending_correlated_condition,
+                    },
+                    get_type_at_condition_flow, resolve_condition_subquery,
                 },
                 get_multi_antecedents, get_single_antecedent,
-                get_type_at_cast_flow::get_type_at_cast_flow,
+                get_type_at_cast_flow::cast_type,
                 get_var_ref_type, narrow_down_type,
                 var_ref_id::get_var_expr_var_ref_id,
             },
@@ -24,7 +30,847 @@ use crate::{
     },
 };
 
-pub fn get_type_at_flow(
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+// One cached flow query: one ref at one flow node, optionally without replaying
+// pending condition narrows.
+// Example: "what is `x` at flow 42, with current guards applied?"
+struct FlowQuery {
+    var_ref_id: VarRefId,
+    var_cache_idx: u32,
+    flow_id: FlowId,
+    mode: FlowMode,
+}
+
+impl FlowQuery {
+    fn new(cache: &mut LuaInferCache, var_ref_id: &VarRefId, flow_id: FlowId) -> Self {
+        Self {
+            var_ref_id: var_ref_id.clone(),
+            var_cache_idx: get_flow_cache_var_ref_id(cache, var_ref_id),
+            flow_id,
+            mode: FlowMode::WithConditions,
+        }
+    }
+
+    fn at_flow(&self, flow_id: FlowId, mode: FlowMode) -> Self {
+        Self {
+            flow_id,
+            mode,
+            ..self.clone()
+        }
+    }
+}
+
+#[derive(Debug)]
+// Suspended state of one query's straight-line backward walk. We keep
+// collecting pending condition narrows until some node produces a final type or
+// needs another query first.
+// Example: while walking backward through `if x then ... end`, remember that
+// `x` must be truthy when the final type is produced.
+struct QueryWalk {
+    query: FlowQuery,
+    antecedent_flow_id: FlowId,
+    pending_condition_narrows: Vec<PendingConditionNarrow>,
+}
+
+// Explicit engine stack of suspended queries. We push one of these when the current query cannot
+// finish until another `FlowQuery` runs first. Each entry stores the suspended `QueryWalk` plus the
+// extra data needed to resume after that dependency query finishes. A dependency query is just
+// another `FlowQuery` started while resolving the current one.
+enum Continuation {
+    // Saved branch-merge state while one incoming branch query is in flight.
+    // Example: `if cond then x = "a" else x = 1 end` queries each incoming
+    // branch, then unions the results here.
+    Merge {
+        walk: QueryWalk,
+        branch_flow_ids: Arc<[FlowId]>,
+        next_pending_idx: usize,
+        merged_type: LuaType,
+    },
+    // Resume an assignment once we know the pre-assignment type of the same ref.
+    // Example: for `x = rhs`, first query `x` just before the assignment, then
+    // combine that antecedent type with the RHS type here.
+    AssignmentAntecedent {
+        walk: QueryWalk,
+        antecedent_flow_id: FlowId,
+        expr_type: LuaType,
+        reuse_source_narrowing: bool,
+    },
+    // Resume a tag cast after reading the antecedent value that the cast rewrites.
+    // Example: `---@cast x Foo` first queries `x` before the cast node, then
+    // applies the cast operators here.
+    TagCastAntecedent {
+        walk: QueryWalk,
+        cast_op_types: Vec<LuaDocOpType>,
+    },
+    // Resume a condition after querying another ref that the condition depends on.
+    // Example: `if #xs > 0 then` or `if shape.kind == "circle" then` needs the
+    // antecedent type of another ref before this query can narrow.
+    ConditionDependency {
+        walk: QueryWalk,
+        flow_id: FlowId,
+        condition_flow: InferConditionFlow,
+        subquery: ConditionSubquery,
+    },
+    // Resume correlated return-overload narrowing after querying one pending root.
+    // Example: `local ok, value = f(); if ok then ... value ... end` may need to
+    // query one multi-return search root at a time before it can narrow `value`.
+    CorrelatedSearchRoot {
+        walk: QueryWalk,
+        flow_id: FlowId,
+        condition_flow: InferConditionFlow,
+        pending_correlated_condition: PendingCorrelatedCondition,
+    },
+}
+
+// The top-loop scheduler decision.
+// `StartQuery` begins one query, optionally saving the current query first.
+// `ContinueWalk` keeps scanning backward through the current query.
+// `ResumeNext(result)` pops one suspended query from `stack` and resumes it
+// with the result of the dependency query that just finished.
+enum SchedulerStep {
+    // Start or reuse one `(var_ref, flow_id, mode)` query.
+    // If `continuation` is present, save that suspended query first so this
+    // dependency result can resume it later.
+    // Example: before resuming `x = rhs`, save the assignment continuation and
+    // then query `x` at the antecedent flow id.
+    StartQuery {
+        query: FlowQuery,
+        continuation: Option<Continuation>,
+    },
+    // Continue the straight-line backward walk for the current query.
+    // Example: after replaying a pending guard, keep scanning toward the next
+    // antecedent node.
+    ContinueWalk(QueryWalk),
+    // Pop one suspended query from `stack` and resume it with this dependency
+    // query result.
+    // Example: after querying `shape.kind`, continue narrowing
+    // `if shape.kind == "circle" then`.
+    ResumeNext(InferResult),
+}
+
+// Single owner of flow evaluation. Only this engine is allowed to schedule
+// follow-up queries, which keeps the flow path iterative.
+struct FlowTypeEngine<'a> {
+    db: &'a DbIndex,
+    tree: &'a FlowTree,
+    cache: &'a mut LuaInferCache,
+    root: &'a LuaChunk,
+}
+
+impl<'a> FlowTypeEngine<'a> {
+    fn run(&mut self, var_ref_id: &VarRefId, flow_id: FlowId) -> InferResult {
+        let mut stack = Vec::new();
+        let mut step = SchedulerStep::StartQuery {
+            query: FlowQuery::new(self.cache, var_ref_id, flow_id),
+            continuation: None,
+        };
+
+        loop {
+            step = match step {
+                SchedulerStep::StartQuery {
+                    query,
+                    continuation,
+                } => {
+                    if let Some(continuation) = continuation {
+                        stack.push(continuation);
+                    }
+                    self.start_query(query)
+                }
+                SchedulerStep::ContinueWalk(walk) => self.evaluate_walk(walk),
+                SchedulerStep::ResumeNext(query_result) => match stack.pop() {
+                    Some(Continuation::Merge {
+                        walk,
+                        branch_flow_ids,
+                        next_pending_idx,
+                        merged_type,
+                    }) => self.resume_merge(
+                        walk,
+                        branch_flow_ids,
+                        next_pending_idx,
+                        merged_type,
+                        query_result,
+                    ),
+                    Some(Continuation::AssignmentAntecedent {
+                        walk,
+                        antecedent_flow_id,
+                        expr_type,
+                        reuse_source_narrowing,
+                    }) => self.resume_assignment_antecedent(
+                        walk,
+                        antecedent_flow_id,
+                        expr_type,
+                        reuse_source_narrowing,
+                        query_result,
+                    ),
+                    Some(Continuation::TagCastAntecedent {
+                        walk,
+                        cast_op_types,
+                    }) => self.resume_tag_cast_antecedent(walk, cast_op_types, query_result),
+                    Some(Continuation::ConditionDependency {
+                        walk,
+                        flow_id,
+                        condition_flow,
+                        subquery,
+                    }) => self.resume_condition_subquery(
+                        walk,
+                        flow_id,
+                        condition_flow,
+                        subquery,
+                        query_result,
+                    ),
+                    Some(Continuation::CorrelatedSearchRoot {
+                        walk,
+                        flow_id,
+                        condition_flow,
+                        pending_correlated_condition,
+                    }) => self.apply_condition_action(
+                        walk,
+                        flow_id,
+                        condition_flow,
+                        advance_pending_correlated_condition(
+                            self.db,
+                            pending_correlated_condition,
+                            query_result,
+                        ),
+                    ),
+                    // No suspended query is waiting on this result, so it is the
+                    // final answer for the original `run(...)` request.
+                    None => break query_result,
+                },
+            }
+            .unwrap_or_else(|err| SchedulerStep::ResumeNext(Err(err)));
+        }
+    }
+
+    // Begin one flow query. If this `(var_ref, flow_id, mode)` pair is already
+    // resolved or already in progress, reuse that state; otherwise start the
+    // backward walk that computes it.
+    fn start_query(&mut self, query: FlowQuery) -> Result<SchedulerStep, InferFailReason> {
+        let type_cache_key = (query.flow_id, query.mode);
+        if let Some(cache_entry) = self
+            .cache
+            .flow_var_caches
+            .get(query.var_cache_idx as usize)
+            .and_then(|var_cache| var_cache.type_cache.get(&type_cache_key))
+        {
+            Ok(SchedulerStep::ResumeNext(match cache_entry {
+                CacheEntry::Cache(narrow_type) => Ok(narrow_type.clone()),
+                CacheEntry::Ready => Err(InferFailReason::RecursiveInfer),
+            }))
+        } else {
+            get_flow_var_cache(self.cache, query.var_cache_idx)
+                .type_cache
+                .insert(type_cache_key, CacheEntry::Ready);
+            self.evaluate_walk(QueryWalk {
+                antecedent_flow_id: query.flow_id,
+                query: query.clone(),
+                pending_condition_narrows: Vec::new(),
+            })
+            .or_else(|err| self.fail_query(&query, err))
+        }
+    }
+
+    // Consume one finished branch result, then either schedule the next branch
+    // query or finish the merged result.
+    fn resume_merge(
+        &mut self,
+        walk: QueryWalk,
+        branch_flow_ids: Arc<[FlowId]>,
+        next_pending_idx: usize,
+        merged_type: LuaType,
+        branch_result: InferResult,
+    ) -> Result<SchedulerStep, InferFailReason> {
+        let branch_type = match branch_result {
+            Ok(branch_type) => branch_type,
+            Err(err) => return self.fail_query(&walk.query, err),
+        };
+
+        let merged_type = TypeOps::Union.apply(self.db, &merged_type, &branch_type);
+        if next_pending_idx == 0 {
+            return Ok(self.finish_walk(walk, merged_type));
+        }
+
+        // Branches are resumed from the end because the initial merge setup
+        // schedules the last incoming branch first.
+        let branch_idx = next_pending_idx - 1;
+        Ok(SchedulerStep::StartQuery {
+            query: walk
+                .query
+                .at_flow(branch_flow_ids[branch_idx], walk.query.mode),
+            continuation: Some(Continuation::Merge {
+                walk,
+                branch_flow_ids,
+                next_pending_idx: branch_idx,
+                merged_type,
+            }),
+        })
+    }
+
+    // Finish one assignment dependency query by reading the pre-assignment type
+    // of the same ref, optionally retrying without condition narrows, then
+    // combining that antecedent type with the RHS type to finish the suspended
+    // query.
+    fn resume_assignment_antecedent(
+        &mut self,
+        walk: QueryWalk,
+        antecedent_flow_id: FlowId,
+        expr_type: LuaType,
+        reuse_source_narrowing: bool,
+        source_result: InferResult,
+    ) -> Result<SchedulerStep, InferFailReason> {
+        let source_type = match source_result {
+            Ok(source_type) => source_type,
+            Err(err) => return self.fail_query(&walk.query, err),
+        };
+
+        if reuse_source_narrowing
+            && !can_reuse_narrowed_assignment_source(self.db, &source_type, &expr_type)
+        {
+            let next_query = walk
+                .query
+                .at_flow(antecedent_flow_id, FlowMode::WithoutConditions);
+            return Ok(SchedulerStep::StartQuery {
+                query: next_query,
+                continuation: Some(Continuation::AssignmentAntecedent {
+                    walk,
+                    antecedent_flow_id,
+                    expr_type,
+                    reuse_source_narrowing: false,
+                }),
+            });
+        }
+
+        let result_type = finish_assignment_result(
+            self.db,
+            self.cache,
+            &source_type,
+            &expr_type,
+            &walk.query.var_ref_id,
+            reuse_source_narrowing,
+            None,
+        );
+        Ok(self.finish_walk(walk, result_type))
+    }
+
+    // Finish one tag-cast dependency query by reading the antecedent type and
+    // replaying the cast operators in source order, then finish the suspended
+    // query with the cast result.
+    fn resume_tag_cast_antecedent(
+        &mut self,
+        walk: QueryWalk,
+        cast_op_types: Vec<LuaDocOpType>,
+        antecedent_result: InferResult,
+    ) -> Result<SchedulerStep, InferFailReason> {
+        let mut cast_input_type = match antecedent_result {
+            Ok(resolved_type) => resolved_type,
+            Err(err) => return self.fail_query(&walk.query, err),
+        };
+        for cast_op_type in cast_op_types {
+            cast_input_type = match cast_type(
+                self.db,
+                self.cache.get_file_id(),
+                cast_op_type,
+                cast_input_type,
+                InferConditionFlow::TrueCondition,
+            ) {
+                Ok(typ) => typ,
+                Err(err) => return self.fail_query(&walk.query, err),
+            };
+        }
+
+        Ok(self.finish_walk(walk, cast_input_type))
+    }
+
+    // Finish one condition dependency query, turn its result into a
+    // `ConditionFlowAction`, and then feed that action back through the normal
+    // condition path. If the dependency query fails, clear the condition cache
+    // entry so a later lookup can retry instead of observing a stuck `Ready`.
+    fn resume_condition_subquery(
+        &mut self,
+        walk: QueryWalk,
+        flow_id: FlowId,
+        condition_flow: InferConditionFlow,
+        subquery: ConditionSubquery,
+        antecedent_result: InferResult,
+    ) -> Result<SchedulerStep, InferFailReason> {
+        let query = walk.query.clone();
+        let result = (|| {
+            let antecedent_type = antecedent_result?;
+            let flow_node = self
+                .tree
+                .get_flow_node(flow_id)
+                .ok_or(InferFailReason::None)?;
+            let action = resolve_condition_subquery(
+                self.db,
+                self.tree,
+                self.cache,
+                self.root,
+                &query.var_ref_id,
+                flow_node,
+                subquery,
+                antecedent_type,
+            )?;
+            self.apply_condition_action(walk, flow_id, condition_flow, action)
+        })();
+
+        result.or_else(|err| {
+            get_flow_var_cache(self.cache, query.var_cache_idx)
+                .condition_cache
+                .remove(&(flow_id, condition_flow));
+            self.fail_query(&query, err)
+        })
+    }
+
+    fn step_assignment(
+        &mut self,
+        mut walk: QueryWalk,
+        flow_node: &FlowNode,
+        assign_ptr: &emmylua_parser::LuaAstPtr<LuaAssignStat>,
+    ) -> Result<SchedulerStep, InferFailReason> {
+        let var_ref_id = walk.query.var_ref_id.clone();
+        let assignment_info =
+            get_flow_assignment_info(self.db, self.cache, self.root, flow_node.id, assign_ptr)?;
+        let antecedent_flow_id = get_single_antecedent(flow_node)?;
+
+        let Some(i) = assignment_info
+            .var_ref_ids
+            .iter()
+            .position(|maybe_ref_id| maybe_ref_id.as_ref() == Some(&var_ref_id))
+        else {
+            walk.antecedent_flow_id = antecedent_flow_id;
+            return Ok(SchedulerStep::ContinueWalk(walk));
+        };
+
+        let var_id = match &assignment_info.vars[i] {
+            LuaVarExpr::NameExpr(name_expr) => {
+                Some(LuaDeclId::new(self.cache.get_file_id(), name_expr.get_position()).into())
+            }
+            LuaVarExpr::IndexExpr(index_expr) => {
+                Some(LuaMemberId::new(index_expr.get_syntax_id(), self.cache.get_file_id()).into())
+            }
+        };
+        let explicit_var_type = var_id
+            .and_then(|id| self.db.get_type_index().get_type_cache(&id))
+            .filter(|tc| tc.is_doc())
+            .map(|tc| tc.as_type().clone());
+
+        let expr_type =
+            match infer_expr_list_value_type_at(self.db, self.cache, &assignment_info.exprs, i) {
+                Ok(expr_type) => expr_type,
+                Err(err) => {
+                    if let Some(explicit_var_type) = explicit_var_type.as_ref() {
+                        return Ok(self.finish_walk(walk, explicit_var_type.clone()));
+                    }
+
+                    if matches!(var_ref_id, VarRefId::IndexRef(_, _))
+                        && let Ok(origin_type) = get_var_ref_type(self.db, self.cache, &var_ref_id)
+                    {
+                        let non_nil_origin =
+                            TypeOps::Remove.apply(self.db, &origin_type, &LuaType::Nil);
+                        return Ok(self.finish_walk(
+                            walk,
+                            if non_nil_origin.is_never() {
+                                origin_type
+                            } else {
+                                non_nil_origin
+                            },
+                        ));
+                    }
+
+                    if matches!(err, InferFailReason::FieldNotFound | InferFailReason::None) {
+                        return Ok(self.finish_walk(walk, LuaType::Nil));
+                    }
+
+                    walk.antecedent_flow_id = antecedent_flow_id;
+                    return Ok(SchedulerStep::ContinueWalk(walk));
+                }
+            };
+        let Some(expr_type) = expr_type else {
+            walk.antecedent_flow_id = antecedent_flow_id;
+            return Ok(SchedulerStep::ContinueWalk(walk));
+        };
+
+        if let Some(explicit_var_type) = explicit_var_type {
+            let result_type = finish_assignment_result(
+                self.db,
+                self.cache,
+                &explicit_var_type,
+                &expr_type,
+                &var_ref_id,
+                true,
+                Some(explicit_var_type.clone()),
+            );
+            return Ok(self.finish_walk(walk, result_type));
+        }
+
+        let reuse_source_narrowing = preserves_assignment_expr_type(&expr_type);
+        let mode = if reuse_source_narrowing {
+            FlowMode::WithConditions
+        } else {
+            FlowMode::WithoutConditions
+        };
+        let subquery = walk.query.at_flow(antecedent_flow_id, mode);
+        Ok(SchedulerStep::StartQuery {
+            query: subquery,
+            continuation: Some(Continuation::AssignmentAntecedent {
+                walk,
+                antecedent_flow_id,
+                expr_type,
+                reuse_source_narrowing,
+            }),
+        })
+    }
+
+    fn step_condition(
+        &mut self,
+        mut walk: QueryWalk,
+        flow_node: &FlowNode,
+        condition_ptr: &emmylua_parser::LuaAstPtr<LuaExpr>,
+        condition_flow: InferConditionFlow,
+    ) -> Result<SchedulerStep, InferFailReason> {
+        let antecedent_flow_id = get_single_antecedent(flow_node)?;
+        if !walk.query.mode.uses_conditions() {
+            walk.antecedent_flow_id = antecedent_flow_id;
+            return Ok(SchedulerStep::ContinueWalk(walk));
+        }
+
+        let condition_info =
+            get_flow_condition_info(self.db, self.cache, self.root, flow_node.id, condition_ptr)?;
+        walk.antecedent_flow_id = antecedent_flow_id;
+        let q = &walk.query;
+        let var_ref_id = &q.var_ref_id;
+        if condition_info.index_var_ref_id.is_some()
+            && condition_info.index_var_ref_id.as_ref() != Some(var_ref_id)
+            && condition_info.index_prefix_var_ref_id.as_ref() != Some(var_ref_id)
+        {
+            return Ok(SchedulerStep::ContinueWalk(walk));
+        }
+
+        let cache_id = q.var_cache_idx;
+        let flow_id = flow_node.id;
+        let cache_key = (flow_id, condition_flow);
+        let action = match self
+            .cache
+            .flow_var_caches
+            .get(cache_id as usize)
+            .and_then(|var_cache| var_cache.condition_cache.get(&cache_key))
+        {
+            Some(CacheEntry::Cache(action)) => action.clone(),
+            Some(CacheEntry::Ready) => {
+                return self.fail_query(q, InferFailReason::RecursiveInfer);
+            }
+            None => {
+                get_flow_var_cache(self.cache, cache_id)
+                    .condition_cache
+                    .insert(cache_key, CacheEntry::Ready);
+                match get_type_at_condition_flow(
+                    self.db,
+                    self.tree,
+                    self.cache,
+                    self.root,
+                    var_ref_id,
+                    flow_node,
+                    condition_info.expr.clone(),
+                    condition_flow,
+                ) {
+                    Ok(action) => action,
+                    Err(err) => {
+                        get_flow_var_cache(self.cache, cache_id)
+                            .condition_cache
+                            .remove(&cache_key);
+                        return self.fail_query(q, err);
+                    }
+                }
+            }
+        };
+
+        self.apply_condition_action(walk, flow_id, condition_flow, action)
+    }
+
+    fn step_tag_cast(
+        &mut self,
+        mut walk: QueryWalk,
+        flow_node: &FlowNode,
+        cast_ast_ptr: &emmylua_parser::LuaAstPtr<emmylua_parser::LuaDocTagCast>,
+    ) -> Result<SchedulerStep, InferFailReason> {
+        let tag_cast = cast_ast_ptr
+            .to_node(self.root)
+            .ok_or(InferFailReason::None)?;
+        let var_ref_id = &walk.query.var_ref_id;
+        if let Some(key_expr) = tag_cast.get_key_expr() {
+            let Some(key_ref_id) = get_var_expr_var_ref_id(self.db, self.cache, key_expr) else {
+                walk.antecedent_flow_id = get_single_antecedent(flow_node)?;
+                return Ok(SchedulerStep::ContinueWalk(walk));
+            };
+            if key_ref_id != *var_ref_id {
+                walk.antecedent_flow_id = get_single_antecedent(flow_node)?;
+                return Ok(SchedulerStep::ContinueWalk(walk));
+            }
+        }
+
+        let cast_op_types = tag_cast.get_op_types().collect::<Vec<_>>();
+        if cast_op_types.is_empty() {
+            walk.antecedent_flow_id = get_single_antecedent(flow_node)?;
+            return Ok(SchedulerStep::ContinueWalk(walk));
+        }
+
+        let antecedent_flow_id = get_single_antecedent(flow_node)?;
+        let subquery = walk
+            .query
+            .at_flow(antecedent_flow_id, FlowMode::WithConditions);
+        Ok(SchedulerStep::StartQuery {
+            query: subquery,
+            continuation: Some(Continuation::TagCastAntecedent {
+                walk,
+                cast_op_types,
+            }),
+        })
+    }
+
+    // Walk one query backward through straight-line antecedents until it either
+    // produces a final type, needs another query first, or reaches a saved
+    // continuation point like a branch merge.
+    fn evaluate_walk(&mut self, mut walk: QueryWalk) -> Result<SchedulerStep, InferFailReason> {
+        loop {
+            let flow_node = self
+                .tree
+                .get_flow_node(walk.antecedent_flow_id)
+                .ok_or(InferFailReason::None)?;
+
+            match &flow_node.kind {
+                FlowNodeKind::Start | FlowNodeKind::Unreachable => {
+                    let result_type =
+                        get_var_ref_type(self.db, self.cache, &walk.query.var_ref_id)?;
+                    return Ok(self.finish_walk(walk, result_type));
+                }
+                FlowNodeKind::LoopLabel
+                | FlowNodeKind::Break
+                | FlowNodeKind::Return
+                | FlowNodeKind::ForIStat(_) => {
+                    walk.antecedent_flow_id = get_single_antecedent(flow_node)?;
+                }
+                FlowNodeKind::BranchLabel | FlowNodeKind::NamedLabel(_) => {
+                    let branch_flow_ids = if matches!(&flow_node.kind, FlowNodeKind::BranchLabel) {
+                        get_branch_label_flow_ids(self.tree, self.cache, flow_node)?
+                    } else {
+                        Arc::<[FlowId]>::from(get_multi_antecedents(self.tree, flow_node)?)
+                    };
+                    let Some(next_pending_idx) = branch_flow_ids.len().checked_sub(1) else {
+                        return Ok(self.finish_walk(walk, LuaType::Never));
+                    };
+                    let q = &walk.query;
+                    let next_query = q.at_flow(branch_flow_ids[next_pending_idx], q.mode);
+                    return Ok(SchedulerStep::StartQuery {
+                        query: next_query,
+                        continuation: Some(Continuation::Merge {
+                            walk,
+                            branch_flow_ids,
+                            next_pending_idx,
+                            merged_type: LuaType::Never,
+                        }),
+                    });
+                }
+                FlowNodeKind::DeclPosition(position) => {
+                    let var_ref_id = &walk.query.var_ref_id;
+                    if *position <= var_ref_id.get_position() {
+                        match get_var_ref_type(self.db, self.cache, var_ref_id) {
+                            Ok(var_type) => {
+                                return Ok(self.finish_walk(walk, var_type));
+                            }
+                            Err(err) => {
+                                if let Some(init_type) = try_infer_decl_initializer_type(
+                                    self.db, self.cache, self.root, var_ref_id,
+                                )? {
+                                    return Ok(self.finish_walk(walk, init_type));
+                                }
+
+                                return self.fail_query(&walk.query, err);
+                            }
+                        }
+                    } else {
+                        walk.antecedent_flow_id = get_single_antecedent(flow_node)?;
+                    }
+                }
+                FlowNodeKind::Assignment(assign_ptr) => {
+                    match self.step_assignment(walk, flow_node, assign_ptr)? {
+                        SchedulerStep::ContinueWalk(next_walk) => walk = next_walk,
+                        step => return Ok(step),
+                    }
+                }
+                FlowNodeKind::ImplFunc(func_ptr) => {
+                    let func_stat = func_ptr.to_node(self.root).ok_or(InferFailReason::None)?;
+                    let Some(func_name) = func_stat.get_func_name() else {
+                        walk.antecedent_flow_id = get_single_antecedent(flow_node)?;
+                        continue;
+                    };
+
+                    let Some(ref_id) =
+                        get_var_expr_var_ref_id(self.db, self.cache, func_name.to_expr())
+                    else {
+                        walk.antecedent_flow_id = get_single_antecedent(flow_node)?;
+                        continue;
+                    };
+
+                    if ref_id == walk.query.var_ref_id {
+                        let Some(closure) = func_stat.get_closure() else {
+                            return self.fail_query(&walk.query, InferFailReason::None);
+                        };
+
+                        return Ok(self.finish_walk(
+                            walk,
+                            LuaType::Signature(LuaSignatureId::from_closure(
+                                self.cache.get_file_id(),
+                                &closure,
+                            )),
+                        ));
+                    } else {
+                        walk.antecedent_flow_id = get_single_antecedent(flow_node)?;
+                    }
+                }
+                FlowNodeKind::TrueCondition(condition_ptr)
+                | FlowNodeKind::FalseCondition(condition_ptr) => {
+                    let condition_flow =
+                        if matches!(&flow_node.kind, FlowNodeKind::TrueCondition(_)) {
+                            InferConditionFlow::TrueCondition
+                        } else {
+                            InferConditionFlow::FalseCondition
+                        };
+                    match self.step_condition(walk, flow_node, condition_ptr, condition_flow)? {
+                        SchedulerStep::ContinueWalk(next_walk) => walk = next_walk,
+                        step => return Ok(step),
+                    }
+                }
+                FlowNodeKind::TagCast(cast_ast_ptr) => {
+                    match self.step_tag_cast(walk, flow_node, cast_ast_ptr)? {
+                        SchedulerStep::ContinueWalk(next_walk) => walk = next_walk,
+                        step => return Ok(step),
+                    }
+                }
+            }
+        }
+    }
+
+    fn apply_condition_action(
+        &mut self,
+        mut walk: QueryWalk,
+        flow_id: FlowId,
+        condition_flow: InferConditionFlow,
+        action: ConditionFlowAction,
+    ) -> Result<SchedulerStep, InferFailReason> {
+        match action {
+            ConditionFlowAction::Continue => {
+                get_flow_var_cache(self.cache, walk.query.var_cache_idx)
+                    .condition_cache
+                    .insert(
+                        (flow_id, condition_flow),
+                        CacheEntry::Cache(ConditionFlowAction::Continue),
+                    );
+                Ok(SchedulerStep::ContinueWalk(walk))
+            }
+            ConditionFlowAction::Result(result_type) => {
+                get_flow_var_cache(self.cache, walk.query.var_cache_idx)
+                    .condition_cache
+                    .insert(
+                        (flow_id, condition_flow),
+                        CacheEntry::Cache(ConditionFlowAction::Result(result_type.clone())),
+                    );
+                Ok(self.finish_walk(walk, result_type))
+            }
+            ConditionFlowAction::Pending(pending_condition_narrow) => {
+                get_flow_var_cache(self.cache, walk.query.var_cache_idx)
+                    .condition_cache
+                    .insert(
+                        (flow_id, condition_flow),
+                        CacheEntry::Cache(ConditionFlowAction::Pending(
+                            pending_condition_narrow.clone(),
+                        )),
+                    );
+                walk.pending_condition_narrows
+                    .push(pending_condition_narrow);
+                Ok(SchedulerStep::ContinueWalk(walk))
+            }
+            ConditionFlowAction::NeedSubquery(subquery) => {
+                let (subquery_var_ref_id, subquery_antecedent_flow_id) = match &subquery {
+                    ConditionSubquery::ArrayLen {
+                        var_ref_id,
+                        antecedent_flow_id,
+                        ..
+                    }
+                    | ConditionSubquery::FieldLiteralEq {
+                        var_ref_id,
+                        antecedent_flow_id,
+                        ..
+                    }
+                    | ConditionSubquery::Correlated {
+                        var_ref_id,
+                        antecedent_flow_id,
+                        ..
+                    } => (var_ref_id, *antecedent_flow_id),
+                };
+                let subquery_query =
+                    FlowQuery::new(self.cache, subquery_var_ref_id, subquery_antecedent_flow_id);
+                Ok(SchedulerStep::StartQuery {
+                    query: subquery_query,
+                    continuation: Some(Continuation::ConditionDependency {
+                        walk,
+                        flow_id,
+                        condition_flow,
+                        subquery,
+                    }),
+                })
+            }
+            ConditionFlowAction::NeedCorrelated(pending_correlated_condition) => {
+                let subquery = walk.query.at_flow(
+                    pending_correlated_condition.current_search_root_flow_id,
+                    FlowMode::WithConditions,
+                );
+                Ok(SchedulerStep::StartQuery {
+                    query: subquery,
+                    continuation: Some(Continuation::CorrelatedSearchRoot {
+                        walk,
+                        flow_id,
+                        condition_flow,
+                        pending_correlated_condition,
+                    }),
+                })
+            }
+        }
+    }
+
+    fn finish_walk(&mut self, walk: QueryWalk, narrow_type: LuaType) -> SchedulerStep {
+        let QueryWalk {
+            query,
+            pending_condition_narrows,
+            ..
+        } = walk;
+        let mut final_type = narrow_type;
+        if query.mode.uses_conditions() {
+            for pending_condition_narrow in pending_condition_narrows.into_iter().rev() {
+                final_type = pending_condition_narrow.apply(self.db, self.cache, final_type);
+            }
+        }
+        get_flow_var_cache(self.cache, query.var_cache_idx)
+            .type_cache
+            .insert(
+                (query.flow_id, query.mode),
+                CacheEntry::Cache(final_type.clone()),
+            );
+        SchedulerStep::ResumeNext(Ok(final_type))
+    }
+
+    fn fail_query<T>(
+        &mut self,
+        query: &FlowQuery,
+        err: InferFailReason,
+    ) -> Result<T, InferFailReason> {
+        get_flow_var_cache(self.cache, query.var_cache_idx)
+            .type_cache
+            .remove(&(query.flow_id, query.mode));
+        Err(err)
+    }
+}
+
+pub(super) fn get_type_at_flow(
     db: &DbIndex,
     tree: &FlowTree,
     cache: &mut LuaInferCache,
@@ -32,7 +878,36 @@ pub fn get_type_at_flow(
     var_ref_id: &VarRefId,
     flow_id: FlowId,
 ) -> InferResult {
-    get_type_at_flow_internal(db, tree, cache, root, var_ref_id, flow_id, true)
+    FlowTypeEngine {
+        db,
+        tree,
+        cache,
+        root,
+    }
+    .run(var_ref_id, flow_id)
+}
+
+fn get_flow_cache_var_ref_id(cache: &mut LuaInferCache, var_ref_id: &VarRefId) -> u32 {
+    if let Some(var_ref_cache_id) = cache.flow_cache_var_ref_ids.get(var_ref_id) {
+        return *var_ref_cache_id;
+    }
+
+    let var_ref_cache_id = cache.next_flow_cache_var_ref_id;
+    cache.next_flow_cache_var_ref_id += 1;
+    cache
+        .flow_cache_var_ref_ids
+        .insert(var_ref_id.clone(), var_ref_cache_id);
+    var_ref_cache_id
+}
+
+fn get_flow_var_cache(cache: &mut LuaInferCache, var_ref_cache_id: u32) -> &mut FlowVarCache {
+    let outer_index = var_ref_cache_id as usize;
+    if cache.flow_var_caches.len() <= outer_index {
+        cache
+            .flow_var_caches
+            .resize_with(outer_index + 1, FlowVarCache::default);
+    }
+    &mut cache.flow_var_caches[outer_index]
 }
 
 fn can_reuse_narrowed_assignment_source(
@@ -67,9 +942,6 @@ fn is_partial_assignment_expr_compatible(
         return true;
     }
 
-    // Only preserve branch narrowing for concrete partial table/object literals.
-    // Broader RHS expressions can carry hidden state the current flow/type model cannot represent
-    // without wider semantic changes.
     if !matches!(expr_type, LuaType::TableConst(_) | LuaType::Object(_)) {
         return false;
     }
@@ -110,353 +982,183 @@ fn is_exact_assignment_expr_type(typ: &LuaType) -> bool {
     }
 }
 
-fn get_type_at_flow_internal(
+fn get_flow_condition_info(
     db: &DbIndex,
-    tree: &FlowTree,
     cache: &mut LuaInferCache,
     root: &LuaChunk,
-    var_ref_id: &VarRefId,
     flow_id: FlowId,
-    use_condition_narrowing: bool,
-) -> InferResult {
-    let key = (var_ref_id.clone(), flow_id, use_condition_narrowing);
-    if let Some(cache_entry) = cache.flow_node_cache.get(&key) {
-        return match cache_entry {
-            CacheEntry::Cache(narrow_type) => Ok::<LuaType, InferFailReason>(narrow_type.clone()),
-            CacheEntry::Ready => Err(InferFailReason::RecursiveInfer),
-        };
+    condition_ptr: &emmylua_parser::LuaAstPtr<LuaExpr>,
+) -> Result<Rc<FlowConditionInfo>, InferFailReason> {
+    let flow_index = flow_id.0 as usize;
+    if let Some(Some(info)) = cache.flow_condition_info_cache.get(flow_index) {
+        return Ok(info.clone());
     }
 
-    cache.flow_node_cache.insert(key.clone(), CacheEntry::Ready);
-
-    let result = (|| {
-        let result_type;
-        let mut antecedent_flow_id = flow_id;
-        let mut pending_condition_narrows: Vec<Rc<PendingConditionNarrow>> = Vec::new();
-        loop {
-            let flow_node = tree
-                .get_flow_node(antecedent_flow_id)
-                .ok_or(InferFailReason::None)?;
-
-            match &flow_node.kind {
-                FlowNodeKind::Start | FlowNodeKind::Unreachable => {
-                    result_type = get_var_ref_type(db, cache, var_ref_id)?;
-                    break;
-                }
-                FlowNodeKind::LoopLabel | FlowNodeKind::Break | FlowNodeKind::Return => {
-                    antecedent_flow_id = get_single_antecedent(flow_node)?;
-                }
-                FlowNodeKind::BranchLabel | FlowNodeKind::NamedLabel(_) => {
-                    let multi_antecedents = get_multi_antecedents(tree, flow_node)?;
-
-                    let mut branch_result_type = LuaType::Never;
-                    for &flow_id in &multi_antecedents {
-                        let branch_type = get_type_at_flow_internal(
-                            db,
-                            tree,
-                            cache,
-                            root,
-                            var_ref_id,
-                            flow_id,
-                            use_condition_narrowing,
-                        )?;
-                        branch_result_type =
-                            TypeOps::Union.apply(db, &branch_result_type, &branch_type);
-                    }
-                    result_type = branch_result_type;
-                    break;
-                }
-                FlowNodeKind::DeclPosition(position) => {
-                    if *position <= var_ref_id.get_position() {
-                        match get_var_ref_type(db, cache, var_ref_id) {
-                            Ok(var_type) => {
-                                result_type = var_type;
-                                break;
-                            }
-                            Err(err) => {
-                                // 尝试推断声明位置的类型, 如果发生错误则返回初始错误, 否则返回当前推断错误
-                                if let Some(init_type) =
-                                    try_infer_decl_initializer_type(db, cache, root, var_ref_id)?
-                                {
-                                    result_type = init_type;
-                                    break;
-                                }
-
-                                return Err(err);
-                            }
-                        }
-                    } else {
-                        antecedent_flow_id = get_single_antecedent(flow_node)?;
-                    }
-                }
-                FlowNodeKind::Assignment(assign_ptr) => {
-                    let assign_stat = assign_ptr.to_node(root).ok_or(InferFailReason::None)?;
-                    let result_or_continue = get_type_at_assign_stat(
-                        db,
-                        tree,
-                        cache,
-                        root,
-                        var_ref_id,
-                        flow_node,
-                        assign_stat,
-                    )?;
-
-                    if let ResultTypeOrContinue::Result(assign_type) = result_or_continue {
-                        result_type = assign_type;
-                        break;
-                    } else {
-                        antecedent_flow_id = get_single_antecedent(flow_node)?;
-                    }
-                }
-                FlowNodeKind::ImplFunc(func_ptr) => {
-                    let func_stat = func_ptr.to_node(root).ok_or(InferFailReason::None)?;
-                    let Some(func_name) = func_stat.get_func_name() else {
-                        antecedent_flow_id = get_single_antecedent(flow_node)?;
-                        continue;
-                    };
-
-                    let Some(ref_id) = get_var_expr_var_ref_id(db, cache, func_name.to_expr())
-                    else {
-                        antecedent_flow_id = get_single_antecedent(flow_node)?;
-                        continue;
-                    };
-
-                    if ref_id == *var_ref_id {
-                        let Some(closure) = func_stat.get_closure() else {
-                            return Err(InferFailReason::None);
-                        };
-
-                        result_type = LuaType::Signature(LuaSignatureId::from_closure(
-                            cache.get_file_id(),
-                            &closure,
-                        ));
-                        break;
-                    } else {
-                        antecedent_flow_id = get_single_antecedent(flow_node)?;
-                    }
-                }
-                FlowNodeKind::TrueCondition(condition_ptr)
-                | FlowNodeKind::FalseCondition(condition_ptr) => {
-                    if !use_condition_narrowing {
-                        antecedent_flow_id = get_single_antecedent(flow_node)?;
-                        continue;
-                    }
-
-                    let condition_flow =
-                        if matches!(&flow_node.kind, FlowNodeKind::TrueCondition(_)) {
-                            InferConditionFlow::TrueCondition
-                        } else {
-                            InferConditionFlow::FalseCondition
-                        };
-                    let condition_key = (
-                        var_ref_id.clone(),
-                        antecedent_flow_id,
-                        matches!(condition_flow, InferConditionFlow::TrueCondition),
-                    );
-                    let condition_action = {
-                        if let Some(cache_entry) = cache.condition_flow_cache.get(&condition_key) {
-                            match cache_entry {
-                                CacheEntry::Cache(action) => {
-                                    Ok::<ConditionFlowAction, InferFailReason>(action.clone())
-                                }
-                                CacheEntry::Ready => Err(InferFailReason::RecursiveInfer),
-                            }
-                        } else {
-                            let condition =
-                                condition_ptr.to_node(root).ok_or(InferFailReason::None)?;
-                            cache
-                                .condition_flow_cache
-                                .insert(condition_key.clone(), CacheEntry::Ready);
-                            let result = get_type_at_condition_flow(
-                                db,
-                                tree,
-                                cache,
-                                root,
-                                var_ref_id,
-                                flow_node,
-                                condition,
-                                condition_flow,
-                            );
-                            match &result {
-                                Ok(action) => {
-                                    cache
-                                        .condition_flow_cache
-                                        .insert(condition_key, CacheEntry::Cache(action.clone()));
-                                }
-                                Err(_) => {
-                                    cache.condition_flow_cache.remove(&condition_key);
-                                }
-                            }
-                            result
-                        }
-                    }?;
-
-                    match condition_action {
-                        ConditionFlowAction::Pending(pending_condition_narrow) => {
-                            pending_condition_narrows.push(pending_condition_narrow);
-                            antecedent_flow_id = get_single_antecedent(flow_node)?;
-                        }
-                        ConditionFlowAction::Result(condition_type) => {
-                            result_type = condition_type;
-                            break;
-                        }
-                        ConditionFlowAction::Continue => {
-                            antecedent_flow_id = get_single_antecedent(flow_node)?;
-                        }
-                    }
-                }
-                FlowNodeKind::ForIStat(_) => {
-                    // todo check for `for i = 1, 10 do end`
-                    antecedent_flow_id = get_single_antecedent(flow_node)?;
-                }
-                FlowNodeKind::TagCast(cast_ast_ptr) => {
-                    let tag_cast = cast_ast_ptr.to_node(root).ok_or(InferFailReason::None)?;
-                    let cast_or_continue = get_type_at_cast_flow(
-                        db, tree, cache, root, var_ref_id, flow_node, tag_cast,
-                    )?;
-
-                    if let ResultTypeOrContinue::Result(cast_type) = cast_or_continue {
-                        result_type = cast_type;
-                        break;
-                    } else {
-                        antecedent_flow_id = get_single_antecedent(flow_node)?;
-                    }
-                }
-            }
-        }
-
-        let result_type = if use_condition_narrowing {
-            pending_condition_narrows.into_iter().rev().fold(
-                result_type,
-                |result_type, pending_condition_narrow| {
-                    pending_condition_narrow.apply(db, cache, result_type)
-                },
-            )
-        } else {
-            result_type
-        };
-
-        Ok(result_type)
-    })();
-
-    match &result {
-        Ok(result_type) => {
-            cache
-                .flow_node_cache
-                .insert(key, CacheEntry::Cache(result_type.clone()));
-        }
-        Err(_) => {
-            cache.flow_node_cache.remove(&key);
-        }
+    let expr = condition_ptr.to_node(root).ok_or(InferFailReason::None)?;
+    let (index_var_ref_id, index_prefix_var_ref_id) =
+        get_condition_index_var_refs(db, cache, expr.clone());
+    let info = Rc::new(FlowConditionInfo {
+        expr,
+        index_var_ref_id,
+        index_prefix_var_ref_id,
+    });
+    if cache.flow_condition_info_cache.len() <= flow_index {
+        cache
+            .flow_condition_info_cache
+            .resize_with(flow_index + 1, || None);
     }
-
-    result
+    cache.flow_condition_info_cache[flow_index] = Some(info.clone());
+    Ok(info)
 }
 
-fn get_type_at_assign_stat(
+fn get_condition_index_var_refs(
     db: &DbIndex,
-    tree: &FlowTree,
     cache: &mut LuaInferCache,
-    root: &LuaChunk,
-    var_ref_id: &VarRefId,
-    flow_node: &FlowNode,
-    assign_stat: LuaAssignStat,
-) -> Result<ResultTypeOrContinue, InferFailReason> {
-    let (vars, exprs) = assign_stat.get_var_and_expr_list();
-    for (i, var) in vars.iter().cloned().enumerate() {
-        let Some(maybe_ref_id) = get_var_expr_var_ref_id(db, cache, var.to_expr()) else {
-            continue;
-        };
-
-        if maybe_ref_id != *var_ref_id {
-            // let typ = get_var_ref_type(db, cache, var_ref_id)?;
-            continue;
-        }
-
-        // Check if there's an explicit type annotation (not just inferred type)
-        let var_id = match var {
-            LuaVarExpr::NameExpr(name_expr) => {
-                Some(LuaDeclId::new(cache.get_file_id(), name_expr.get_position()).into())
-            }
-            LuaVarExpr::IndexExpr(index_expr) => {
-                Some(LuaMemberId::new(index_expr.get_syntax_id(), cache.get_file_id()).into())
-            }
-        };
-
-        let explicit_var_type = var_id
-            .and_then(|id| db.get_type_index().get_type_cache(&id))
-            .filter(|tc| tc.is_doc())
-            .map(|tc| tc.as_type().clone());
-
-        let expr_type = infer_expr_list_value_type_at(db, cache, &exprs, i)?;
-        let Some(expr_type) = expr_type else {
-            return Ok(ResultTypeOrContinue::Continue);
-        };
-
-        let (source_type, reuse_source_narrowing) =
-            if let Some(explicit) = explicit_var_type.clone() {
-                (explicit, true)
+    condition: LuaExpr,
+) -> (Option<VarRefId>, Option<VarRefId>) {
+    match condition {
+        LuaExpr::IndexExpr(index_expr) => {
+            let index_var_ref_id =
+                get_var_expr_var_ref_id(db, cache, LuaExpr::IndexExpr(index_expr.clone()));
+            let index_prefix_var_ref_id = if index_var_ref_id.is_some() {
+                index_expr
+                    .get_prefix_expr()
+                    .and_then(|prefix_expr| get_var_expr_var_ref_id(db, cache, prefix_expr))
             } else {
-                let antecedent_flow_id = get_single_antecedent(flow_node)?;
-                if !preserves_assignment_expr_type(&expr_type) {
-                    (
-                        get_type_at_flow_internal(
-                            db,
-                            tree,
-                            cache,
-                            root,
-                            var_ref_id,
-                            antecedent_flow_id,
-                            false,
-                        )?,
-                        false,
-                    )
-                } else {
-                    let narrowed_source_type =
-                        get_type_at_flow(db, tree, cache, root, var_ref_id, antecedent_flow_id)?;
-                    if can_reuse_narrowed_assignment_source(db, &narrowed_source_type, &expr_type) {
-                        (narrowed_source_type, true)
-                    } else {
-                        (
-                            get_type_at_flow_internal(
-                                db,
-                                tree,
-                                cache,
-                                root,
-                                var_ref_id,
-                                antecedent_flow_id,
-                                false,
-                            )?,
-                            false,
-                        )
-                    }
-                }
+                None
+            };
+            (index_var_ref_id, index_prefix_var_ref_id)
+        }
+        LuaExpr::ParenExpr(paren_expr) => paren_expr
+            .get_expr()
+            .map(|expr| get_condition_index_var_refs(db, cache, expr))
+            .unwrap_or((None, None)),
+        LuaExpr::UnaryExpr(unary_expr) => {
+            let Some(op_token) = unary_expr.get_op_token() else {
+                return (None, None);
             };
 
-        let narrowed = if source_type == LuaType::Nil {
-            None
-        } else {
-            let declared =
-                get_var_ref_type(db, cache, var_ref_id)
-                    .ok()
-                    .and_then(|decl| match decl {
-                        LuaType::Def(_) | LuaType::Ref(_) => Some(decl),
-                        _ => None,
-                    });
+            if op_token.get_op() != UnaryOperator::OpNot {
+                return (None, None);
+            }
 
-            narrow_down_type(db, source_type.clone(), expr_type.clone(), declared)
-        };
+            unary_expr
+                .get_expr()
+                .map(|expr| get_condition_index_var_refs(db, cache, expr))
+                .unwrap_or((None, None))
+        }
+        _ => (None, None),
+    }
+}
 
-        let result_type = if reuse_source_narrowing || preserves_assignment_expr_type(&expr_type) {
-            narrowed.unwrap_or_else(|| explicit_var_type.unwrap_or_else(|| expr_type.clone()))
-        } else {
-            expr_type
-        };
-
-        return Ok(ResultTypeOrContinue::Result(result_type));
+fn get_branch_label_flow_ids(
+    tree: &FlowTree,
+    cache: &mut LuaInferCache,
+    flow_node: &FlowNode,
+) -> Result<Arc<[FlowId]>, InferFailReason> {
+    let flow_index = flow_node.id.0 as usize;
+    if let Some(Some(flow_ids)) = cache.flow_branch_inputs_cache.get(flow_index) {
+        return Ok(flow_ids.clone());
     }
 
-    Ok(ResultTypeOrContinue::Continue)
+    let mut pending = get_multi_antecedents(tree, flow_node)?;
+    let mut visited_labels = HashSet::with_capacity(pending.len());
+    let mut branch_flow_ids = Vec::with_capacity(pending.len());
+
+    while let Some(flow_id) = pending.pop() {
+        let branch_flow_node = tree.get_flow_node(flow_id).ok_or(InferFailReason::None)?;
+        match &branch_flow_node.kind {
+            FlowNodeKind::BranchLabel => {
+                if !visited_labels.insert(flow_id) {
+                    continue;
+                }
+
+                if let Some(Some(cached_flow_ids)) =
+                    cache.flow_branch_inputs_cache.get(flow_id.0 as usize)
+                {
+                    branch_flow_ids.extend(cached_flow_ids.iter().copied());
+                } else {
+                    pending.extend(get_multi_antecedents(tree, branch_flow_node)?);
+                }
+            }
+            _ => branch_flow_ids.push(flow_id),
+        }
+    }
+
+    if cache.flow_branch_inputs_cache.len() <= flow_index {
+        cache
+            .flow_branch_inputs_cache
+            .resize_with(flow_index + 1, || None);
+    }
+    let branch_flow_ids = Arc::<[FlowId]>::from(branch_flow_ids);
+    cache.flow_branch_inputs_cache[flow_index] = Some(branch_flow_ids.clone());
+    Ok(branch_flow_ids)
+}
+
+fn get_flow_assignment_info(
+    db: &DbIndex,
+    cache: &mut LuaInferCache,
+    root: &LuaChunk,
+    flow_id: FlowId,
+    assign_ptr: &emmylua_parser::LuaAstPtr<LuaAssignStat>,
+) -> Result<Rc<FlowAssignmentInfo>, InferFailReason> {
+    let flow_index = flow_id.0 as usize;
+    if let Some(Some(info)) = cache.flow_assignment_info_cache.get(flow_index) {
+        return Ok(info.clone());
+    }
+
+    let assign_stat = assign_ptr.to_node(root).ok_or(InferFailReason::None)?;
+    let (vars, exprs) = assign_stat.get_var_and_expr_list();
+    let var_ref_ids = vars
+        .iter()
+        .map(|var| get_var_expr_var_ref_id(db, cache, var.to_expr()))
+        .collect::<Vec<_>>();
+    let info = Rc::new(FlowAssignmentInfo {
+        vars,
+        exprs,
+        var_ref_ids,
+    });
+    if cache.flow_assignment_info_cache.len() <= flow_index {
+        cache
+            .flow_assignment_info_cache
+            .resize_with(flow_index + 1, || None);
+    }
+    cache.flow_assignment_info_cache[flow_index] = Some(info.clone());
+    Ok(info)
+}
+
+fn finish_assignment_result(
+    db: &DbIndex,
+    cache: &mut LuaInferCache,
+    source_type: &LuaType,
+    expr_type: &LuaType,
+    var_ref_id: &VarRefId,
+    reuse_source_narrowing: bool,
+    fallback_type: Option<LuaType>,
+) -> LuaType {
+    // Unknown RHS usually means the lookup failed, so keep the last known runtime type.
+    if expr_type.is_unknown() {
+        return source_type.clone();
+    }
+
+    let narrowed = if *source_type == LuaType::Nil {
+        None
+    } else {
+        let declared = get_var_ref_type(db, cache, var_ref_id)
+            .ok()
+            .and_then(|decl| match decl {
+                LuaType::Def(_) | LuaType::Ref(_) => Some(decl),
+                _ => None,
+            });
+
+        narrow_down_type(db, source_type.clone(), expr_type.clone(), declared)
+    };
+
+    if reuse_source_narrowing || preserves_assignment_expr_type(expr_type) {
+        narrowed.unwrap_or_else(|| fallback_type.unwrap_or_else(|| expr_type.clone()))
+    } else {
+        expr_type.clone()
+    }
 }
 
 fn try_infer_decl_initializer_type(
@@ -490,4 +1192,41 @@ fn try_infer_decl_initializer_type(
     let init_type = expr_type.get_result_slot_type(0);
 
     Ok(init_type)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{CacheOptions, FileId};
+
+    #[test]
+    fn test_flow_caches_stay_sparse_for_large_flow_ids() {
+        let mut cache = LuaInferCache::new(FileId::new(0), CacheOptions::default());
+        let var_ref_id = VarRefId::VarRef(LuaDeclId::new(FileId::new(0), 0.into()));
+        let query = FlowQuery::new(&mut cache, &var_ref_id, FlowId(10_000));
+
+        get_flow_var_cache(&mut cache, 0)
+            .type_cache
+            .insert((query.flow_id, query.mode), CacheEntry::Ready);
+        get_flow_var_cache(&mut cache, 0).condition_cache.insert(
+            (FlowId(20_000), InferConditionFlow::FalseCondition),
+            CacheEntry::Ready,
+        );
+
+        assert_eq!(cache.flow_var_caches.len(), 1);
+        assert_eq!(cache.flow_var_caches[0].type_cache.len(), 1);
+        assert_eq!(cache.flow_var_caches[0].condition_cache.len(), 1);
+        assert!(matches!(
+            cache.flow_var_caches[0]
+                .type_cache
+                .get(&(query.flow_id, query.mode)),
+            Some(CacheEntry::Ready)
+        ));
+        assert!(matches!(
+            cache.flow_var_caches[0]
+                .condition_cache
+                .get(&(FlowId(20_000), InferConditionFlow::FalseCondition)),
+            Some(CacheEntry::Ready)
+        ));
+    }
 }

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/mod.rs
@@ -6,13 +6,13 @@ mod var_ref_id;
 
 use crate::{
     CacheEntry, DbIndex, FlowAntecedent, FlowId, FlowNode, FlowTree, InferFailReason,
-    LuaInferCache, LuaType, infer_param,
+    LuaInferCache, infer_param,
     semantic::infer::{
         InferResult,
         infer_name::{find_decl_member_type, infer_global_type},
     },
 };
-pub(in crate::semantic) use condition_flow::ConditionFlowAction;
+pub(in crate::semantic) use condition_flow::{ConditionFlowAction, InferConditionFlow};
 use emmylua_parser::{LuaAstNode, LuaChunk, LuaExpr};
 pub use get_type_at_cast_flow::get_type_at_call_expr_inline_cast;
 pub use narrow_type::{narrow_down_type, narrow_false_or_nil, remove_false_or_nil};
@@ -95,10 +95,4 @@ fn get_multi_antecedents(tree: &FlowTree, flow: &FlowNode) -> Result<Vec<FlowId>
         },
         None => Err(InferFailReason::None),
     }
-}
-
-#[derive(Debug)]
-pub enum ResultTypeOrContinue {
-    Result(LuaType),
-    Continue,
 }

--- a/crates/emmylua_ls/src/handlers/test/semantic_token_test.rs
+++ b/crates/emmylua_ls/src/handlers/test/semantic_token_test.rs
@@ -28,6 +28,19 @@ mod tests {
         result
     }
 
+    fn make_issue_1028_repeated_prefix_guard_chain_content() -> String {
+        let mut content = String::from("V_cfad19afc42b = V_cfad19afc42b or {}\n");
+        for i in 0..600 {
+            let table_key = 3_121_212;
+            let field_key = 1_111_112 + i;
+            content.push_str(&format!(
+                "if V_cfad19afc42b[{table_key}] and V_cfad19afc42b[{table_key}][{field_key}] then\n    V_cfad19afc42b[{table_key}][{field_key}][\"__STR_{i}__\"] = \"__STR_{}__\"\nend\n\n",
+                i + 1,
+            ));
+        }
+        content
+    }
+
     #[gtest]
     fn test_1() -> Result<()> {
         let mut ws = ProviderVirtualWorkspace::new();
@@ -115,6 +128,16 @@ m.foo()
                 not(contains(eq(&(1, 27, 6, variable, 0)))),
             ]
         )?;
+        Ok(())
+    }
+
+    #[gtest]
+    fn test_issue_1028_i18n_semantic_tokens_repeated_prefix_guard_chain() -> Result<()> {
+        let mut ws = ProviderVirtualWorkspace::new();
+        let content = make_issue_1028_repeated_prefix_guard_chain_content();
+        let file_id = ws.def_file("i18n.lua", &content);
+        let data = ws.get_semantic_token_data_for_file(file_id)?;
+        assert!(!data.is_empty());
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- replace recursive flow evaluation with an explicit query stack so deep branch and condition chains stay stack-safe
- cache per-variable flow lookups, flattened branch inputs, and decoded flow metadata to avoid rebuilding narrowing state on repeated queries
- skip redundant `get_field_key()` rescans for value and static table fields during compilation analysis

## Tests
- add regressions for issue #1028, correlated guards, and index-based narrows
- add regressions for the maxwellhome-like large-array case
- add regressions for `pairs()` preserving integer keys on value fields

Fixes #1028