### PR TITLE
fix(flow): reuse ordered return analysis for loop exits

### DIFF
--- a/crates/emmylua_code_analysis/src/compilation/analyzer/lua/closure.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/lua/closure.rs
@@ -14,7 +14,7 @@ use crate::{
     infer_expr,
 };
 
-use super::{LuaAnalyzer, LuaReturnPoint, func_body::analyze_func_body_returns};
+use super::{LuaAnalyzer, LuaReturnPoint, analyze_func_body_returns_with};
 
 pub fn analyze_closure(analyzer: &mut LuaAnalyzer, closure: LuaClosureExpr) -> Option<()> {
     let signature_id = LuaSignatureId::from_closure(analyzer.file_id, &closure);
@@ -136,15 +136,26 @@ fn analyze_return(
         }
     };
 
-    let return_points = analyze_func_body_returns(block);
-    let returns = match analyze_return_point(
-        analyzer.db,
-        analyzer
-            .context
-            .infer_manager
-            .get_infer_cache(analyzer.file_id),
-        &return_points,
-    ) {
+    let cache = analyzer
+        .context
+        .infer_manager
+        .get_infer_cache(analyzer.file_id);
+    let return_points = match analyze_func_body_returns_with(block.clone(), &mut |expr| {
+        infer_expr(analyzer.db, cache, expr.clone())
+    }) {
+        Ok(return_points) => return_points,
+        Err(reason) => {
+            let unresolve = UnResolveReturn {
+                file_id: analyzer.file_id,
+                signature_id: *signature_id,
+                body: block,
+            };
+
+            analyzer.context.add_unresolve(unresolve.into(), reason);
+            return None;
+        }
+    };
+    let returns = match analyze_return_point(analyzer.db, cache, &return_points) {
         Ok(returns) => returns,
         Err(InferFailReason::None) => {
             vec![LuaDocReturnInfo {
@@ -158,7 +169,7 @@ fn analyze_return(
             let unresolve = UnResolveReturn {
                 file_id: analyzer.file_id,
                 signature_id: *signature_id,
-                return_points,
+                body: block,
             };
 
             analyzer.context.add_unresolve(unresolve.into(), reason);
@@ -189,13 +200,12 @@ fn analyze_lambda_returns(
         .get_args()
         .position(|arg| arg.get_position() == pos)?;
     let block = closure.get_block()?;
-    let return_points = analyze_func_body_returns(block);
     let unresolved = UnResolveClosureReturn {
         file_id: analyzer.file_id,
         signature_id: *signature_id,
         call_expr,
         param_idx: founded_idx,
-        return_points,
+        body: block,
     };
 
     analyzer

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/lua/func_body.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/lua/func_body.rs
@@ -1,7 +1,9 @@
 use emmylua_parser::{
-    LuaBlock, LuaCallExprStat, LuaDoStat, LuaExpr, LuaForRangeStat, LuaForStat, LuaIfStat,
-    LuaRepeatStat, LuaReturnStat, LuaStat, LuaWhileStat,
+    LuaBlock, LuaCallExprStat, LuaDoStat, LuaExpr, LuaForRangeStat, LuaForStat, LuaIfClauseStat,
+    LuaIfStat, LuaRepeatStat, LuaReturnStat, LuaStat, LuaWhileStat,
 };
+
+use crate::{InferFailReason, LuaType};
 
 #[derive(Debug, Clone)]
 pub enum LuaReturnPoint {
@@ -11,158 +13,387 @@ pub enum LuaReturnPoint {
     Error,
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
-enum ChangeFlow {
-    None,
-    Break,
-    Error,
-    Return,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConditionState {
+    Dynamic,
+    Truthy,
+    Falsy,
+    Never,
 }
 
-pub fn analyze_func_body_returns(body: LuaBlock) -> Vec<LuaReturnPoint> {
-    let mut returns = Vec::new();
+#[derive(Debug, Default)]
+struct ReturnFlow {
+    return_points: Vec<LuaReturnPoint>,
+    can_continue: bool,
+    can_break: bool,
+    // `can_stall` means control can get stuck without returning, e.g. `while true do end`.
+    can_stall: bool,
+}
 
-    let flow = analyze_block_returns(body, &mut returns);
-    match flow {
-        Some(ChangeFlow::Break) | Some(ChangeFlow::None) => {
-            returns.push(LuaReturnPoint::Nil);
+impl ReturnFlow {
+    fn continue_flow() -> Self {
+        Self {
+            can_continue: true,
+            ..Default::default()
         }
-        _ => {}
     }
 
-    returns
+    fn merge_choice(&mut self, mut other: Self) {
+        self.return_points.append(&mut other.return_points);
+        self.can_continue |= other.can_continue;
+        self.can_break |= other.can_break;
+        self.can_stall |= other.can_stall;
+    }
 }
 
-fn analyze_block_returns(block: LuaBlock, returns: &mut Vec<LuaReturnPoint>) -> Option<ChangeFlow> {
+pub fn analyze_func_body_returns_with<F>(
+    body: LuaBlock,
+    infer_expr_type: &mut F,
+) -> Result<Vec<LuaReturnPoint>, InferFailReason>
+where
+    F: FnMut(&LuaExpr) -> Result<LuaType, InferFailReason>,
+{
+    let mut flow = analyze_block_returns(body, infer_expr_type)?;
+    if flow.can_continue || flow.can_break {
+        flow.return_points.push(LuaReturnPoint::Nil);
+    }
+
+    Ok(flow.return_points)
+}
+
+pub fn does_func_body_always_return_or_exit<F>(
+    body: LuaBlock,
+    infer_expr_type: &mut F,
+) -> Result<bool, InferFailReason>
+where
+    F: FnMut(&LuaExpr) -> Result<LuaType, InferFailReason>,
+{
+    let flow = analyze_block_returns(body, infer_expr_type)?;
+    Ok(!flow.can_continue && !flow.can_break && !flow.can_stall)
+}
+
+fn analyze_block_returns<F>(
+    block: LuaBlock,
+    infer_expr_type: &mut F,
+) -> Result<ReturnFlow, InferFailReason>
+where
+    F: FnMut(&LuaExpr) -> Result<LuaType, InferFailReason>,
+{
+    let mut flow = ReturnFlow::default();
+    let mut can_continue = true;
+
     for stat in block.get_stats() {
-        match stat {
-            LuaStat::DoStat(do_stat) => {
-                let flow = analyze_do_stat_returns(do_stat, returns);
-                match flow {
-                    Some(ChangeFlow::None) => {}
-                    _ => return flow,
-                }
-            }
-            LuaStat::WhileStat(while_stat) => {
-                analyze_while_stat_returns(while_stat, returns);
-            }
-            LuaStat::RepeatStat(repeat_stat) => {
-                analyze_repeat_stat_returns(repeat_stat, returns);
-            }
-            LuaStat::IfStat(if_stat) => {
-                analyze_if_stat_returns(if_stat, returns);
-            }
-            LuaStat::ForStat(for_stat) => {
-                analyze_for_stat_returns(for_stat, returns);
-            }
-            LuaStat::ForRangeStat(for_range_stat) => {
-                analyze_for_range_stat_returns(for_range_stat, returns);
-            }
-            LuaStat::CallExprStat(call_expr) => {
-                let flow = analyze_call_expr_stat_returns(call_expr, returns);
-                if let Some(ChangeFlow::Error) = flow {
-                    return Some(ChangeFlow::Error);
-                }
-            }
-            LuaStat::BreakStat(_) => {
-                return Some(ChangeFlow::Break);
-            }
-            LuaStat::ReturnStat(return_stat) => {
-                return analyze_return_stat_returns(return_stat, returns);
-            }
-            _ => {}
-        };
+        if !can_continue {
+            break;
+        }
+
+        let stat_flow = analyze_stat_returns(stat, infer_expr_type)?;
+        flow.return_points.extend(stat_flow.return_points);
+        flow.can_break |= stat_flow.can_break;
+        flow.can_stall |= stat_flow.can_stall;
+        can_continue = stat_flow.can_continue;
     }
 
-    Some(ChangeFlow::None)
+    flow.can_continue = can_continue;
+    Ok(flow)
 }
 
-fn analyze_do_stat_returns(
+fn analyze_optional_block_returns<F>(
+    block: Option<LuaBlock>,
+    infer_expr_type: &mut F,
+) -> Result<ReturnFlow, InferFailReason>
+where
+    F: FnMut(&LuaExpr) -> Result<LuaType, InferFailReason>,
+{
+    match block {
+        Some(block) => analyze_block_returns(block, infer_expr_type),
+        None => Ok(ReturnFlow::continue_flow()),
+    }
+}
+
+fn analyze_stat_returns<F>(
+    stat: LuaStat,
+    infer_expr_type: &mut F,
+) -> Result<ReturnFlow, InferFailReason>
+where
+    F: FnMut(&LuaExpr) -> Result<LuaType, InferFailReason>,
+{
+    match stat {
+        LuaStat::DoStat(do_stat) => analyze_do_stat_returns(do_stat, infer_expr_type),
+        LuaStat::WhileStat(while_stat) => analyze_while_stat_returns(while_stat, infer_expr_type),
+        LuaStat::RepeatStat(repeat_stat) => {
+            analyze_repeat_stat_returns(repeat_stat, infer_expr_type)
+        }
+        LuaStat::IfStat(if_stat) => analyze_if_stat_returns(if_stat, infer_expr_type),
+        LuaStat::ForStat(for_stat) => analyze_for_stat_returns(for_stat, infer_expr_type),
+        LuaStat::ForRangeStat(for_range_stat) => {
+            analyze_for_range_stat_returns(for_range_stat, infer_expr_type)
+        }
+        LuaStat::CallExprStat(call_expr) => analyze_call_expr_stat_returns(call_expr),
+        LuaStat::BreakStat(_) => Ok(ReturnFlow {
+            can_break: true,
+            ..Default::default()
+        }),
+        LuaStat::ReturnStat(return_stat) => Ok(analyze_return_stat_returns(return_stat)),
+        _ => Ok(ReturnFlow::continue_flow()),
+    }
+}
+
+fn analyze_do_stat_returns<F>(
     do_stat: LuaDoStat,
-    returns: &mut Vec<LuaReturnPoint>,
-) -> Option<ChangeFlow> {
-    analyze_block_returns(do_stat.get_block()?, returns)
+    infer_expr_type: &mut F,
+) -> Result<ReturnFlow, InferFailReason>
+where
+    F: FnMut(&LuaExpr) -> Result<LuaType, InferFailReason>,
+{
+    analyze_optional_block_returns(do_stat.get_block(), infer_expr_type)
 }
 
-fn analyze_while_stat_returns(
+fn analyze_while_stat_returns<F>(
     while_stat: LuaWhileStat,
-    returns: &mut Vec<LuaReturnPoint>,
-) -> Option<ChangeFlow> {
-    let flow = analyze_block_returns(while_stat.get_block()?, returns);
-    match flow {
-        Some(ChangeFlow::Break) => Some(ChangeFlow::None),
-        _ => flow,
+    infer_expr_type: &mut F,
+) -> Result<ReturnFlow, InferFailReason>
+where
+    F: FnMut(&LuaExpr) -> Result<LuaType, InferFailReason>,
+{
+    let condition_state =
+        analyze_condition_state(while_stat.get_condition_expr(), infer_expr_type)?;
+    match condition_state {
+        ConditionState::Falsy => Ok(ReturnFlow::continue_flow()),
+        ConditionState::Never => Ok(ReturnFlow::default()),
+        ConditionState::Truthy | ConditionState::Dynamic => {
+            let body = analyze_optional_block_returns(while_stat.get_block(), infer_expr_type)?;
+            Ok(ReturnFlow {
+                return_points: body.return_points,
+                can_continue: matches!(condition_state, ConditionState::Dynamic) || body.can_break,
+                can_break: false,
+                can_stall: body.can_continue || body.can_stall,
+            })
+        }
     }
 }
 
-fn analyze_repeat_stat_returns(
+fn analyze_repeat_stat_returns<F>(
     repeat_stat: LuaRepeatStat,
-    returns: &mut Vec<LuaReturnPoint>,
-) -> Option<ChangeFlow> {
-    let flow = analyze_block_returns(repeat_stat.get_block()?, returns);
-    match flow {
-        Some(ChangeFlow::Break) => Some(ChangeFlow::None),
-        _ => flow,
+    infer_expr_type: &mut F,
+) -> Result<ReturnFlow, InferFailReason>
+where
+    F: FnMut(&LuaExpr) -> Result<LuaType, InferFailReason>,
+{
+    let body = analyze_optional_block_returns(repeat_stat.get_block(), infer_expr_type)?;
+    let mut flow = ReturnFlow {
+        return_points: body.return_points,
+        can_continue: body.can_break,
+        can_break: false,
+        can_stall: body.can_stall,
+    };
+
+    if !body.can_continue {
+        return Ok(flow);
     }
+
+    match analyze_condition_state(repeat_stat.get_condition_expr(), infer_expr_type)? {
+        ConditionState::Truthy => {
+            flow.can_continue = true;
+        }
+        ConditionState::Falsy => {
+            flow.can_stall = true;
+        }
+        ConditionState::Dynamic => {
+            flow.can_continue = true;
+            flow.can_stall = true;
+        }
+        ConditionState::Never => {}
+    }
+
+    Ok(flow)
 }
 
-fn analyze_for_stat_returns(
+fn analyze_for_stat_returns<F>(
     for_stat: LuaForStat,
-    returns: &mut Vec<LuaReturnPoint>,
-) -> Option<ChangeFlow> {
-    let flow = analyze_block_returns(for_stat.get_block()?, returns);
-    match flow {
-        Some(ChangeFlow::Break) => Some(ChangeFlow::None),
-        _ => flow,
-    }
+    infer_expr_type: &mut F,
+) -> Result<ReturnFlow, InferFailReason>
+where
+    F: FnMut(&LuaExpr) -> Result<LuaType, InferFailReason>,
+{
+    let mut flow = analyze_optional_block_returns(for_stat.get_block(), infer_expr_type)?;
+    flow.can_continue = true;
+    flow.can_break = false;
+    Ok(flow)
 }
 
-// todo
-fn analyze_if_stat_returns(
+fn analyze_if_stat_returns<F>(
     if_stat: LuaIfStat,
-    returns: &mut Vec<LuaReturnPoint>,
-) -> Option<ChangeFlow> {
-    analyze_block_returns(if_stat.get_block()?, returns);
-    for clause in if_stat.get_all_clause() {
-        analyze_block_returns(clause.get_block()?, returns);
+    infer_expr_type: &mut F,
+) -> Result<ReturnFlow, InferFailReason>
+where
+    F: FnMut(&LuaExpr) -> Result<LuaType, InferFailReason>,
+{
+    let mut flow = ReturnFlow::default();
+    let mut can_reach_next_clause = true;
+
+    match analyze_condition_state(if_stat.get_condition_expr(), infer_expr_type)? {
+        ConditionState::Truthy => {
+            return analyze_optional_block_returns(if_stat.get_block(), infer_expr_type);
+        }
+        ConditionState::Falsy => {}
+        ConditionState::Dynamic => {
+            flow.merge_choice(analyze_optional_block_returns(
+                if_stat.get_block(),
+                infer_expr_type,
+            )?);
+        }
+        ConditionState::Never => {
+            return Ok(flow);
+        }
     }
 
-    Some(ChangeFlow::None)
+    for clause in if_stat.get_all_clause() {
+        if !can_reach_next_clause {
+            break;
+        }
+
+        match clause {
+            LuaIfClauseStat::ElseIf(clause) => {
+                match analyze_condition_state(clause.get_condition_expr(), infer_expr_type)? {
+                    ConditionState::Truthy => {
+                        flow.merge_choice(analyze_optional_block_returns(
+                            clause.get_block(),
+                            infer_expr_type,
+                        )?);
+                        can_reach_next_clause = false;
+                    }
+                    ConditionState::Falsy => {}
+                    ConditionState::Dynamic => {
+                        flow.merge_choice(analyze_optional_block_returns(
+                            clause.get_block(),
+                            infer_expr_type,
+                        )?);
+                    }
+                    ConditionState::Never => {
+                        can_reach_next_clause = false;
+                    }
+                }
+            }
+            LuaIfClauseStat::Else(clause) => {
+                flow.merge_choice(analyze_optional_block_returns(
+                    clause.get_block(),
+                    infer_expr_type,
+                )?);
+                can_reach_next_clause = false;
+            }
+        }
+    }
+
+    if can_reach_next_clause {
+        flow.can_continue = true;
+    }
+
+    Ok(flow)
 }
 
-fn analyze_for_range_stat_returns(
+fn analyze_for_range_stat_returns<F>(
     for_range_stat: LuaForRangeStat,
-    returns: &mut Vec<LuaReturnPoint>,
-) -> Option<ChangeFlow> {
-    let flow = analyze_block_returns(for_range_stat.get_block()?, returns);
-    match flow {
-        Some(ChangeFlow::Break) => Some(ChangeFlow::None),
-        _ => flow,
-    }
+    infer_expr_type: &mut F,
+) -> Result<ReturnFlow, InferFailReason>
+where
+    F: FnMut(&LuaExpr) -> Result<LuaType, InferFailReason>,
+{
+    let mut flow = analyze_optional_block_returns(for_range_stat.get_block(), infer_expr_type)?;
+    flow.can_continue = true;
+    flow.can_break = false;
+    Ok(flow)
 }
 
 fn analyze_call_expr_stat_returns(
     call_expr_stat: LuaCallExprStat,
-    returns: &mut Vec<LuaReturnPoint>,
-) -> Option<ChangeFlow> {
-    let call_expr = call_expr_stat.get_call_expr()?;
+) -> Result<ReturnFlow, InferFailReason> {
+    let Some(call_expr) = call_expr_stat.get_call_expr() else {
+        return Ok(ReturnFlow::continue_flow());
+    };
+
     if call_expr.is_error() {
-        returns.push(LuaReturnPoint::Error);
-        return Some(ChangeFlow::Error);
+        return Ok(ReturnFlow {
+            return_points: vec![LuaReturnPoint::Error],
+            ..Default::default()
+        });
     }
-    Some(ChangeFlow::None)
+
+    Ok(ReturnFlow::continue_flow())
 }
 
-fn analyze_return_stat_returns(
-    return_stat: LuaReturnStat,
-    returns: &mut Vec<LuaReturnPoint>,
-) -> Option<ChangeFlow> {
+fn analyze_return_stat_returns(return_stat: LuaReturnStat) -> ReturnFlow {
     let exprs: Vec<LuaExpr> = return_stat.get_expr_list().collect();
-    match exprs.len() {
-        0 => returns.push(LuaReturnPoint::Nil),
-        1 => returns.push(LuaReturnPoint::Expr(exprs[0].clone())),
-        _ => returns.push(LuaReturnPoint::MuliExpr(exprs)),
+    let return_point = match exprs.len() {
+        0 => LuaReturnPoint::Nil,
+        1 => LuaReturnPoint::Expr(exprs[0].clone()),
+        _ => LuaReturnPoint::MuliExpr(exprs),
+    };
+
+    ReturnFlow {
+        return_points: vec![return_point],
+        ..Default::default()
+    }
+}
+
+fn analyze_condition_state<F>(
+    condition: Option<LuaExpr>,
+    infer_expr_type: &mut F,
+) -> Result<ConditionState, InferFailReason>
+where
+    F: FnMut(&LuaExpr) -> Result<LuaType, InferFailReason>,
+{
+    let Some(condition) = condition else {
+        return Ok(ConditionState::Dynamic);
+    };
+
+    if !can_analyze_condition(&condition) {
+        return Ok(ConditionState::Dynamic);
     }
 
-    Some(ChangeFlow::Return)
+    let condition_type = match infer_expr_type(&condition) {
+        Ok(condition_type) => condition_type,
+        Err(InferFailReason::None | InferFailReason::RecursiveInfer) => {
+            return Ok(ConditionState::Dynamic);
+        }
+        Err(reason) => return Err(reason),
+    };
+
+    Ok(condition_state_from_type(&condition_type))
+}
+
+fn condition_state_from_type(condition_type: &LuaType) -> ConditionState {
+    if condition_type.is_never() {
+        return ConditionState::Never;
+    }
+
+    if condition_type.is_always_truthy() {
+        return ConditionState::Truthy;
+    }
+
+    if condition_type.is_always_falsy() {
+        return ConditionState::Falsy;
+    }
+
+    ConditionState::Dynamic
+}
+
+fn can_analyze_condition(expr: &LuaExpr) -> bool {
+    match expr {
+        LuaExpr::LiteralExpr(_) | LuaExpr::TableExpr(_) | LuaExpr::ClosureExpr(_) => true,
+        // Return-flow analysis keeps call conditions dynamic. A call like `pred()`
+        // can change after rebinding or depend on another file, so we only fold
+        // self-contained expressions here.
+        LuaExpr::CallExpr(_) => false,
+        LuaExpr::ParenExpr(paren_expr) => paren_expr
+            .get_expr()
+            .is_some_and(|expr| can_analyze_condition(&expr)),
+        LuaExpr::UnaryExpr(unary_expr) => unary_expr
+            .get_expr()
+            .is_some_and(|expr| can_analyze_condition(&expr)),
+        LuaExpr::BinaryExpr(binary_expr) => binary_expr.get_exprs().is_some_and(|(left, right)| {
+            can_analyze_condition(&left) && can_analyze_condition(&right)
+        }),
+        LuaExpr::NameExpr(_) | LuaExpr::IndexExpr(_) => false,
+    }
 }

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/lua/mod.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/lua/mod.rs
@@ -13,7 +13,9 @@ pub use closure::analyze_return_point;
 use emmylua_parser::{LuaAst, LuaAstNode, LuaExpr};
 use for_range_stat::analyze_for_range_stat;
 pub use for_range_stat::infer_for_range_iter_expr_func;
-pub use func_body::LuaReturnPoint;
+pub use func_body::{
+    LuaReturnPoint, analyze_func_body_returns_with, does_func_body_always_return_or_exit,
+};
 use metatable::analyze_setmetatable;
 use module::analyze_chunk_return;
 use stats::{

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/lua/module.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/lua/module.rs
@@ -2,16 +2,23 @@ use emmylua_parser::{LuaAstNode, LuaChunk, LuaExpr};
 
 use crate::{
     InferFailReason, LuaDeclId, LuaSemanticDeclId, LuaSignatureId,
-    compilation::analyzer::unresolve::UnResolveModule, db_index::LuaType,
+    compilation::analyzer::unresolve::UnResolveModule, db_index::LuaType, infer_expr,
 };
 
-use super::{LuaAnalyzer, LuaReturnPoint, func_body::analyze_func_body_returns};
+use super::{LuaAnalyzer, LuaReturnPoint, analyze_func_body_returns_with};
 
 pub fn analyze_chunk_return(analyzer: &mut LuaAnalyzer, chunk: LuaChunk) -> Option<()> {
     let block = chunk.get_block()?;
-    let return_exprs = analyze_func_body_returns(block);
+    let file_id = analyzer.file_id;
+    let cache = analyzer.context.infer_manager.get_infer_cache(file_id);
+    let return_exprs = analyze_func_body_returns_with(block, &mut |expr| {
+        Ok(infer_expr(analyzer.db, cache, expr.clone()).unwrap_or(LuaType::Unknown))
+    })
+    .unwrap_or_default();
     for point in return_exprs {
         if let LuaReturnPoint::Expr(expr) = point {
+            // Module export selection follows the first return candidate.
+            // It does not refine `pred()`-style call conditions.
             let expr_type = match analyzer.infer_expr(&expr) {
                 Ok(expr_type) => expr_type,
                 Err(InferFailReason::None) => LuaType::Unknown,

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/mod.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/mod.rs
@@ -6,6 +6,8 @@ mod infer_cache_manager;
 mod lua;
 mod unresolve;
 
+pub(crate) use lua::does_func_body_always_return_or_exit;
+
 use crate::{
     Emmyrc, FileId, InFiled, InferFailReason,
     db_index::{DbIndex, WorkspaceId},

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/unresolve/mod.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/unresolve/mod.rs
@@ -13,7 +13,8 @@ use crate::{
 };
 use check_reason::{check_reach_reason, resolve_all_reason};
 use emmylua_parser::{
-    LuaAssignStat, LuaCallExpr, LuaExpr, LuaFuncStat, LuaNameToken, LuaTableExpr, LuaTableField,
+    LuaAssignStat, LuaBlock, LuaCallExpr, LuaExpr, LuaFuncStat, LuaNameToken, LuaTableExpr,
+    LuaTableField,
 };
 use resolve::{
     try_resolve_decl, try_resolve_iter_var, try_resolve_member, try_resolve_module,
@@ -23,7 +24,7 @@ use resolve_closure::{
     try_resolve_call_closure_params, try_resolve_closure_parent_params, try_resolve_closure_return,
 };
 
-use super::{AnalyzeContext, infer_cache_manager::InferCacheManager, lua::LuaReturnPoint};
+use super::{AnalyzeContext, infer_cache_manager::InferCacheManager};
 
 type ResolveResult = Result<(), InferFailReason>;
 
@@ -336,7 +337,7 @@ impl From<UnResolveModule> for UnResolve {
 pub struct UnResolveReturn {
     pub file_id: FileId,
     pub signature_id: LuaSignatureId,
-    pub return_points: Vec<LuaReturnPoint>,
+    pub body: LuaBlock,
 }
 
 impl From<UnResolveReturn> for UnResolve {
@@ -378,7 +379,7 @@ pub struct UnResolveClosureReturn {
     pub signature_id: LuaSignatureId,
     pub call_expr: LuaCallExpr,
     pub param_idx: usize,
-    pub return_points: Vec<LuaReturnPoint>,
+    pub body: LuaBlock,
 }
 
 impl From<UnResolveClosureReturn> for UnResolve {

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/unresolve/resolve.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/unresolve/resolve.rs
@@ -10,7 +10,9 @@ use crate::{
     LuaTypeDeclId, OperatorFunction, SignatureReturnStatus, TypeOps,
     compilation::analyzer::{
         common::{add_member, bind_type},
-        lua::{analyze_return_point, infer_for_range_iter_expr_func},
+        lua::{
+            analyze_func_body_returns_with, analyze_return_point, infer_for_range_iter_expr_func,
+        },
         unresolve::UnResolveConstructor,
     },
     db_index::{DbIndex, LuaMemberOwner, LuaType},
@@ -180,7 +182,10 @@ pub fn try_resolve_return_point(
     cache: &mut LuaInferCache,
     return_: &mut UnResolveReturn,
 ) -> ResolveResult {
-    let return_docs = analyze_return_point(db, cache, &return_.return_points)?;
+    let return_points = analyze_func_body_returns_with(return_.body.clone(), &mut |expr| {
+        infer_expr(db, cache, expr.clone())
+    })?;
+    let return_docs = analyze_return_point(db, cache, &return_points)?;
 
     let signature = db
         .get_signature_index_mut()

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/unresolve/resolve_closure.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/unresolve/resolve_closure.rs
@@ -187,7 +187,7 @@ fn try_convert_to_func_body_infer(
     let mut unresolve = UnResolveReturn {
         file_id: closure_return.file_id,
         signature_id: closure_return.signature_id,
-        return_points: closure_return.return_points.clone(),
+        body: closure_return.body.clone(),
     };
 
     try_resolve_return_point(db, cache, &mut unresolve)

--- a/crates/emmylua_code_analysis/src/compilation/mod.rs
+++ b/crates/emmylua_code_analysis/src/compilation/mod.rs
@@ -3,6 +3,8 @@ mod test;
 
 use std::sync::Arc;
 
+pub(crate) use analyzer::does_func_body_always_return_or_exit;
+
 use crate::{
     Emmyrc, FileId, InFiled, LuaIndex, LuaInferCache, db_index::DbIndex, semantic::SemanticModel,
 };

--- a/crates/emmylua_code_analysis/src/compilation/test/closure_return_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/closure_return_test.rs
@@ -2,6 +2,18 @@
 mod test {
     use crate::{DiagnosticCode, VirtualWorkspace};
 
+    fn assert_inferred_return_without_nil(code: &str) {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(code);
+
+        let ty = ws.expr_ty("result");
+        let expected = ws.ty("integer");
+        let nil = ws.ty("nil");
+        assert!(ws.check_type(&ty, &expected));
+        assert!(!ws.check_type(&ty, &nil));
+    }
+
     #[test]
     fn test_flow() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
@@ -124,5 +136,226 @@ mod test {
         );
 
         assert_eq!(ws.expr_ty("result"), ws.ty("never"));
+    }
+
+    #[test]
+    fn test_inferred_return_from_truthy_loops() {
+        for code in [
+            r#"
+        local function f()
+            while true do
+                return 1
+            end
+        end
+
+        result = f()
+        "#,
+            r#"
+        local function f()
+            while (true) do
+                return 1
+            end
+        end
+
+        result = f()
+        "#,
+            r#"
+        local function f()
+            while 1 == 1 do
+                return 1
+            end
+        end
+
+        result = f()
+        "#,
+            r#"
+        local function f()
+            while 1 do
+                return 1
+            end
+        end
+
+        result = f()
+        "#,
+            r#"
+        local function f()
+            while {} do
+                return 1
+            end
+        end
+
+        result = f()
+        "#,
+            r#"
+        local function f()
+            repeat
+                return 1
+            until true
+        end
+
+        result = f()
+        "#,
+            r#"
+        local function f()
+            repeat
+                return 1
+            until 1 == 1
+        end
+
+        result = f()
+        "#,
+            r#"
+        local function f()
+            repeat
+                return 1
+            until "done"
+        end
+
+        result = f()
+        "#,
+            r#"
+        local function f()
+            repeat
+                return 1
+            until function() end
+        end
+
+        result = f()
+        "#,
+            r#"
+        local function f(a)
+            repeat
+                if a then
+                    return 1
+                end
+            until true
+
+            return 2
+        end
+
+        result = f()
+        "#,
+        ] {
+            assert_inferred_return_without_nil(code);
+        }
+    }
+
+    #[test]
+    fn test_inferred_return_from_truthy_ifs() {
+        for code in [
+            r#"
+        local function f()
+            if 1 == 1 then
+                return 1
+            end
+        end
+
+        result = f()
+        "#,
+            r#"
+        local function f()
+            if 1 then
+                return 1
+            end
+        end
+
+        result = f()
+        "#,
+            r#"
+        local function f()
+            if {} then
+                return 1
+            end
+        end
+
+        result = f()
+        "#,
+            r#"
+        local function f()
+            if "done" then
+                return 1
+            end
+        end
+
+        result = f()
+        "#,
+        ] {
+            assert_inferred_return_without_nil(code);
+        }
+    }
+
+    #[test]
+    fn test_inferred_return_from_infinite_repeat_does_not_assume_nil() {
+        assert_inferred_return_without_nil(
+            r#"
+        local function f(a)
+            repeat
+                if a then
+                    return 1
+                end
+            until false
+        end
+
+        result = f()
+        "#,
+        );
+    }
+
+    #[test]
+    fn test_return_flow_keeps_local_while_call_condition_dynamic() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+        local should_enter_loop = function()
+            return true
+        end
+
+        local function f()
+            while should_enter_loop() do
+                return 1
+            end
+
+            return ""
+        end
+
+        result = f()
+        "#,
+        );
+
+        let ty = ws.expr_ty("result");
+        let expected = ws.ty("integer|string");
+        let nil = ws.ty("nil");
+        assert!(ws.check_type(&ty, &expected));
+        assert!(!ws.check_type(&ty, &nil));
+    }
+
+    #[test]
+    fn test_return_flow_keeps_global_if_call_condition_dynamic() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+        function should_take_branch()
+            return true
+        end
+
+        local function f()
+            if should_take_branch() then
+                return 1
+            else
+                return ""
+            end
+        end
+
+        result = f()
+        "#,
+        );
+
+        let ty = ws.expr_ty("result");
+        let expected = ws.ty("integer|string");
+        let nil = ws.ty("nil");
+        assert!(ws.check_type(&ty, &expected));
+        assert!(!ws.check_type(&ty, &nil));
     }
 }

--- a/crates/emmylua_code_analysis/src/compilation/test/module_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/module_test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod test {
-    use crate::{ModuleVisibility, VirtualWorkspace};
+    use crate::{DiagnosticCode, ModuleVisibility, VirtualWorkspace};
 
     #[test]
     fn test_module_annotation() {
@@ -121,5 +121,53 @@ mod test {
             assert!(module.is_some());
             assert!(module.unwrap().visible == ModuleVisibility::Internal);
         }
+    }
+
+    #[test]
+    fn test_module_return_from_truthy_while_block() {
+        let mut ws = VirtualWorkspace::new_with_init_std_lib();
+
+        ws.def(
+            r#"
+                while {} do
+                    return 1
+                end
+                "#,
+        );
+
+        // `def()` creates `virtual_0.lua`, so the block is requireable as `virtual_0`.
+        let ty = ws.expr_ty(r#"require("virtual_0")"#);
+        let integer = ws.ty("integer");
+        let nil = ws.ty("nil");
+        assert!(ws.check_type(&ty, &integer));
+        assert!(!ws.check_type(&ty, &nil));
+    }
+
+    #[test]
+    fn test_module_multiple_return_paths_preserve_export_metadata_block() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+                ---@class (partial) ModuleExport
+                ---@field private hidden integer
+                local export = {}
+
+                if flag then
+                    return export
+                end
+
+                return export
+                "#,
+        );
+
+        // `AccessInvisible` only fires if the export still points at `export`.
+        assert!(!ws.check_code_for(
+            DiagnosticCode::AccessInvisible,
+            r#"
+                local export = require("virtual_0")
+                export.hidden = 1
+                "#,
+        ));
     }
 }

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/check_return_count.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/check_return_count.rs
@@ -1,9 +1,12 @@
 use emmylua_parser::{
-    LuaAst, LuaAstNode, LuaAstToken, LuaBlock, LuaCallExprStat, LuaClosureExpr, LuaGeneralToken,
-    LuaIfStat, LuaReturnStat, LuaTokenKind, LuaWhileStat,
+    LuaAst, LuaAstNode, LuaAstToken, LuaBlock, LuaClosureExpr, LuaExpr, LuaGeneralToken,
+    LuaReturnStat, LuaTokenKind,
 };
 
-use crate::{DiagnosticCode, LuaSignatureId, LuaType, SemanticModel, SignatureReturnStatus};
+use crate::{
+    DiagnosticCode, LuaSignatureId, LuaType, SemanticModel, SignatureReturnStatus,
+    compilation::does_func_body_always_return_or_exit,
+};
 
 use super::{Checker, DiagnosticContext, get_return_stats};
 
@@ -108,15 +111,19 @@ fn check_missing_return(
     // 检测缺少返回语句需要处理 if while
     if min_expected_return_count > 0 {
         let range = if let Some(block) = closure_expr.get_block() {
-            let result = check_return_block(context, semantic_model, block);
-            match result {
-                Ok(_) => return Some(()),
-                Err(block) => {
-                    let token = get_block_end_token(&block)
-                        .unwrap_or(block.tokens::<LuaGeneralToken>().last()?);
-                    Some(token.get_range())
-                }
+            if does_func_body_always_return_or_exit(block.clone(), &mut |expr: &LuaExpr| {
+                Ok(semantic_model
+                    .infer_expr(expr.clone())
+                    .unwrap_or(LuaType::Unknown))
+            })
+            .ok()?
+            {
+                return Some(());
             }
+
+            let token =
+                get_block_end_token(&block).unwrap_or(block.tokens::<LuaGeneralToken>().last()?);
+            Some(token.get_range())
         } else {
             Some(closure_expr.token_by_kind(LuaTokenKind::TkEnd)?.get_range())
         };
@@ -138,114 +145,6 @@ fn get_block_end_token(block: &LuaBlock) -> Option<LuaGeneralToken> {
         .token_by_kind(LuaTokenKind::TkEnd)
         .unwrap_or(LuaAst::cast(block.syntax().parent()?)?.token_by_kind(LuaTokenKind::TkEnd)?);
     Some(token)
-}
-
-fn check_return_block(
-    context: &mut DiagnosticContext,
-    semantic_model: &SemanticModel,
-    block: LuaBlock,
-) -> Result<(), LuaBlock> {
-    // 检查是否存在return语句
-    if block.children::<LuaReturnStat>().count() > 0 {
-        return Ok(());
-    }
-
-    // 检查是否 error() 了
-    for call_expr_stat in block.children::<LuaCallExprStat>() {
-        if let Some(call_expr) = call_expr_stat.get_call_expr()
-            && call_expr.is_error()
-        {
-            return Ok(());
-        }
-    }
-
-    // 检查`if`和`while`语句
-    let has_return = check_if_stat(context, semantic_model, &block)?
-        | check_while_stat(context, semantic_model, &block)?;
-
-    if has_return { Ok(()) } else { Err(block) }
-}
-
-fn check_if_stat(
-    context: &mut DiagnosticContext,
-    semantic_model: &SemanticModel,
-    block: &LuaBlock,
-) -> Result<bool, LuaBlock> {
-    let mut has_return = false;
-    for if_stat in block.children::<LuaIfStat>() {
-        // 检查`if`的主块
-        if let Some(if_block) = if_stat.get_block() {
-            if check_return_block(context, semantic_model, if_block.clone()).is_err() {
-                has_return = false;
-            }
-        } else {
-            return Err(block.clone());
-        }
-
-        // 检查所有条件分支
-        for clause in if_stat.get_all_clause() {
-            if let Some(clause_block) = clause.get_block() {
-                if check_return_block(context, semantic_model, clause_block.clone()).is_err() {
-                    has_return = false;
-                }
-            } else {
-                return Err(block.clone());
-            }
-        }
-
-        // 检查是否存在`else`分支, 如果存在则上面已经检查过
-        if if_stat.get_else_clause().is_some() {
-            has_return = true;
-        }
-    }
-
-    if has_return {
-        Ok(has_return)
-    } else {
-        Err(block.clone())
-    }
-}
-
-fn check_while_stat(
-    context: &mut DiagnosticContext,
-    semantic_model: &SemanticModel,
-    block: &LuaBlock,
-) -> Result<bool, LuaBlock> {
-    let mut has_return = false;
-    for while_stat in block.children::<LuaWhileStat>() {
-        if let Some(while_block) = while_stat.get_block() {
-            check_return_block(context, semantic_model, while_block.clone())?;
-        } else {
-            return Err(block.clone());
-        }
-
-        // 检查`while`条件是否恒真, 如果恒真则代表存在返回语句(上面已经检查过子块)
-        if is_while_condition_true(semantic_model, &while_stat).is_some() {
-            has_return = true;
-        }
-    }
-    Ok(has_return)
-}
-
-/// 确定 LuaWhileStat 的条件表达式是否为`true`
-fn is_while_condition_true(
-    semantic_model: &SemanticModel,
-    while_stat: &LuaWhileStat,
-) -> Option<()> {
-    let condition_expr = while_stat.get_condition_expr()?;
-    let condition_type = semantic_model
-        .infer_expr(condition_expr.clone())
-        .unwrap_or(LuaType::Any);
-    match condition_type {
-        LuaType::BooleanConst(value) => {
-            if value {
-                Some(())
-            } else {
-                None
-            }
-        }
-        _ => None,
-    }
 }
 
 /// 检查返回值数量

--- a/crates/emmylua_code_analysis/src/diagnostic/test/check_return_count_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/check_return_count_test.rs
@@ -2,6 +2,16 @@
 mod tests {
     use crate::{DiagnosticCode, VirtualWorkspace};
 
+    fn assert_missing_return_ok(code: &str) {
+        let mut ws = VirtualWorkspace::new();
+        assert!(ws.check_code_for(DiagnosticCode::MissingReturn, code));
+    }
+
+    fn assert_missing_return_error(code: &str) {
+        let mut ws = VirtualWorkspace::new();
+        assert!(!ws.check_code_for(DiagnosticCode::MissingReturn, code));
+    }
+
     #[test]
     fn test_1() {
         let mut ws = VirtualWorkspace::new();
@@ -221,6 +231,65 @@ mod tests {
             "#
         ));
 
+        assert!(ws.check_code_for(
+            DiagnosticCode::MissingReturn,
+            r#"
+            ---@return number
+            local function foo()
+                while true do
+                    return 1
+                end
+            end
+            "#
+        ));
+
+        assert!(ws.check_code_for(
+            DiagnosticCode::MissingReturn,
+            r#"
+            local A
+            ---@return number
+            local function foo()
+                if A then
+                    A = false
+                end
+
+                while true do
+                    return 1
+                end
+            end
+            "#
+        ));
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::MissingReturn,
+            r#"
+            local A
+            ---@return number
+            local function foo()
+                while true do
+                    if A then
+                        break
+                    end
+
+                    return 1
+                end
+            end
+            "#
+        ));
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::MissingReturn,
+            r#"
+            ---@return number
+            local function foo(A)
+                while A do
+                end
+
+                return 1
+            end
+            "#
+        ));
+
         assert!(!ws.check_code_for(
             DiagnosticCode::MissingReturn,
             r#"
@@ -229,6 +298,63 @@ mod tests {
             function F()
                 while true do
                     if A then
+                        return 1
+                    end
+                end
+            end
+            "#
+        ));
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::MissingReturn,
+            r#"
+            local A
+            ---@return number
+            local function foo()
+                while true do
+                    if A then
+                        do
+                            break
+                        end
+                    end
+
+                    while true do
+                        return 1
+                    end
+                end
+            end
+            "#
+        ));
+
+        assert!(ws.check_code_for(
+            DiagnosticCode::MissingReturn,
+            r#"
+            local A
+            ---@return number
+            local function foo()
+                while true do
+                    return 1
+
+                    if A then
+                        break
+                    end
+                end
+            end
+            "#
+        ));
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::MissingReturn,
+            r#"
+            local A
+            ---@return number
+            local function foo()
+                while true do
+                    if A then
+                        break
+                    end
+
+                    while true do
                         return 1
                     end
                 end
@@ -397,6 +523,185 @@ mod tests {
             end
             "#
         ));
+    }
+
+    #[test]
+    fn test_missing_return_accepts_truthy_loops() {
+        for code in [
+            r#"
+            ---@return number
+            local function foo()
+                while (true) do
+                    return 1
+                end
+            end
+            "#,
+            r#"
+            ---@return number
+            local function foo()
+                while 1 == 1 do
+                    return 1
+                end
+            end
+            "#,
+            r#"
+            ---@return number
+            local function foo()
+                while 1 do
+                    return 1
+                end
+            end
+            "#,
+            r#"
+            ---@return number
+            local function foo()
+                while {} do
+                    return 1
+                end
+            end
+            "#,
+            r#"
+            ---@return number
+            local function foo()
+                repeat
+                    return 1
+                until true
+            end
+            "#,
+            r#"
+            ---@return number
+            local function foo()
+                repeat
+                    return 1
+                until 1 == 1
+            end
+            "#,
+            r#"
+            ---@return number
+            local function foo()
+                repeat
+                    return 1
+                until "done"
+            end
+            "#,
+            r#"
+            ---@return number
+            local function foo()
+                repeat
+                    return 1
+                until function() end
+            end
+            "#,
+            r#"
+            ---@return number
+            local function foo(a)
+                repeat
+                    if a then
+                        return 1
+                    end
+                until true
+
+                return 2
+            end
+            "#,
+        ] {
+            assert_missing_return_ok(code);
+        }
+    }
+
+    #[test]
+    fn test_missing_return_accepts_truthy_ifs() {
+        for code in [
+            r#"
+            ---@return number
+            local function foo()
+                if 1 == 1 then
+                    return 1
+                end
+            end
+            "#,
+            r#"
+            ---@return number
+            local function foo()
+                if 1 == 1 then
+                    return 1
+                else
+                    while pred() do
+                    end
+                end
+            end
+            "#,
+            r#"
+            ---@return number
+            local function foo()
+                if {} then
+                    return 1
+                end
+            end
+            "#,
+        ] {
+            assert_missing_return_ok(code);
+        }
+    }
+
+    #[test]
+    fn test_missing_return_keeps_local_if_call_condition_dynamic() {
+        assert_missing_return_error(
+            r#"
+            local should_take_branch = function()
+                return true
+            end
+
+            ---@return number
+            local function foo()
+                if should_take_branch() then
+                    return 1
+                end
+            end
+            "#,
+        );
+    }
+
+    #[test]
+    fn test_missing_return_rejects_stalling_numeric_for_before_return() {
+        assert_missing_return_error(
+            r#"
+            ---@return number
+            local function foo()
+                for _ = 1, 10 do
+                    while true do
+                    end
+                end
+
+                return 1
+            end
+            "#,
+        );
+    }
+
+    #[test]
+    fn test_missing_return_rejects_stalling_generic_for_before_return() {
+        assert_missing_return_error(
+            r#"
+            local function iter(_, done)
+                if done then
+                    return nil
+                end
+
+                return true, true
+            end
+
+            ---@return number
+            local function foo()
+                for _ in iter, nil, nil do
+                    while true do
+                    end
+                end
+
+                return 1
+            end
+            "#,
+        );
     }
 
     #[test]


### PR DESCRIPTION
Replace the old missing-return special cases with the same ordered block
walker used for inferred returns. This avoids false MissingReturn
diagnostics for functions that return from truthy while/repeat loops,
keeps break and repeat-until flow consistent across inference and
diagnostics, and adds regressions for closure returns, diagnostics, and
module exports.
