### PR TITLE
Fix stack overflow in large flow-tree narrowing

### DIFF
--- a/crates/emmylua_code_analysis/src/db_index/flow/flow_tree.rs
+++ b/crates/emmylua_code_analysis/src/db_index/flow/flow_tree.rs
@@ -41,6 +41,10 @@ impl FlowTree {
         self.flow_nodes.get(flow_id.0 as usize)
     }
 
+    pub fn node_count(&self) -> usize {
+        self.flow_nodes.len()
+    }
+
     pub fn get_multi_antecedents(&self, id: u32) -> Option<&[FlowId]> {
         self.multiple_antecedents
             .get(id as usize)

--- a/crates/emmylua_code_analysis/src/diagnostic/test/return_type_mismatch_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/return_type_mismatch_test.rs
@@ -672,4 +672,42 @@ mod tests {
             "#
         ));
     }
+
+    #[test]
+    fn test_large_flow_tree_falls_back_without_stack_overflow() {
+        let mut ws = VirtualWorkspace::new();
+        let mut code = String::from(
+            r#"
+                ---@param tag integer
+                ---@return integer
+                local function test(tag)
+                    local result = 0
+            "#,
+        );
+
+        for i in 0..700 {
+            if i == 0 {
+                code.push_str(&format!(
+                    "\n                    if tag == {i} then\n                        result = {i}"
+                ));
+            } else {
+                code.push_str(&format!(
+                    "\n                    elseif tag == {i} then\n                        result = {i}"
+                ));
+            }
+        }
+
+        code.push_str(
+            r#"
+                    else
+                        result = 701
+                    end
+
+                    return result
+                end
+            "#,
+        );
+
+        assert!(ws.check_code_for(DiagnosticCode::ReturnTypeMismatch, &code));
+    }
 }

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/get_type_at_flow.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/get_type_at_flow.rs
@@ -24,6 +24,8 @@ use crate::{
     },
 };
 
+const MAX_FLOW_CHAIN_DEPTH: usize = 2048;
+
 pub fn get_type_at_flow(
     db: &DbIndex,
     tree: &FlowTree,
@@ -32,7 +34,7 @@ pub fn get_type_at_flow(
     var_ref_id: &VarRefId,
     flow_id: FlowId,
 ) -> InferResult {
-    get_type_at_flow_internal(db, tree, cache, root, var_ref_id, flow_id, true)
+    get_type_at_flow_internal(db, tree, cache, root, var_ref_id, flow_id, true, 0)
 }
 
 fn can_reuse_narrowed_assignment_source(
@@ -118,7 +120,12 @@ fn get_type_at_flow_internal(
     var_ref_id: &VarRefId,
     flow_id: FlowId,
     use_condition_narrowing: bool,
+    depth: usize,
 ) -> InferResult {
+    if depth >= MAX_FLOW_CHAIN_DEPTH {
+        return get_var_ref_type(db, cache, var_ref_id).or(Err(InferFailReason::RecursiveInfer));
+    }
+
     let key = (var_ref_id.clone(), flow_id, use_condition_narrowing);
     if let Some(cache_entry) = cache.flow_node_cache.get(&key) {
         return match cache_entry {
@@ -159,6 +166,7 @@ fn get_type_at_flow_internal(
                             var_ref_id,
                             flow_id,
                             use_condition_narrowing,
+                            depth + 1,
                         )?;
                         branch_result_type =
                             TypeOps::Union.apply(db, &branch_result_type, &branch_type);
@@ -199,6 +207,7 @@ fn get_type_at_flow_internal(
                         var_ref_id,
                         flow_node,
                         assign_stat,
+                        depth + 1,
                     )?;
 
                     if let ResultTypeOrContinue::Result(assign_type) = result_or_continue {
@@ -361,6 +370,7 @@ fn get_type_at_assign_stat(
     var_ref_id: &VarRefId,
     flow_node: &FlowNode,
     assign_stat: LuaAssignStat,
+    depth: usize,
 ) -> Result<ResultTypeOrContinue, InferFailReason> {
     let (vars, exprs) = assign_stat.get_var_and_expr_list();
     for (i, var) in vars.iter().cloned().enumerate() {
@@ -408,12 +418,21 @@ fn get_type_at_assign_stat(
                             var_ref_id,
                             antecedent_flow_id,
                             false,
+                            depth + 1,
                         )?,
                         false,
                     )
                 } else {
-                    let narrowed_source_type =
-                        get_type_at_flow(db, tree, cache, root, var_ref_id, antecedent_flow_id)?;
+                    let narrowed_source_type = get_type_at_flow_internal(
+                        db,
+                        tree,
+                        cache,
+                        root,
+                        var_ref_id,
+                        antecedent_flow_id,
+                        true,
+                        depth + 1,
+                    )?;
                     if can_reuse_narrowed_assignment_source(db, &narrowed_source_type, &expr_type) {
                         (narrowed_source_type, true)
                     } else {
@@ -426,6 +445,7 @@ fn get_type_at_assign_stat(
                                 var_ref_id,
                                 antecedent_flow_id,
                                 false,
+                                depth + 1,
                             )?,
                             false,
                         )

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/mod.rs
@@ -18,6 +18,8 @@ pub use get_type_at_cast_flow::get_type_at_call_expr_inline_cast;
 pub use narrow_type::{narrow_down_type, narrow_false_or_nil, remove_false_or_nil};
 pub use var_ref_id::{VarRefId, get_var_expr_var_ref_id};
 
+const MAX_NARROW_FLOW_NODES: usize = 512;
+
 pub fn infer_expr_narrow_type(
     db: &DbIndex,
     cache: &mut LuaInferCache,
@@ -32,6 +34,10 @@ pub fn infer_expr_narrow_type(
     let Some(flow_id) = flow_tree.get_flow_id(expr.get_syntax_id()) else {
         return get_var_ref_type(db, cache, &var_ref_id);
     };
+
+    if flow_tree.node_count() > MAX_NARROW_FLOW_NODES {
+        return get_var_ref_type(db, cache, &var_ref_id);
+    }
 
     let root = LuaChunk::cast(expr.get_root()).ok_or(InferFailReason::None)?;
     get_type_at_flow::get_type_at_flow(db, flow_tree, cache, &root, &var_ref_id, flow_id)


### PR DESCRIPTION
Root cause: infer_expr_narrow_type could enter flow narrowing on very large control-flow graphs, and get_type_at_flow recursively walked branch and assignment antecedents until the process exhausted the stack on large single-file Lua scripts.

Fix: add a flow-tree size based fallback that skips branch narrowing for oversized graphs, keep a depth guard in flow backtracking as a second safety net, expose FlowTree::node_count for the gate, and add a regression test covering a large elseif chain so the analyzer returns normally instead of overflowing the stack.