### PR TITLE
fix(semantic): avoid recursive inference while preserving flow precision

### DIFF
--- a/crates/emmylua_code_analysis/src/compilation/test/flow.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/flow.rs
@@ -193,6 +193,38 @@ mod test {
     }
 
     #[test]
+    fn test_stacked_local_call_alias_type_guards_build_semantic_model() {
+        let mut ws = VirtualWorkspace::new();
+        let repeated_guards = "if not pred(value) then return end\n".repeat(STACKED_TYPE_GUARDS);
+        let block = format!(
+            r#"
+        ---@param v any
+        ---@return TypeGuard<string>
+        local function is_string(v)
+            return true
+        end
+
+        local pred = is_string
+        local value ---@type string|integer|boolean
+
+        {repeated_guards}
+        after_guard = value
+        "#,
+        );
+
+        let file_id = ws.def(&block);
+
+        assert!(
+            ws.analysis
+                .compilation
+                .get_semantic_model(file_id)
+                .is_some(),
+            "expected semantic model for stacked local call alias type guard repro"
+        );
+        assert_eq!(ws.expr_ty("after_guard"), ws.ty("string"));
+    }
+
+    #[test]
     fn test_stacked_same_var_call_type_guard_eq_false_build_semantic_model() {
         let mut ws = VirtualWorkspace::new();
         let repeated_guards = "if instance_of(value, 'string') == false then return end\n"
@@ -1910,6 +1942,28 @@ end
     }
 
     #[test]
+    fn test_feature_initializer_alias_keeps_flow_type() {
+        let mut ws = VirtualWorkspace::new_with_init_std_lib();
+
+        ws.def(
+            r#"
+            local x --- @type string | integer
+
+            if type(x) ~= "string" then
+                return
+            end
+
+            local y = x
+            after = y
+            "#,
+        );
+
+        let after = ws.expr_ty("after");
+        let after_expected = ws.ty("string");
+        assert_eq!(after, after_expected);
+    }
+
+    #[test]
     fn test_feature_const_local_alias_chain_does_not_inherit_flow() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
@@ -2651,6 +2705,55 @@ _2 = a[1]
 
         assert_eq!(ws.expr_ty("before_assign"), ws.ty("string"));
         assert_eq!(ws.expr_ty("after_assign"), ws.ty("string|integer|boolean"));
+    }
+
+    #[test]
+    fn test_eq_uses_branch_narrowed_rhs_ref_type() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            local x ---@type string|integer
+            local y ---@type string|integer
+
+            if type(y) ~= "string" then
+                return
+            end
+
+            if x == y then
+                after_guard = x
+            end
+            "#,
+        );
+
+        assert_eq!(ws.expr_ty("after_guard"), ws.ty("string"));
+    }
+
+    #[test]
+    fn test_eq_uses_branch_narrowed_rhs_index_type() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Foo
+            ---@field kind "foo"
+
+            ---@class Bar
+            ---@field kind "bar"
+
+            local x ---@type "foo"|"bar"
+            local y ---@type Foo|Bar
+
+            if y.kind == "foo" then
+                if x == y.kind then
+                    after_guard = x
+                end
+            end
+            "#,
+        );
+
+        let after_guard = ws.expr_ty("after_guard");
+        assert_eq!(ws.humanize_type(after_guard), r#""foo""#);
     }
 
     #[test]

--- a/crates/emmylua_code_analysis/src/compilation/test/member_infer_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/member_infer_test.rs
@@ -391,6 +391,28 @@ mod test {
     }
 
     #[test]
+    fn test_rawget_alias_guard_narrows_matching_index_expr() {
+        let mut ws = VirtualWorkspace::new_with_init_std_lib();
+
+        ws.def(
+            r#"
+        ---@class T
+        ---@field x? integer
+
+        ---@type T
+        local t = {}
+        local get = rawget
+
+        if get(t, "x") then
+            result = t.x
+        end
+        "#,
+        );
+
+        assert_eq!(ws.expr_ty("result"), LuaType::Integer);
+    }
+
+    #[test]
     fn test_type_guard_call_narrows_matching_index_expr() {
         let mut ws = VirtualWorkspace::new();
 

--- a/crates/emmylua_code_analysis/src/compilation/test/pcall_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/pcall_test.rs
@@ -177,6 +177,31 @@ mod test {
     }
 
     #[test]
+    fn test_pcall_alias_callee_narrows_return_after_error_guard() {
+        let mut ws = VirtualWorkspace::new_with_init_std_lib();
+
+        ws.def(
+            r#"
+        ---@return integer
+        local function foo()
+            return 1
+        end
+
+        local runner = pcall
+        local ok, result = runner(foo)
+
+        if not ok then
+            error(result)
+        end
+
+        narrowed = result
+        "#,
+        );
+
+        assert_eq!(ws.expr_ty("narrowed"), ws.ty("integer"));
+    }
+
+    #[test]
     fn test_pcall_any_callable_splits_success_unknown_and_failure_string() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 

--- a/crates/emmylua_code_analysis/src/db_index/member/lua_member.rs
+++ b/crates/emmylua_code_analysis/src/db_index/member/lua_member.rs
@@ -6,7 +6,10 @@ use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 
 use super::lua_member_feature::LuaMemberFeature;
-use crate::{DbIndex, FileId, GlobalId, InferFailReason, LuaInferCache, LuaType, infer_expr};
+use crate::{
+    DbIndex, FileId, GlobalId, InferFailReason, LuaInferCache, LuaType, infer_expr,
+    semantic::try_infer_expr_for_index,
+};
 
 #[derive(Debug)]
 pub struct LuaMember {
@@ -99,10 +102,29 @@ pub enum LuaMemberKey {
 }
 
 impl LuaMemberKey {
+    pub(crate) fn from_type(expr_type: LuaType) -> Self {
+        match expr_type {
+            LuaType::StringConst(s) => LuaMemberKey::Name(s.deref().clone()),
+            LuaType::DocStringConst(s) => LuaMemberKey::Name(s.deref().clone()),
+            LuaType::IntegerConst(i) => LuaMemberKey::Integer(i),
+            LuaType::DocIntegerConst(i) => LuaMemberKey::Integer(i),
+            _ => LuaMemberKey::ExprType(expr_type),
+        }
+    }
+
     pub fn from_index_key(
         db: &DbIndex,
         cache: &mut LuaInferCache,
         key: &LuaIndexKey,
+    ) -> Result<Self, InferFailReason> {
+        Self::from_index_key_with_mode(db, cache, key, false)
+    }
+
+    pub(crate) fn from_index_key_with_mode(
+        db: &DbIndex,
+        cache: &mut LuaInferCache,
+        key: &LuaIndexKey,
+        no_flow: bool,
     ) -> Result<Self, InferFailReason> {
         match key {
             LuaIndexKey::Name(name) => Ok(LuaMemberKey::Name(name.get_name_text().into())),
@@ -116,14 +138,15 @@ impl LuaMemberKey {
             }
             LuaIndexKey::Idx(idx) => Ok(LuaMemberKey::Integer(*idx as i64)),
             LuaIndexKey::Expr(expr) => {
-                let expr_type = infer_expr(db, cache, expr.clone())?;
-                match expr_type {
-                    LuaType::StringConst(s) => Ok(LuaMemberKey::Name(s.deref().clone())),
-                    LuaType::DocStringConst(s) => Ok(LuaMemberKey::Name(s.deref().clone())),
-                    LuaType::IntegerConst(i) => Ok(LuaMemberKey::Integer(i)),
-                    LuaType::DocIntegerConst(i) => Ok(LuaMemberKey::Integer(i)),
-                    _ => Ok(LuaMemberKey::ExprType(expr_type)),
-                }
+                let expr_type = if no_flow {
+                    let Some(expr_type) = try_infer_expr_for_index(db, cache, expr.clone())? else {
+                        return Err(InferFailReason::None);
+                    };
+                    expr_type
+                } else {
+                    infer_expr(db, cache, expr.clone())?
+                };
+                Ok(LuaMemberKey::from_type(expr_type))
             }
         }
     }

--- a/crates/emmylua_code_analysis/src/semantic/cache/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/cache/mod.rs
@@ -17,6 +17,13 @@ pub enum CacheEntry<T> {
     Cache(T),
 }
 
+#[derive(Debug)]
+pub enum NoFlowCacheEntry<T> {
+    Ready,
+    Declined,
+    Cache(T),
+}
+
 #[derive(Debug, Clone)]
 pub(in crate::semantic) struct FlowConditionInfo {
     pub expr: LuaExpr,
@@ -53,9 +60,13 @@ pub(in crate::semantic) struct FlowVarCache {
 pub struct LuaInferCache {
     file_id: FileId,
     config: CacheOptions,
+    no_flow_mode: bool,
     pub expr_cache: HashMap<LuaSyntaxId, CacheEntry<LuaType>>,
+    pub expr_no_flow_cache: HashMap<LuaSyntaxId, NoFlowCacheEntry<LuaType>>,
     pub call_cache:
         HashMap<(LuaSyntaxId, Option<usize>, LuaType), CacheEntry<Arc<LuaFunctionType>>>,
+    pub call_no_flow_cache:
+        HashMap<(LuaSyntaxId, Option<usize>, LuaType), NoFlowCacheEntry<Arc<LuaFunctionType>>>,
     pub(in crate::semantic) flow_cache_var_ref_ids: HashMap<VarRefId, u32>,
     pub(in crate::semantic) next_flow_cache_var_ref_id: u32,
     pub(in crate::semantic) flow_var_caches: Vec<FlowVarCache>,
@@ -72,8 +83,11 @@ impl LuaInferCache {
         Self {
             file_id,
             config,
+            no_flow_mode: false,
             expr_cache: HashMap::new(),
+            expr_no_flow_cache: HashMap::new(),
             call_cache: HashMap::new(),
+            call_no_flow_cache: HashMap::new(),
             flow_cache_var_ref_ids: HashMap::new(),
             next_flow_cache_var_ref_id: 0,
             flow_var_caches: Vec::new(),
@@ -94,13 +108,30 @@ impl LuaInferCache {
         self.file_id
     }
 
+    pub(in crate::semantic) fn is_no_flow(&self) -> bool {
+        self.no_flow_mode
+    }
+
+    pub(in crate::semantic) fn with_no_flow<R>(
+        &mut self,
+        f: impl FnOnce(&mut LuaInferCache) -> R,
+    ) -> R {
+        let previous_mode = std::mem::replace(&mut self.no_flow_mode, true);
+        let result = f(self);
+        self.no_flow_mode = previous_mode;
+        result
+    }
+
     pub fn set_phase(&mut self, phase: LuaAnalysisPhase) {
         self.config.analysis_phase = phase;
     }
 
     pub fn clear(&mut self) {
+        self.no_flow_mode = false;
         self.expr_cache.clear();
+        self.expr_no_flow_cache.clear();
         self.call_cache.clear();
+        self.call_no_flow_cache.clear();
         self.flow_cache_var_ref_ids.clear();
         self.next_flow_cache_var_ref_id = 0;
         self.flow_var_caches.clear();

--- a/crates/emmylua_code_analysis/src/semantic/infer/infer_call/infer_require.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/infer_call/infer_require.rs
@@ -1,20 +1,25 @@
-use emmylua_parser::LuaCallExpr;
+use emmylua_parser::{LuaCallExpr, LuaExpr};
 
 use crate::{
     DbIndex, InFiled, InferFailReason, LuaInferCache, LuaType, infer_expr,
     semantic::infer::InferResult,
 };
 
-pub fn infer_require_call(
+pub(super) fn infer_require_call(
     db: &DbIndex,
     cache: &mut LuaInferCache,
     call_expr: LuaCallExpr,
 ) -> InferResult {
     let arg_list = call_expr.get_args_list().ok_or(InferFailReason::None)?;
     let first_arg = arg_list.get_args().next().ok_or(InferFailReason::None)?;
-    let require_path_type = infer_expr(db, cache, first_arg)?;
+    let require_path_type = infer_expr(db, cache, LuaExpr::from(first_arg))?;
     let module_path: String = match &require_path_type {
-        LuaType::StringConst(module_path) => module_path.as_ref().to_string(),
+        LuaType::StringConst(module_path) | LuaType::DocStringConst(module_path) => {
+            module_path.as_ref().to_string()
+        }
+        _ if cache.is_no_flow() => {
+            return Err(InferFailReason::None);
+        }
         _ => {
             return Ok(LuaType::Any);
         }

--- a/crates/emmylua_code_analysis/src/semantic/infer/infer_call/infer_setmetatable.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/infer_call/infer_setmetatable.rs
@@ -6,7 +6,7 @@ use crate::{
     semantic::{infer::InferResult, member::find_members_with_key},
 };
 
-pub fn infer_setmetatable_call(
+pub(super) fn infer_setmetatable_call(
     db: &DbIndex,
     cache: &mut LuaInferCache,
     call_expr: LuaCallExpr,
@@ -22,6 +22,12 @@ pub fn infer_setmetatable_call(
     let metatable = args[1].clone();
 
     let (meta_type, is_index) = infer_metatable_index_type(db, cache, metatable)?;
+    if cache.is_no_flow() && !is_index && !meta_type.is_custom_type() {
+        // No-flow setmetatable inference is only used as a conservative fallback.
+        // If the metatable does not resolve to an actual metatable shape, decline
+        // instead of treating arbitrary static expressions as the result type.
+        return Err(InferFailReason::None);
+    }
     match &basic_table {
         LuaExpr::TableExpr(table_expr) => {
             if table_expr.is_empty() && is_index {

--- a/crates/emmylua_code_analysis/src/semantic/infer/infer_call/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/infer_call/mod.rs
@@ -10,7 +10,7 @@ use super::{
 use crate::{
     CacheEntry, DbIndex, InFiled, LuaFunctionType, LuaGenericType, LuaInstanceType,
     LuaIntersectionType, LuaOperatorMetaMethod, LuaOperatorOwner, LuaSignature, LuaSignatureId,
-    LuaType, LuaTypeDeclId, LuaUnionType, TypeVisitTrait,
+    LuaType, LuaTypeDeclId, LuaUnionType, NoFlowCacheEntry, TypeVisitTrait,
 };
 use crate::{
     InferGuardRef,
@@ -38,18 +38,31 @@ pub fn infer_call_expr_func(
 ) -> InferCallFuncResult {
     let syntax_id = call_expr.get_syntax_id();
     let key = (syntax_id, args_count, call_expr_type.clone());
-    if let Some(cache) = cache.call_cache.get(&key) {
-        match cache {
+    let is_no_flow = cache.is_no_flow();
+    if is_no_flow {
+        if let Some(cache_entry) = cache.call_no_flow_cache.get(&key) {
+            match cache_entry {
+                NoFlowCacheEntry::Cache(ty) => return Ok(ty.clone()),
+                NoFlowCacheEntry::Declined => return Err(InferFailReason::None),
+                NoFlowCacheEntry::Ready => return Err(InferFailReason::RecursiveInfer),
+            }
+        }
+    } else if let Some(cache_entry) = cache.call_cache.get(&key) {
+        match cache_entry {
             CacheEntry::Cache(ty) => return Ok(ty.clone()),
-            _ => return Err(InferFailReason::RecursiveInfer),
+            CacheEntry::Ready => return Err(InferFailReason::RecursiveInfer),
         }
     }
 
-    cache.call_cache.insert(key.clone(), CacheEntry::Ready);
+    if is_no_flow {
+        cache
+            .call_no_flow_cache
+            .insert(key.clone(), NoFlowCacheEntry::Ready);
+    } else {
+        cache.call_cache.insert(key.clone(), CacheEntry::Ready);
+    }
     let result = match &call_expr_type {
-        LuaType::DocFunction(func) => {
-            infer_doc_function(db, cache, func, call_expr.clone(), args_count)
-        }
+        LuaType::DocFunction(func) => infer_doc_function(db, cache, func, call_expr.clone()),
         LuaType::Signature(signature_id) => {
             infer_signature_doc_function(db, cache, *signature_id, call_expr.clone(), args_count)
         }
@@ -143,15 +156,34 @@ pub fn infer_call_expr_func(
 
     match &result {
         Ok(func_ty) => {
+            if is_no_flow {
+                cache
+                    .call_no_flow_cache
+                    .insert(key, NoFlowCacheEntry::Cache(func_ty.clone()));
+            } else {
+                cache
+                    .call_cache
+                    .insert(key, CacheEntry::Cache(func_ty.clone()));
+            }
+        }
+        Err(InferFailReason::None) | Err(InferFailReason::RecursiveInfer) if is_no_flow => {
             cache
-                .call_cache
-                .insert(key, CacheEntry::Cache(func_ty.clone()));
+                .call_no_flow_cache
+                .insert(key, NoFlowCacheEntry::Declined);
         }
         Err(r) if r.is_need_resolve() => {
-            cache.call_cache.remove(&key);
+            if is_no_flow {
+                cache.call_no_flow_cache.remove(&key);
+            } else {
+                cache.call_cache.remove(&key);
+            }
         }
         Err(InferFailReason::None) => {
-            cache.call_cache.remove(&key);
+            if is_no_flow {
+                cache.call_no_flow_cache.remove(&key);
+            } else {
+                cache.call_cache.remove(&key);
+            }
         }
         _ => {}
     }
@@ -181,7 +213,6 @@ fn infer_doc_function(
     cache: &mut LuaInferCache,
     func: &LuaFunctionType,
     call_expr: LuaCallExpr,
-    _: Option<usize>,
 ) -> InferCallFuncResult {
     if func.contain_tpl() {
         let result = instantiate_func_generic(db, cache, func, call_expr)?;
@@ -597,7 +628,7 @@ fn infer_intersection(
     resolve_signature(db, cache, overloads, call_expr, false, args_count)
 }
 
-pub(crate) fn unwrapp_return_type(
+fn unwrapp_return_type(
     db: &DbIndex,
     cache: &mut LuaInferCache,
     return_type: LuaType,
@@ -721,7 +752,8 @@ pub fn infer_call_expr(
     .get_ret()
     .clone();
 
-    if let Some(tree) = db.get_flow_index().get_flow_tree(&cache.get_file_id())
+    if !cache.is_no_flow()
+        && let Some(tree) = db.get_flow_index().get_flow_tree(&cache.get_file_id())
         && let Some(flow_id) = tree.get_flow_id(call_expr.get_syntax_id())
         && let Some(flow_ret_type) =
             get_type_at_call_expr_inline_cast(db, cache, tree, call_expr, flow_id, ret_type.clone())
@@ -780,7 +812,8 @@ fn signature_is_generic(
 #[cfg(test)]
 mod tests {
     use crate::{
-        InferFailReason, InferGuard, LuaType, VirtualWorkspace, semantic::infer_call_expr_func,
+        InferFailReason, InferGuard, LuaType, NoFlowCacheEntry, VirtualWorkspace,
+        semantic::infer_call_expr_func,
     };
 
     #[test]
@@ -840,5 +873,47 @@ mod tests {
 
         assert_eq!(ws.expr_ty("ok"), ws.ty("boolean"));
         assert_eq!(ws.expr_ty("payload"), ws.ty("string"));
+    }
+
+    #[test]
+    fn test_call_cache_no_flow_decline_is_cached() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            ---@overload fun(x: string): string
+            ---@param x integer
+            ---@return integer
+            local function pick(x) end
+
+            local value = pick({})
+            "#,
+        );
+        let call_expr = ws.get_node::<emmylua_parser::LuaCallExpr>(file_id);
+        let semantic_model = ws.analysis.compilation.get_semantic_model(file_id).unwrap();
+        let db = semantic_model.get_db();
+        let mut cache = semantic_model.get_cache().borrow_mut();
+        let prefix_expr = call_expr.get_prefix_expr().unwrap();
+        let call_expr_type = cache
+            .with_no_flow(|cache| crate::infer_expr(db, cache, prefix_expr))
+            .unwrap();
+
+        let result = cache.with_no_flow(|cache| {
+            infer_call_expr_func(
+                db,
+                cache,
+                call_expr,
+                call_expr_type,
+                &InferGuard::new(),
+                None,
+            )
+        });
+
+        assert!(matches!(result, Err(InferFailReason::None)));
+        assert!(
+            cache
+                .call_no_flow_cache
+                .values()
+                .any(|entry| matches!(entry, NoFlowCacheEntry::Declined))
+        );
     }
 }

--- a/crates/emmylua_code_analysis/src/semantic/infer/infer_index/infer_array.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/infer_index/infer_array.rs
@@ -5,10 +5,12 @@ use emmylua_parser::{
 
 use crate::{
     DbIndex, InferFailReason, LuaArrayLen, LuaArrayType, LuaInferCache, LuaType, TypeOps,
-    infer_expr, semantic::infer::narrow::get_var_expr_var_ref_id,
+    semantic::infer::narrow::get_var_expr_var_ref_id,
 };
 
-pub fn infer_array_member(
+use super::infer_expr_for_index;
+
+pub(super) fn infer_array_member(
     db: &DbIndex,
     cache: &mut LuaInferCache,
     array_type: &LuaArrayType,
@@ -52,7 +54,7 @@ pub fn infer_array_member(
             Ok(result_type)
         }
         LuaIndexKey::Expr(expr) => {
-            let expr_type = infer_expr(db, cache, expr.clone())?;
+            let expr_type = infer_expr_for_index(db, cache, expr.clone())?;
             if expr_type.is_integer() {
                 let base_type = array_type.get_base();
                 match (array_type.get_len(), expr_type) {
@@ -93,7 +95,7 @@ pub fn infer_array_member(
     }
 }
 
-pub fn check_iter_var_range(
+pub(super) fn check_iter_var_range(
     db: &DbIndex,
     cache: &mut LuaInferCache,
     may_iter_var: &LuaExpr,
@@ -135,7 +137,7 @@ fn check_index_var_in_range(
             unary_expr
         }
         3 => {
-            let step_type = infer_expr(db, cache, iter_exprs[2].clone()).ok()?;
+            let step_type = infer_expr_for_index(db, cache, iter_exprs[2].clone()).ok()?;
             let LuaType::IntegerConst(step_value) = step_type else {
                 return None;
             };

--- a/crates/emmylua_code_analysis/src/semantic/infer/infer_index/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/infer_index/mod.rs
@@ -31,7 +31,49 @@ use crate::{
     },
 };
 
-use super::{InferFailReason, InferResult, infer_expr, infer_name::infer_global_type};
+use super::{
+    InferFailReason, InferResult, infer_expr, infer_name::infer_global_type, supports_no_flow_expr,
+    try_infer_expr_no_flow,
+};
+
+pub(crate) fn try_infer_expr_for_index(
+    db: &DbIndex,
+    cache: &mut LuaInferCache,
+    expr: LuaExpr,
+) -> Result<Option<LuaType>, InferFailReason> {
+    if cache.is_no_flow() {
+        if !supports_no_flow_index_expr(&expr) {
+            return Ok(None);
+        }
+
+        return match try_infer_expr_no_flow(db, cache, expr) {
+            Ok(result) => Ok(result),
+            Err(err) if err.is_need_resolve() => Ok(None),
+            Err(err) => Err(err),
+        };
+    }
+
+    Ok(Some(infer_expr(db, cache, expr)?))
+}
+
+fn infer_expr_for_index(db: &DbIndex, cache: &mut LuaInferCache, expr: LuaExpr) -> InferResult {
+    let Some(expr_type) = try_infer_expr_for_index(db, cache, expr)? else {
+        return Err(InferFailReason::None);
+    };
+    Ok(expr_type)
+}
+
+fn supports_no_flow_index_expr(expr: &LuaExpr) -> bool {
+    match expr {
+        LuaExpr::ParenExpr(paren_expr) => paren_expr
+            .get_expr()
+            .is_some_and(|expr| supports_no_flow_index_expr(&expr)),
+        _ => {
+            supports_no_flow_expr(expr)
+                && !matches!(expr, LuaExpr::CallExpr(_) | LuaExpr::ClosureExpr(_))
+        }
+    }
+}
 
 pub fn infer_index_expr(
     db: &DbIndex,
@@ -40,56 +82,36 @@ pub fn infer_index_expr(
     pass_flow: bool,
 ) -> InferResult {
     let prefix_expr = index_expr.get_prefix_expr().ok_or(InferFailReason::None)?;
-    let prefix_type = infer_expr(db, cache, prefix_expr)?;
+    let prefix_type = infer_expr_for_index(db, cache, prefix_expr)?;
     let index_member_expr = LuaIndexMemberExpr::IndexExpr(index_expr.clone());
 
-    let reason = match infer_member_by_member_key(
+    let member_type = match infer_member_by_member_key(
         db,
         cache,
         &prefix_type,
         index_member_expr.clone(),
         &InferGuard::new(),
     ) {
-        Ok(member_type) => {
-            if pass_flow {
-                return infer_member_type_pass_flow(
-                    db,
-                    cache,
-                    index_expr,
-                    // &prefix_type,
-                    member_type,
-                );
-            }
-            return Ok(member_type);
-        }
-        Err(InferFailReason::FieldNotFound) => InferFailReason::FieldNotFound,
+        Ok(member_type) => member_type,
+        Err(InferFailReason::FieldNotFound) => match infer_member_by_operator(
+            db,
+            cache,
+            &prefix_type,
+            index_member_expr,
+            &InferGuard::new(),
+        ) {
+            Ok(member_type) => member_type,
+            Err(InferFailReason::FieldNotFound) => return Err(InferFailReason::FieldNotFound),
+            Err(err) => return Err(err),
+        },
         Err(err) => return Err(err),
     };
 
-    match infer_member_by_operator(
-        db,
-        cache,
-        &prefix_type,
-        index_member_expr,
-        &InferGuard::new(),
-    ) {
-        Ok(member_type) => {
-            if pass_flow {
-                return infer_member_type_pass_flow(
-                    db,
-                    cache,
-                    index_expr,
-                    // &prefix_type,
-                    member_type,
-                );
-            }
-            return Ok(member_type);
-        }
-        Err(InferFailReason::FieldNotFound) => {}
-        Err(err) => return Err(err),
+    if pass_flow {
+        infer_member_type_pass_flow(db, cache, index_expr, member_type)
+    } else {
+        Ok(member_type)
     }
-
-    Err(reason)
 }
 
 fn infer_member_type_pass_flow(
@@ -141,6 +163,30 @@ pub fn get_index_expr_var_ref_id(
     }
 
     None
+}
+
+fn infer_index_key_type(
+    db: &DbIndex,
+    cache: &mut LuaInferCache,
+    index_key: &LuaIndexKey,
+) -> Result<Option<LuaType>, InferFailReason> {
+    match index_key {
+        LuaIndexKey::Name(name) => Ok(Some(LuaType::StringConst(
+            SmolStr::new(name.get_name_text()).into(),
+        ))),
+        LuaIndexKey::String(s) => Ok(Some(LuaType::StringConst(
+            SmolStr::new(s.get_value()).into(),
+        ))),
+        LuaIndexKey::Integer(i) => {
+            if let NumberResult::Int(index_value) = i.get_number_value() {
+                Ok(Some(LuaType::IntegerConst(index_value)))
+            } else {
+                Err(InferFailReason::FieldNotFound)
+            }
+        }
+        LuaIndexKey::Idx(i) => Ok(Some(LuaType::IntegerConst(*i as i64))),
+        LuaIndexKey::Expr(expr) => try_infer_expr_for_index(db, cache, expr.clone()),
+    }
 }
 
 pub fn infer_member_by_member_key(
@@ -227,7 +273,7 @@ fn infer_table_member(
 ) -> InferResult {
     let owner = LuaMemberOwner::Element(inst);
     let index_key = index_expr.get_index_key().ok_or(InferFailReason::None)?;
-    let key = LuaMemberKey::from_index_key(db, cache, &index_key)?;
+    let key = LuaMemberKey::from_index_key_with_mode(db, cache, &index_key, cache.is_no_flow())?;
     let member_item = match db.get_member_index().get_member_item(&owner, &key) {
         Some(member_item) => member_item,
         None => return Err(InferFailReason::FieldNotFound),
@@ -270,7 +316,7 @@ fn infer_custom_type_member(
 
     let owner = LuaMemberOwner::Type(prefix_type_id.clone());
     let index_key = index_expr.get_index_key().ok_or(InferFailReason::None)?;
-    let key = LuaMemberKey::from_index_key(db, cache, &index_key)?;
+    let key = LuaMemberKey::from_index_key_with_mode(db, cache, &index_key, cache.is_no_flow())?;
 
     if let Some(member_item) = db.get_member_index().get_member_item(&owner, &key) {
         return member_item.resolve_type(db);
@@ -278,27 +324,9 @@ fn infer_custom_type_member(
 
     // 解决`key`为表达式的情况
     if let LuaIndexKey::Expr(expr) = index_key
-        && let Some(keys) = get_expr_member_key(db, cache, &expr)
+        && let Some(result_type) = infer_expr_key_member_type(db, cache, &expr, &owner)?
     {
-        let mut result_types = Vec::new();
-        for key in keys {
-            // 解决 enum[enum] | class[class] 的情况
-            if let Some(member_type) = get_expr_key_members(db, &key, &owner) {
-                result_types.push(member_type);
-                continue;
-            }
-
-            if let Some(member_item) = db.get_member_index().get_member_item(&owner, &key)
-                && let Ok(member_type) = member_item.resolve_type(db)
-            {
-                result_types.push(member_type);
-            }
-        }
-        match &result_types[..] {
-            [] => {}
-            [first] => return Ok(first.clone()),
-            _ => return Ok(LuaType::from_vec(result_types)),
-        }
+        return Ok(result_type);
     }
 
     if type_decl.is_class()
@@ -353,6 +381,38 @@ fn get_expr_key_members(
         1 => Some(result[0].clone()),
         _ => Some(LuaType::from_vec(result)),
     }
+}
+
+fn infer_expr_key_member_type(
+    db: &DbIndex,
+    cache: &mut LuaInferCache,
+    expr: &LuaExpr,
+    owner: &LuaMemberOwner,
+) -> Result<Option<LuaType>, InferFailReason> {
+    let Some(keys) = get_expr_member_key(db, cache, expr)? else {
+        return Ok(None);
+    };
+
+    let mut result_types = Vec::new();
+    for key in keys {
+        // 解决 enum[enum] | class[class] 的情况
+        if let Some(member_type) = get_expr_key_members(db, &key, owner) {
+            result_types.push(member_type);
+            continue;
+        }
+
+        if let Some(member_item) = db.get_member_index().get_member_item(owner, &key)
+            && let Ok(member_type) = member_item.resolve_type(db)
+        {
+            result_types.push(member_type);
+        }
+    }
+
+    Ok(match &result_types[..] {
+        [] => None,
+        [first] => Some(first.clone()),
+        _ => Some(LuaType::from_vec(result_types)),
+    })
 }
 
 fn get_all_member_key(db: &DbIndex, origin_type: &LuaType) -> Option<Vec<LuaMemberKey>> {
@@ -432,7 +492,7 @@ fn infer_tuple_member(
     index_expr: LuaIndexMemberExpr,
 ) -> InferResult {
     let index_key = index_expr.get_index_key().ok_or(InferFailReason::None)?;
-    let key = LuaMemberKey::from_index_key(db, cache, &index_key)?;
+    let key = LuaMemberKey::from_index_key_with_mode(db, cache, &index_key, cache.is_no_flow())?;
     match &key {
         LuaMemberKey::Integer(i) => {
             let index = if *i > 0 { *i - 1 } else { 0 };
@@ -465,7 +525,7 @@ fn infer_tuple_member(
                     LuaIndexKey::Expr(expr) => expr,
                     _ => return Ok(result),
                 };
-                if check_iter_var_range(db, cache, &maybe_iter_var, index_prefix_expr)
+                if check_iter_var_range(db, cache, maybe_iter_var, index_prefix_expr)
                     .unwrap_or(false)
                 {
                     return Ok(result);
@@ -489,7 +549,8 @@ fn infer_object_member(
     index_expr: LuaIndexMemberExpr,
 ) -> InferResult {
     let index_key = index_expr.get_index_key().ok_or(InferFailReason::None)?;
-    let member_key = LuaMemberKey::from_index_key(db, cache, &index_key)?;
+    let member_key =
+        LuaMemberKey::from_index_key_with_mode(db, cache, &index_key, cache.is_no_flow())?;
     if let Some(member_type) = object_type.get_field(&member_key) {
         return Ok(member_type.clone());
     }
@@ -519,18 +580,8 @@ fn infer_index_metamethod(
     key_type: &LuaType,
     value_type: &LuaType,
 ) -> InferResult {
-    let access_key_type = match &index_key {
-        LuaIndexKey::Name(name) => LuaType::StringConst(SmolStr::new(name.get_name_text()).into()),
-        LuaIndexKey::String(s) => LuaType::StringConst(SmolStr::new(s.get_value()).into()),
-        LuaIndexKey::Integer(i) => {
-            if let NumberResult::Int(index_value) = i.get_number_value() {
-                LuaType::IntegerConst(index_value)
-            } else {
-                return Err(InferFailReason::FieldNotFound);
-            }
-        }
-        LuaIndexKey::Idx(i) => LuaType::IntegerConst(*i as i64),
-        LuaIndexKey::Expr(expr) => infer_expr(db, cache, expr.clone())?,
+    let Some(access_key_type) = infer_index_key_type(db, cache, index_key)? else {
+        return Err(InferFailReason::None);
     };
 
     if check_type_compact(db, key_type, &access_key_type).is_ok() {
@@ -817,11 +868,19 @@ fn infer_member_by_index_table(
         }
         None => {
             let index_key = index_expr.get_index_key().ok_or(InferFailReason::None)?;
-            if let LuaIndexKey::Expr(expr) = index_key {
-                let key_type = infer_expr(db, cache, expr.clone())?;
-                let members = db
-                    .get_member_index()
-                    .get_members(&LuaMemberOwner::Element(table_range.clone()));
+            let owner = LuaMemberOwner::Element(table_range.clone());
+            if let LuaIndexKey::Expr(expr) = &index_key
+                && let Some(result_type) = infer_expr_key_member_type(db, cache, expr, &owner)?
+            {
+                return Ok(result_type);
+            }
+
+            if matches!(index_key, LuaIndexKey::Expr(_)) {
+                let Some(key_type) = infer_index_key_type(db, cache, &index_key)? else {
+                    return Err(InferFailReason::None);
+                };
+
+                let members = db.get_member_index().get_members(&owner);
                 if let Some(mut members) = members {
                     members.sort_by(|a, b| a.get_key().cmp(b.get_key()));
                     let mut result_type = LuaType::Never;
@@ -936,7 +995,7 @@ fn infer_member_by_index_array(
         return Ok(expression_type);
     } else if member_key.is_expr() {
         let expr = member_key.get_expr().ok_or(InferFailReason::None)?;
-        let expr_type = infer_expr(db, cache, expr.clone())?;
+        let expr_type = infer_expr_for_index(db, cache, expr.clone())?;
         if check_type_compact(db, &LuaType::Number, &expr_type).is_ok() {
             return Ok(expression_type);
         }
@@ -955,7 +1014,7 @@ fn infer_member_by_index_object(
     let access_member_type = object.get_index_access();
     if member_key.is_expr() {
         let expr = member_key.get_expr().ok_or(InferFailReason::None)?;
-        let expr_type = infer_expr(db, cache, expr.clone())?;
+        let expr_type = infer_expr_for_index(db, cache, expr.clone())?;
         for (key, field) in access_member_type {
             if type_check::check_type_compact(db, key, &expr_type).is_ok() {
                 return Ok(field.clone());
@@ -1145,7 +1204,8 @@ fn infer_namespace_member(
     index_expr: LuaIndexMemberExpr,
 ) -> InferResult {
     let index_key = index_expr.get_index_key().ok_or(InferFailReason::None)?;
-    let member_key = LuaMemberKey::from_index_key(db, cache, &index_key)?;
+    let member_key =
+        LuaMemberKey::from_index_key_with_mode(db, cache, &index_key, cache.is_no_flow())?;
     let member_key = match member_key {
         LuaMemberKey::Name(name) => name.to_string(),
         LuaMemberKey::Integer(i) => i.to_string(),
@@ -1167,8 +1227,10 @@ fn get_expr_member_key(
     db: &DbIndex,
     cache: &mut LuaInferCache,
     expr: &LuaExpr,
-) -> Option<Vec<LuaMemberKey>> {
-    let expr_type = infer_expr(db, cache, expr.clone()).ok()?;
+) -> Result<Option<Vec<LuaMemberKey>>, InferFailReason> {
+    let Some(expr_type) = try_infer_expr_for_index(db, cache, expr.clone())? else {
+        return Ok(None);
+    };
     let mut keys: HashSet<LuaMemberKey> = HashSet::new();
     let mut stack = vec![expr_type.clone()];
     let mut visited = HashSet::new();
@@ -1233,7 +1295,7 @@ fn get_expr_member_key(
     // 转换为 Vec 并排序以确保顺序确定性
     let mut keys: Vec<_> = keys.into_iter().collect();
     keys.sort();
-    Some(keys)
+    Ok(Some(keys))
 }
 
 fn infer_tpl_ref_member(

--- a/crates/emmylua_code_analysis/src/semantic/infer/infer_name.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/infer_name.rs
@@ -7,7 +7,7 @@ use crate::{
     db_index::{DbIndex, LuaDeclOrMemberId},
     infer_node_semantic_decl,
     semantic::{
-        infer::narrow::{VarRefId, infer_expr_narrow_type},
+        infer::narrow::{VarRefId, get_var_ref_type, infer_expr_narrow_type},
         semantic_info::resolve_global_decl_id,
     },
 };
@@ -33,7 +33,7 @@ pub fn infer_name_expr(
         .ok_or(InferFailReason::None)?;
     let decl_id = file_ref.get_decl_id(&range);
     if let Some(decl_id) = decl_id {
-        infer_expr_narrow_type(
+        infer_var_ref_type(
             db,
             cache,
             LuaExpr::NameExpr(name_expr),
@@ -47,13 +47,25 @@ pub fn infer_name_expr(
 fn infer_self(db: &DbIndex, cache: &mut LuaInferCache, name_expr: LuaNameExpr) -> InferResult {
     let decl_or_member_id =
         find_self_decl_or_member_id(db, cache, &name_expr).ok_or(InferFailReason::None)?;
-    // LuaDeclOrMemberId::Member(member_id) => find_decl_member_type(db, member_id),
-    infer_expr_narrow_type(
+    infer_var_ref_type(
         db,
         cache,
         LuaExpr::NameExpr(name_expr),
         VarRefId::SelfRef(decl_or_member_id),
     )
+}
+
+fn infer_var_ref_type(
+    db: &DbIndex,
+    cache: &mut LuaInferCache,
+    expr: LuaExpr,
+    var_ref_id: VarRefId,
+) -> InferResult {
+    if cache.is_no_flow() {
+        get_var_ref_type(db, cache, &var_ref_id)
+    } else {
+        infer_expr_narrow_type(db, cache, expr, var_ref_id)
+    }
 }
 
 pub fn get_name_expr_var_ref_id(

--- a/crates/emmylua_code_analysis/src/semantic/infer/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/mod.rs
@@ -13,7 +13,7 @@ use std::ops::Deref;
 
 use emmylua_parser::{
     LuaAst, LuaAstNode, LuaCallExpr, LuaClosureExpr, LuaExpr, LuaLiteralExpr, LuaLiteralToken,
-    LuaTableExpr, LuaVarExpr, NumberResult,
+    LuaSyntaxId, LuaTableExpr, LuaVarExpr, NumberResult,
 };
 use infer_binary::infer_binary_expr;
 use infer_call::infer_call_expr;
@@ -21,6 +21,7 @@ pub use infer_call::infer_call_expr_func;
 pub use infer_doc_type::{DocTypeInferContext, infer_doc_type};
 pub use infer_fail_reason::InferFailReason;
 pub use infer_index::infer_index_expr;
+pub(crate) use infer_index::try_infer_expr_for_index;
 use infer_name::infer_name_expr;
 pub use infer_name::{find_self_decl_or_member_id, infer_param};
 use infer_table::infer_table_expr;
@@ -37,35 +38,93 @@ use crate::{
     db_index::{DbIndex, LuaOperator, LuaOperatorMetaMethod, LuaSignatureId, LuaType},
 };
 
-use super::{CacheEntry, LuaInferCache, member::infer_raw_member_type};
+use super::{CacheEntry, LuaInferCache, NoFlowCacheEntry, member::infer_raw_member_type};
 
 pub type InferResult = Result<LuaType, InferFailReason>;
 pub use infer_call::InferCallFuncResult;
 
-pub fn infer_expr(db: &DbIndex, cache: &mut LuaInferCache, expr: LuaExpr) -> InferResult {
-    let syntax_id = expr.get_syntax_id();
-    let key = syntax_id;
-    if let Some(cache) = cache.expr_cache.get(&key) {
-        match cache {
-            CacheEntry::Cache(ty) => return Ok(ty.clone()),
-            _ => return Err(InferFailReason::RecursiveInfer),
+fn prepare_expr_cache(
+    db: &DbIndex,
+    cache: &mut LuaInferCache,
+    syntax_id: LuaSyntaxId,
+) -> Result<Option<LuaType>, InferFailReason> {
+    let file_id = cache.get_file_id();
+    if cache.is_no_flow() {
+        if let Some(cache_entry) = cache.expr_no_flow_cache.get(&syntax_id) {
+            match cache_entry {
+                NoFlowCacheEntry::Cache(ty) => return Ok(Some(ty.clone())),
+                NoFlowCacheEntry::Declined => return Err(InferFailReason::None),
+                NoFlowCacheEntry::Ready => return Err(InferFailReason::RecursiveInfer),
+            }
+        }
+
+        let in_filed_syntax_id = InFiled::new(file_id, syntax_id);
+        if let Some(bind_type_cache) = db
+            .get_type_index()
+            .get_type_cache(&in_filed_syntax_id.into())
+        {
+            let ty = bind_type_cache.as_type().clone();
+            cache
+                .expr_no_flow_cache
+                .insert(syntax_id, NoFlowCacheEntry::Cache(ty.clone()));
+            return Ok(Some(ty));
+        }
+
+        cache
+            .expr_no_flow_cache
+            .insert(syntax_id, NoFlowCacheEntry::Ready);
+        return Ok(None);
+    }
+
+    if let Some(cache_entry) = cache.expr_cache.get(&syntax_id) {
+        match cache_entry {
+            CacheEntry::Cache(ty) => return Ok(Some(ty.clone())),
+            CacheEntry::Ready => return Err(InferFailReason::RecursiveInfer),
         }
     }
 
-    // for @as
-    let file_id = cache.get_file_id();
     let in_filed_syntax_id = InFiled::new(file_id, syntax_id);
     if let Some(bind_type_cache) = db
         .get_type_index()
         .get_type_cache(&in_filed_syntax_id.into())
     {
+        let ty = bind_type_cache.as_type().clone();
         cache
             .expr_cache
-            .insert(key, CacheEntry::Cache(bind_type_cache.as_type().clone()));
-        return Ok(bind_type_cache.as_type().clone());
+            .insert(syntax_id, CacheEntry::Cache(ty.clone()));
+        return Ok(Some(ty));
     }
 
-    cache.expr_cache.insert(key, CacheEntry::Ready);
+    cache.expr_cache.insert(syntax_id, CacheEntry::Ready);
+    Ok(None)
+}
+
+pub(in crate::semantic) fn supports_no_flow_expr(expr: &LuaExpr) -> bool {
+    matches!(
+        expr,
+        LuaExpr::CallExpr(_)
+            | LuaExpr::BinaryExpr(_)
+            | LuaExpr::LiteralExpr(_)
+            | LuaExpr::ClosureExpr(_)
+            | LuaExpr::ParenExpr(_)
+            | LuaExpr::NameExpr(_)
+            | LuaExpr::UnaryExpr(_)
+            | LuaExpr::IndexExpr(_)
+    )
+}
+
+pub fn infer_expr(db: &DbIndex, cache: &mut LuaInferCache, expr: LuaExpr) -> InferResult {
+    let no_flow = cache.is_no_flow();
+    let syntax_id = expr.get_syntax_id();
+    if let Some(result_type) = prepare_expr_cache(db, cache, syntax_id)? {
+        return Ok(result_type);
+    }
+    if no_flow && !supports_no_flow_expr(&expr) {
+        cache
+            .expr_no_flow_cache
+            .insert(syntax_id, NoFlowCacheEntry::Declined);
+        return Err(InferFailReason::None);
+    }
     let result_type = match expr {
         LuaExpr::CallExpr(call_expr) => infer_call_expr(db, cache, call_expr),
         LuaExpr::TableExpr(table_expr) => infer_table_expr(db, cache, table_expr),
@@ -79,37 +138,67 @@ pub fn infer_expr(db: &DbIndex, cache: &mut LuaInferCache, expr: LuaExpr) -> Inf
             paren_expr.get_expr().ok_or(InferFailReason::None)?,
         ),
         LuaExpr::NameExpr(name_expr) => infer_name_expr(db, cache, name_expr),
-        LuaExpr::IndexExpr(index_expr) => infer_index_expr(db, cache, index_expr, true),
+        LuaExpr::IndexExpr(index_expr) => infer_index_expr(db, cache, index_expr, !no_flow),
     };
 
     match &result_type {
         Ok(result_type) => {
-            cache
-                .expr_cache
-                .insert(key, CacheEntry::Cache(result_type.clone()));
-        }
-        Err(InferFailReason::None) | Err(InferFailReason::RecursiveInfer) => {
-            cache
-                .expr_cache
-                .insert(key, CacheEntry::Cache(LuaType::Unknown));
-            return Ok(LuaType::Unknown);
-        }
-        Err(InferFailReason::FieldNotFound) => {
-            if cache.get_config().analysis_phase.is_force() {
+            if no_flow {
+                cache
+                    .expr_no_flow_cache
+                    .insert(syntax_id, NoFlowCacheEntry::Cache(result_type.clone()));
+            } else {
                 cache
                     .expr_cache
-                    .insert(key, CacheEntry::Cache(LuaType::Nil));
+                    .insert(syntax_id, CacheEntry::Cache(result_type.clone()));
+            }
+        }
+        Err(InferFailReason::None) | Err(InferFailReason::RecursiveInfer) => {
+            if no_flow {
+                cache
+                    .expr_no_flow_cache
+                    .insert(syntax_id, NoFlowCacheEntry::Declined);
+            } else {
+                cache
+                    .expr_cache
+                    .insert(syntax_id, CacheEntry::Cache(LuaType::Unknown));
+                return Ok(LuaType::Unknown);
+            }
+        }
+        Err(InferFailReason::FieldNotFound) => {
+            if no_flow {
+                cache.expr_no_flow_cache.remove(&syntax_id);
+            } else if cache.get_config().analysis_phase.is_force() {
+                cache
+                    .expr_cache
+                    .insert(syntax_id, CacheEntry::Cache(LuaType::Nil));
                 return Ok(LuaType::Nil);
             } else {
-                cache.expr_cache.remove(&key);
+                cache.expr_cache.remove(&syntax_id);
             }
         }
         _ => {
-            cache.expr_cache.remove(&key);
+            if no_flow {
+                cache.expr_no_flow_cache.remove(&syntax_id);
+            } else {
+                cache.expr_cache.remove(&syntax_id);
+            }
         }
     }
 
     result_type
+}
+
+pub(in crate::semantic) fn try_infer_expr_no_flow(
+    db: &DbIndex,
+    cache: &mut LuaInferCache,
+    expr: LuaExpr,
+) -> Result<Option<LuaType>, InferFailReason> {
+    match cache.with_no_flow(|cache| infer_expr(db, cache, expr)) {
+        Ok(result_type) => Ok(Some(result_type)),
+        Err(InferFailReason::None) | Err(InferFailReason::RecursiveInfer) => Ok(None),
+        Err(err) => Err(err),
+    }
 }
 
 fn infer_literal_expr(db: &DbIndex, config: &LuaInferCache, expr: LuaLiteralExpr) -> InferResult {

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/binary_flow.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/binary_flow.rs
@@ -4,7 +4,7 @@ use emmylua_parser::{
 };
 
 use crate::{
-    DbIndex, FlowNode, FlowTree, InferFailReason, LuaInferCache, LuaType, TypeOps, infer_expr,
+    DbIndex, FlowNode, FlowTree, InferFailReason, LuaInferCache, LuaType, TypeOps,
     semantic::infer::{
         VarRefId,
         narrow::{
@@ -13,9 +13,10 @@ use crate::{
                 InferConditionFlow, PendingConditionNarrow, always_literal_equal,
                 call_flow::get_type_at_call_expr,
             },
-            get_single_antecedent, get_var_ref_type,
+            get_single_antecedent, get_var_ref_type, infer_expr_at_antecedent_flow,
             var_ref_id::get_var_expr_var_ref_id,
         },
+        try_infer_expr_no_flow,
     },
 };
 
@@ -66,7 +67,9 @@ pub fn get_type_at_binary_expr(
         ),
         BinaryOperator::OpGt => try_get_at_gt_or_ge_expr(
             db,
+            tree,
             cache,
+            root,
             var_ref_id,
             flow_node,
             left_expr,
@@ -76,7 +79,9 @@ pub fn get_type_at_binary_expr(
         ),
         BinaryOperator::OpGe => try_get_at_gt_or_ge_expr(
             db,
+            tree,
             cache,
+            root,
             var_ref_id,
             flow_node,
             left_expr,
@@ -142,6 +147,7 @@ fn try_get_at_eq_or_neq_expr(
         db,
         tree,
         cache,
+        root,
         var_ref_id,
         flow_node,
         left_expr,
@@ -153,7 +159,9 @@ fn try_get_at_eq_or_neq_expr(
 #[allow(clippy::too_many_arguments)]
 fn try_get_at_gt_or_ge_expr(
     db: &DbIndex,
+    tree: &FlowTree,
     cache: &mut LuaInferCache,
+    root: &LuaChunk,
     var_ref_id: &VarRefId,
     flow_node: &FlowNode,
     left_expr: LuaExpr,
@@ -185,7 +193,11 @@ fn try_get_at_gt_or_ge_expr(
                 return Ok(ConditionFlowAction::Continue);
             }
 
-            let right_expr_type = infer_expr(db, cache, right_expr)?;
+            let Some(right_expr_type) =
+                infer_expr_at_antecedent_flow(db, tree, cache, root, flow_node, right_expr)?
+            else {
+                return Ok(ConditionFlowAction::Continue);
+            };
             let antecedent_flow_id = get_single_antecedent(flow_node)?;
             Ok(ConditionFlowAction::NeedSubquery(
                 ConditionSubquery::ArrayLen {
@@ -358,6 +370,7 @@ fn get_var_eq_condition_action(
     db: &DbIndex,
     tree: &FlowTree,
     cache: &mut LuaInferCache,
+    root: &LuaChunk,
     var_ref_id: &VarRefId,
     flow_node: &FlowNode,
     left_expr: LuaExpr,
@@ -386,7 +399,11 @@ fn get_var_eq_condition_action(
                     return Ok(ConditionFlowAction::Continue);
                 }
                 let antecedent_flow_id = get_single_antecedent(flow_node)?;
-                let right_expr_type = infer_expr(db, cache, right_expr)?;
+                let Some(right_expr_type) =
+                    infer_expr_at_antecedent_flow(db, tree, cache, root, flow_node, right_expr)?
+                else {
+                    return Ok(ConditionFlowAction::Continue);
+                };
                 return Ok(ConditionFlowAction::NeedSubquery(
                     ConditionSubquery::Correlated {
                         var_ref_id: maybe_ref_id,
@@ -403,7 +420,11 @@ fn get_var_eq_condition_action(
                 ));
             }
 
-            let right_expr_type = infer_expr(db, cache, right_expr)?;
+            let Some(right_expr_type) =
+                infer_expr_at_antecedent_flow(db, tree, cache, root, flow_node, right_expr)?
+            else {
+                return Ok(ConditionFlowAction::Continue);
+            };
             let result_type = match condition_flow {
                 InferConditionFlow::TrueCondition => {
                     // self 是特殊的, 我们删除其 nil 类型
@@ -442,7 +463,16 @@ fn get_var_eq_condition_action(
                             }
                         };
 
-                        return get_type_at_call_expr(db, cache, var_ref_id, left_call_expr, flow);
+                        return get_type_at_call_expr(
+                            db,
+                            tree,
+                            cache,
+                            root,
+                            var_ref_id,
+                            flow_node,
+                            left_call_expr,
+                            flow,
+                        );
                     }
                     _ => return Ok(ConditionFlowAction::Continue),
                 }
@@ -462,7 +492,11 @@ fn get_var_eq_condition_action(
                 return Ok(ConditionFlowAction::Continue);
             }
 
-            let right_expr_type = infer_expr(db, cache, right_expr)?;
+            let Some(right_expr_type) =
+                infer_expr_at_antecedent_flow(db, tree, cache, root, flow_node, right_expr)?
+            else {
+                return Ok(ConditionFlowAction::Continue);
+            };
             if matches!(condition_flow, InferConditionFlow::FalseCondition) {
                 return Ok(ConditionFlowAction::Pending(PendingConditionNarrow::Eq {
                     right_expr_type,
@@ -495,7 +529,11 @@ fn get_var_eq_condition_action(
                 return Ok(ConditionFlowAction::Continue);
             }
 
-            let right_expr_type = infer_expr(db, cache, right_expr)?;
+            let Some(right_expr_type) =
+                infer_expr_at_antecedent_flow(db, tree, cache, root, flow_node, right_expr)?
+            else {
+                return Ok(ConditionFlowAction::Continue);
+            };
             let antecedent_flow_id = get_single_antecedent(flow_node)?;
             Ok(ConditionFlowAction::NeedSubquery(
                 ConditionSubquery::ArrayLen {
@@ -565,7 +603,10 @@ fn maybe_field_literal_eq_action(
     cache
         .narrow_by_literal_stop_position_cache
         .insert(syntax_id);
-    let right_type = infer_expr(db, cache, LuaExpr::LiteralExpr(literal_expr))?;
+    let Some(right_type) = try_infer_expr_no_flow(db, cache, LuaExpr::LiteralExpr(literal_expr))?
+    else {
+        return Ok(None);
+    };
     Ok(Some(ConditionFlowAction::NeedSubquery(
         ConditionSubquery::FieldLiteralEq {
             var_ref_id: var_ref_id.clone(),

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/call_flow.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/call_flow.rs
@@ -1,25 +1,30 @@
 use std::{ops::Deref, sync::Arc};
 
-use emmylua_parser::{LuaCallExpr, LuaExpr, LuaIndexMemberExpr};
+use emmylua_parser::{LuaCallExpr, LuaChunk, LuaExpr, LuaIndexMemberExpr};
 
 use crate::{
-    DbIndex, InferFailReason, InferGuard, LuaAliasCallKind, LuaAliasCallType, LuaFunctionType,
-    LuaInferCache, LuaSignatureId, LuaType, infer_call_expr_func, infer_expr,
+    DbIndex, FlowNode, FlowTree, InferFailReason, InferGuard, LuaAliasCallKind, LuaAliasCallType,
+    LuaFunctionType, LuaInferCache, LuaSignatureId, LuaType,
     semantic::infer::{
         VarRefId,
         infer_index::infer_member_by_member_key,
         narrow::{
             condition_flow::{ConditionFlowAction, InferConditionFlow, PendingConditionNarrow},
-            get_var_ref_type, narrow_false_or_nil, remove_false_or_nil,
+            get_var_ref_type, infer_expr_at_antecedent_flow, narrow_false_or_nil,
+            remove_false_or_nil,
             var_ref_id::get_var_expr_var_ref_id,
         },
     },
+    semantic::instantiate_func_generic,
 };
 
 pub fn get_type_at_call_expr(
     db: &DbIndex,
+    tree: &FlowTree,
     cache: &mut LuaInferCache,
+    root: &LuaChunk,
     var_ref_id: &VarRefId,
+    flow_node: &FlowNode,
     call_expr: LuaCallExpr,
     condition_flow: InferConditionFlow,
 ) -> Result<ConditionFlowAction, InferFailReason> {
@@ -27,43 +32,41 @@ pub fn get_type_at_call_expr(
         return Ok(ConditionFlowAction::Continue);
     };
 
-    let maybe_func = if call_expr.is_colon_call() {
-        match &prefix_expr {
-            LuaExpr::IndexExpr(index_expr) => {
-                if let Some(self_expr) = index_expr.get_prefix_expr()
-                    && let Some(self_var_ref_id) = get_var_expr_var_ref_id(db, cache, self_expr)
-                    && self_var_ref_id == *var_ref_id
-                {
-                    let self_type = get_var_ref_type(db, cache, var_ref_id)?;
-                    let member_type = infer_member_by_member_key(
-                        db,
-                        cache,
-                        &self_type,
-                        LuaIndexMemberExpr::IndexExpr(index_expr.clone()),
-                        &InferGuard::new(),
-                    )?;
+    let maybe_func = if call_expr.is_colon_call()
+        && let LuaExpr::IndexExpr(index_expr) = &prefix_expr
+        && let Some(self_expr) = index_expr.get_prefix_expr()
+        && let Some(self_var_ref_id) = get_var_expr_var_ref_id(db, cache, self_expr)
+        && self_var_ref_id == *var_ref_id
+    {
+        let self_type = get_var_ref_type(db, cache, var_ref_id)?;
+        let member_type = infer_member_by_member_key(
+            db,
+            cache,
+            &self_type,
+            LuaIndexMemberExpr::IndexExpr(index_expr.clone()),
+            &InferGuard::new(),
+        )?;
 
-                    if needs_antecedent_same_var_colon_lookup(&member_type) {
-                        // Keep the dedicated pending case here: replay needs the antecedent type
-                        // for member lookup itself, not just for applying a cast after lookup.
-                        return Ok(ConditionFlowAction::Pending(
-                            PendingConditionNarrow::SameVarColonCall {
-                                idx: LuaIndexMemberExpr::IndexExpr(index_expr.clone()),
-                                condition_flow,
-                            },
-                        ));
-                    } else {
-                        member_type
-                    }
-                } else {
-                    infer_expr(db, cache, prefix_expr.clone())?
-                }
-            }
-            _ => infer_expr(db, cache, prefix_expr.clone())?,
+        if needs_antecedent_same_var_colon_lookup(&member_type) {
+            // Keep the dedicated pending case here: replay needs the antecedent type
+            // for member lookup itself, not just for applying a cast after lookup.
+            return Ok(ConditionFlowAction::Pending(
+                PendingConditionNarrow::SameVarColonCall {
+                    idx: LuaIndexMemberExpr::IndexExpr(index_expr.clone()),
+                    condition_flow,
+                },
+            ));
         }
+        member_type
     } else {
-        infer_expr(db, cache, prefix_expr.clone())?
+        let Some(maybe_func) =
+            infer_expr_at_antecedent_flow(db, tree, cache, root, flow_node, prefix_expr.clone())?
+        else {
+            return Ok(ConditionFlowAction::Continue);
+        };
+        maybe_func
     };
+
     match maybe_func {
         LuaType::DocFunction(f) => {
             let return_type = f.get_ret();
@@ -176,16 +179,11 @@ fn get_type_guard_call_info(
 
     let mut return_type = func_type.get_ret().clone();
     if return_type.contain_tpl() {
-        let call_expr_type = LuaType::DocFunction(func_type);
-        let inst_func = infer_call_expr_func(
-            db,
-            cache,
-            call_expr,
-            call_expr_type,
-            &InferGuard::new(),
-            None,
-        )?;
-
+        let Ok(inst_func) = cache.with_no_flow(|cache| {
+            instantiate_func_generic(db, cache, func_type.as_ref(), call_expr)
+        }) else {
+            return Ok(None);
+        };
         return_type = inst_func.get_ret().clone();
     }
 
@@ -331,7 +329,7 @@ fn get_type_at_call_expr_by_call(
     }
 
     if alias_call_type.get_call_kind() == LuaAliasCallKind::RawGet {
-        let antecedent_type = infer_expr(db, cache, LuaExpr::CallExpr(call_expr))?;
+        let antecedent_type = get_var_ref_type(db, cache, var_ref_id)?;
         let result_type = match condition_flow {
             InferConditionFlow::FalseCondition => narrow_false_or_nil(db, antecedent_type),
             InferConditionFlow::TrueCondition => remove_false_or_nil(antecedent_type),

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/correlated_flow.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/correlated_flow.rs
@@ -4,8 +4,14 @@ use emmylua_parser::{LuaAstPtr, LuaCallExpr, LuaChunk};
 
 use crate::{
     DbIndex, FlowId, FlowTree, InferFailReason, LuaDeclId, LuaFunctionType, LuaInferCache,
-    LuaSignature, LuaType, TypeOps, infer_expr, instantiate_func_generic,
-    semantic::infer::{InferResult, VarRefId, narrow::narrow_down_type},
+    LuaSignature, LuaType, TypeOps,
+    semantic::{
+        infer::{
+            InferResult, VarRefId,
+            narrow::{infer_expr_at_expr_flow, narrow_down_type},
+        },
+        instantiate_func_generic,
+    },
 };
 
 use super::{ConditionFlowAction, PendingConditionNarrow};
@@ -222,6 +228,7 @@ fn prepare_search_root_correlated_types(
         has_opaque_target_origin,
     } = collect_matching_correlated_types(
         db,
+        tree,
         cache,
         root,
         &discriminant_refs,
@@ -451,6 +458,7 @@ fn correlated_type_contains(db: &DbIndex, container: &LuaType, target: &LuaType)
 #[allow(clippy::too_many_arguments)]
 fn collect_matching_correlated_types(
     db: &DbIndex,
+    tree: &FlowTree,
     cache: &mut LuaInferCache,
     root: &LuaChunk,
     discriminant_refs: &[crate::DeclMultiReturnRef],
@@ -465,7 +473,7 @@ fn collect_matching_correlated_types(
 
     for discriminant_ref in discriminant_refs {
         let Some((call_expr, signature)) =
-            infer_signature_for_call_ptr(db, cache, root, &discriminant_ref.call_expr)?
+            infer_signature_for_call_ptr(db, tree, cache, root, &discriminant_ref.call_expr)?
         else {
             continue;
         };
@@ -510,7 +518,7 @@ fn collect_matching_correlated_types(
         }
 
         let Some((call_expr, signature)) =
-            infer_signature_for_call_ptr(db, cache, root, &target_ref.call_expr)?
+            infer_signature_for_call_ptr(db, tree, cache, root, &target_ref.call_expr)?
         else {
             has_opaque_target_origin = true;
             continue;
@@ -537,6 +545,7 @@ fn collect_matching_correlated_types(
 
 fn infer_signature_for_call_ptr<'a>(
     db: &'a DbIndex,
+    tree: &FlowTree,
     cache: &mut LuaInferCache,
     root: &LuaChunk,
     call_expr_ptr: &LuaAstPtr<LuaCallExpr>,
@@ -547,8 +556,8 @@ fn infer_signature_for_call_ptr<'a>(
     let Some(prefix_expr) = call_expr.get_prefix_expr() else {
         return Ok(None);
     };
-    let signature_id = match infer_expr(db, cache, prefix_expr)? {
-        LuaType::Signature(signature_id) => signature_id,
+    let signature_id = match infer_expr_at_expr_flow(db, tree, cache, root, prefix_expr)? {
+        Some(LuaType::Signature(signature_id)) => signature_id,
         _ => return Ok(None),
     };
     let Some(signature) = db.get_signature_index().get(&signature_id) else {
@@ -564,23 +573,28 @@ fn instantiate_return_rows(
     call_expr: LuaCallExpr,
     signature: &LuaSignature,
 ) -> Vec<Vec<LuaType>> {
+    let mut instantiate_return_type = |return_type: LuaType| {
+        if !return_type.contain_tpl() {
+            return return_type;
+        }
+
+        let func = LuaFunctionType::new(
+            signature.async_state,
+            signature.is_colon_define,
+            signature.is_vararg,
+            signature.get_type_params(),
+            return_type.clone(),
+        );
+        match cache
+            .with_no_flow(|cache| instantiate_func_generic(db, cache, &func, call_expr.clone()))
+        {
+            Ok(instantiated) => instantiated.get_ret().clone(),
+            Err(_) => return_type,
+        }
+    };
+
     if signature.return_overloads.is_empty() {
-        let return_type = signature.get_return_type();
-        let instantiated_return_type = if return_type.contain_tpl() {
-            let func = LuaFunctionType::new(
-                signature.async_state,
-                signature.is_colon_define,
-                signature.is_vararg,
-                signature.get_type_params(),
-                return_type.clone(),
-            );
-            match instantiate_func_generic(db, cache, &func, call_expr) {
-                Ok(instantiated) => instantiated.get_ret().clone(),
-                Err(_) => return_type,
-            }
-        } else {
-            return_type
-        };
+        let instantiated_return_type = instantiate_return_type(signature.get_return_type());
         return vec![LuaSignature::return_type_to_row(instantiated_return_type)];
     }
 
@@ -588,22 +602,7 @@ fn instantiate_return_rows(
     for overload in &signature.return_overloads {
         let type_refs = &overload.type_refs;
         let overload_return_type = LuaSignature::row_to_return_type(type_refs.to_vec());
-        let instantiated_return_type = if overload_return_type.contain_tpl() {
-            let overload_func = LuaFunctionType::new(
-                signature.async_state,
-                signature.is_colon_define,
-                signature.is_vararg,
-                signature.get_type_params(),
-                overload_return_type.clone(),
-            );
-            match instantiate_func_generic(db, cache, &overload_func, call_expr.clone()) {
-                Ok(instantiated) => instantiated.get_ret().clone(),
-                Err(_) => overload_return_type,
-            }
-        } else {
-            overload_return_type
-        };
-
+        let instantiated_return_type = instantiate_return_type(overload_return_type);
         rows.push(LuaSignature::return_type_to_row(instantiated_return_type));
     }
 

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/mod.rs
@@ -360,7 +360,16 @@ pub(super) fn get_type_at_condition_flow(
                 continue;
             }
             LuaExpr::CallExpr(call_expr) => {
-                return get_type_at_call_expr(db, cache, var_ref_id, call_expr, condition_flow);
+                return get_type_at_call_expr(
+                    db,
+                    tree,
+                    cache,
+                    root,
+                    var_ref_id,
+                    flow_node,
+                    call_expr,
+                    condition_flow,
+                );
             }
             LuaExpr::IndexExpr(index_expr) => {
                 return get_type_at_index_expr(db, cache, var_ref_id, index_expr, condition_flow);

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/get_type_at_flow.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/get_type_at_flow.rs
@@ -6,7 +6,7 @@ use std::{rc::Rc, sync::Arc};
 
 use crate::{
     CacheEntry, DbIndex, FlowId, FlowNode, FlowNodeKind, FlowTree, InferFailReason, LuaDeclId,
-    LuaInferCache, LuaMemberId, LuaSignatureId, LuaType, TypeOps, check_type_compact, infer_expr,
+    LuaInferCache, LuaMemberId, LuaSignatureId, LuaType, TypeOps, check_type_compact,
     semantic::{
         cache::{FlowAssignmentInfo, FlowConditionInfo, FlowMode, FlowVarCache},
         infer::{
@@ -22,7 +22,7 @@ use crate::{
                 },
                 get_multi_antecedents, get_single_antecedent,
                 get_type_at_cast_flow::cast_type,
-                get_var_ref_type, narrow_down_type,
+                get_var_ref_type, infer_expr_at_expr_flow, narrow_down_type,
                 var_ref_id::get_var_expr_var_ref_id,
             },
         },
@@ -678,9 +678,23 @@ impl<'a> FlowTypeEngine<'a> {
                                 return Ok(self.finish_walk(walk, var_type));
                             }
                             Err(err) => {
-                                if let Some(init_type) = try_infer_decl_initializer_type(
-                                    self.db, self.cache, self.root, var_ref_id,
-                                )? {
+                                let Some(decl_id) = var_ref_id.get_decl_id_ref() else {
+                                    return self.fail_query(&walk.query, err);
+                                };
+                                let decl = self
+                                    .db
+                                    .get_decl_index()
+                                    .get_decl(&decl_id)
+                                    .ok_or(InferFailReason::None)?;
+                                if let Some(value_syntax_id) = decl.get_value_syntax_id()
+                                    && let Some(node) =
+                                        value_syntax_id.to_node_from_root(self.root.syntax())
+                                    && let Some(expr) = LuaExpr::cast(node)
+                                    && let Some(expr_type) = infer_expr_at_expr_flow(
+                                        self.db, self.tree, self.cache, self.root, expr,
+                                    )?
+                                    && let Some(init_type) = expr_type.get_result_slot_type(0)
+                                {
                                     return Ok(self.finish_walk(walk, init_type));
                                 }
 
@@ -1159,39 +1173,6 @@ fn finish_assignment_result(
     } else {
         expr_type.clone()
     }
-}
-
-fn try_infer_decl_initializer_type(
-    db: &DbIndex,
-    cache: &mut LuaInferCache,
-    root: &LuaChunk,
-    var_ref_id: &VarRefId,
-) -> Result<Option<LuaType>, InferFailReason> {
-    let Some(decl_id) = var_ref_id.get_decl_id_ref() else {
-        return Ok(None);
-    };
-
-    let decl = db
-        .get_decl_index()
-        .get_decl(&decl_id)
-        .ok_or(InferFailReason::None)?;
-
-    let Some(value_syntax_id) = decl.get_value_syntax_id() else {
-        return Ok(None);
-    };
-
-    let Some(node) = value_syntax_id.to_node_from_root(root.syntax()) else {
-        return Ok(None);
-    };
-
-    let Some(expr) = LuaExpr::cast(node) else {
-        return Ok(None);
-    };
-
-    let expr_type = infer_expr(db, cache, expr.clone())?;
-    let init_type = expr_type.get_result_slot_type(0);
-
-    Ok(init_type)
 }
 
 #[cfg(test)]

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/mod.rs
@@ -5,15 +5,17 @@ mod narrow_type;
 mod var_ref_id;
 
 use crate::{
-    CacheEntry, DbIndex, FlowAntecedent, FlowId, FlowNode, FlowTree, InferFailReason,
+    CacheEntry, DbIndex, FlowAntecedent, FlowId, FlowNode, FlowTree, InferFailReason, InferGuard,
     LuaInferCache, infer_param,
     semantic::infer::{
         InferResult,
+        infer_index::infer_member_by_member_key,
         infer_name::{find_decl_member_type, infer_global_type},
+        try_infer_expr_no_flow,
     },
 };
 pub(in crate::semantic) use condition_flow::{ConditionFlowAction, InferConditionFlow};
-use emmylua_parser::{LuaAstNode, LuaChunk, LuaExpr};
+use emmylua_parser::{LuaAstNode, LuaChunk, LuaExpr, LuaIndexMemberExpr};
 pub use get_type_at_cast_flow::get_type_at_call_expr_inline_cast;
 pub use narrow_type::{narrow_down_type, narrow_false_or_nil, remove_false_or_nil};
 pub use var_ref_id::{VarRefId, get_var_expr_var_ref_id};
@@ -37,7 +39,105 @@ pub fn infer_expr_narrow_type(
     get_type_at_flow::get_type_at_flow(db, flow_tree, cache, &root, &var_ref_id, flow_id)
 }
 
-fn get_var_ref_type(db: &DbIndex, cache: &mut LuaInferCache, var_ref_id: &VarRefId) -> InferResult {
+pub(in crate::semantic) fn infer_expr_at_antecedent_flow(
+    db: &DbIndex,
+    tree: &FlowTree,
+    cache: &mut LuaInferCache,
+    root: &LuaChunk,
+    flow_node: &FlowNode,
+    expr: LuaExpr,
+) -> Result<Option<crate::LuaType>, InferFailReason> {
+    let antecedent_flow_id = get_single_antecedent(flow_node)?;
+    infer_expr_at_flow(db, tree, cache, root, antecedent_flow_id, expr)
+}
+
+pub(in crate::semantic) fn infer_expr_at_expr_flow(
+    db: &DbIndex,
+    tree: &FlowTree,
+    cache: &mut LuaInferCache,
+    root: &LuaChunk,
+    expr: LuaExpr,
+) -> Result<Option<crate::LuaType>, InferFailReason> {
+    let Some(flow_id) = tree.get_flow_id(expr.get_syntax_id()) else {
+        return try_infer_expr_no_flow(db, cache, expr);
+    };
+    infer_expr_at_flow(db, tree, cache, root, flow_id, expr)
+}
+
+fn infer_expr_at_flow(
+    db: &DbIndex,
+    tree: &FlowTree,
+    cache: &mut LuaInferCache,
+    root: &LuaChunk,
+    flow_id: FlowId,
+    mut expr: LuaExpr,
+) -> Result<Option<crate::LuaType>, InferFailReason> {
+    loop {
+        match &expr {
+            LuaExpr::ParenExpr(paren_expr) => {
+                expr = paren_expr.get_expr().ok_or(InferFailReason::None)?;
+            }
+            LuaExpr::NameExpr(_) => {
+                let Some(var_ref_id) = get_var_expr_var_ref_id(db, cache, expr.clone()) else {
+                    return try_infer_expr_no_flow(db, cache, expr);
+                };
+
+                // Reuse the existing flow engine for simple ref leaves. If that query
+                // cannot answer, fall back to the current no-flow behavior instead of
+                // copying name/index-specific logic into each condition site.
+                return match get_type_at_flow::get_type_at_flow(
+                    db,
+                    tree,
+                    cache,
+                    root,
+                    &var_ref_id,
+                    flow_id,
+                ) {
+                    Ok(ty) => Ok(Some(ty)),
+                    Err(
+                        InferFailReason::None
+                        | InferFailReason::RecursiveInfer
+                        | InferFailReason::FieldNotFound,
+                    ) => try_infer_expr_no_flow(db, cache, expr),
+                    Err(err) => Err(err),
+                };
+            }
+            LuaExpr::IndexExpr(index_expr) => {
+                let Some(prefix_expr) = index_expr.get_prefix_expr() else {
+                    return try_infer_expr_no_flow(db, cache, expr);
+                };
+                let Some(prefix_type) =
+                    infer_expr_at_flow(db, tree, cache, root, flow_id, prefix_expr)?
+                else {
+                    return try_infer_expr_no_flow(db, cache, expr);
+                };
+
+                return match infer_member_by_member_key(
+                    db,
+                    cache,
+                    &prefix_type,
+                    LuaIndexMemberExpr::IndexExpr(index_expr.clone()),
+                    &InferGuard::new(),
+                ) {
+                    Ok(ty) => Ok(Some(ty)),
+                    Err(
+                        InferFailReason::None
+                        | InferFailReason::RecursiveInfer
+                        | InferFailReason::FieldNotFound,
+                    ) => try_infer_expr_no_flow(db, cache, expr),
+                    Err(err) => Err(err),
+                };
+            }
+            _ => return try_infer_expr_no_flow(db, cache, expr),
+        }
+    }
+}
+
+pub(in crate::semantic) fn get_var_ref_type(
+    db: &DbIndex,
+    cache: &mut LuaInferCache,
+    var_ref_id: &VarRefId,
+) -> InferResult {
     if let Some(decl_id) = var_ref_id.get_decl_id_ref() {
         let decl = db
             .get_decl_index()

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/var_ref_id.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/var_ref_id.rs
@@ -7,9 +7,9 @@ use smol_str::SmolStr;
 
 use crate::{
     DbIndex, LuaAliasCallKind, LuaDeclId, LuaDeclOrMemberId, LuaInferCache, LuaMemberId, LuaType,
-    infer_expr,
     semantic::infer::{
         infer_index::get_index_expr_var_ref_id, infer_name::get_name_expr_var_ref_id,
+        try_infer_expr_no_flow,
     },
 };
 
@@ -74,7 +74,7 @@ fn get_call_expr_var_ref_id(
     call_expr: &LuaCallExpr,
 ) -> Option<VarRefId> {
     let prefix_expr = call_expr.get_prefix_expr()?;
-    let maybe_func = infer_expr(db, cache, prefix_expr.clone()).ok()?;
+    let maybe_func = try_infer_expr_no_flow(db, cache, prefix_expr.clone()).ok()??;
 
     let ret = match maybe_func {
         LuaType::DocFunction(f) => f.get_ret().clone(),

--- a/crates/emmylua_code_analysis/src/semantic/infer/test.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/test.rs
@@ -1,6 +1,126 @@
 #[cfg(test)]
 mod test {
-    use crate::{DiagnosticCode, VirtualWorkspace};
+    use emmylua_parser::{
+        LuaAstNode, LuaBinaryExpr, LuaCallExpr, LuaExpr, LuaIndexExpr, LuaTableExpr,
+    };
+
+    use crate::{
+        DiagnosticCode, FileId, NoFlowCacheEntry, VirtualWorkspace,
+        semantic::{
+            infer::{InferFailReason, infer_expr},
+            type_check::check_type_compact,
+        },
+    };
+
+    fn infer_expr_no_flow(
+        db: &crate::DbIndex,
+        cache: &mut crate::LuaInferCache,
+        expr: LuaExpr,
+    ) -> Result<crate::LuaType, InferFailReason> {
+        cache.with_no_flow(|cache| infer_expr(db, cache, expr))
+    }
+
+    fn infer_expr_type(
+        ws: &VirtualWorkspace,
+        file_id: FileId,
+        expr: LuaExpr,
+        no_flow: bool,
+    ) -> Result<crate::LuaType, InferFailReason> {
+        let semantic_model = ws.analysis.compilation.get_semantic_model(file_id).unwrap();
+        let db = semantic_model.get_db();
+        let mut cache = semantic_model.get_cache().borrow_mut();
+
+        if no_flow {
+            infer_expr_no_flow(db, &mut cache, expr)
+        } else {
+            infer_expr(db, &mut cache, expr)
+        }
+    }
+
+    fn assert_infer_expr_type_matches(
+        ws: &VirtualWorkspace,
+        file_id: FileId,
+        expr: LuaExpr,
+        expected: &crate::LuaType,
+        no_flow: bool,
+    ) {
+        let semantic_model = ws.analysis.compilation.get_semantic_model(file_id).unwrap();
+        let db = semantic_model.get_db();
+        let result = infer_expr_type(ws, file_id, expr, no_flow).unwrap();
+        assert!(check_type_compact(db, &result, expected).is_ok());
+    }
+
+    fn setup_issue_416_workspace() -> (VirtualWorkspace, FileId, LuaCallExpr) {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def_file(
+            "test.lua",
+            r#"
+            ---@class CustomEvent
+            ---@field private custom_event_manager? EventManager
+            local M = {}
+
+            ---@return EventManager
+            function newEventManager()
+            end
+
+            function M:event_on()
+                if not self.custom_event_manager then
+                    self.custom_event_manager = newEventManager()
+                end
+                local trigger = self.custom_event_manager:get_trigger()
+                return trigger
+            end
+            "#,
+        );
+        ws.def_file(
+            "test2.lua",
+            r#"
+            ---@class Trigger
+
+            ---@class EventManager
+            local EventManager
+
+            ---@return Trigger
+            function EventManager:get_trigger()
+            end
+            "#,
+        );
+
+        let tree = ws
+            .analysis
+            .compilation
+            .get_db()
+            .get_vfs()
+            .get_syntax_tree(&file_id)
+            .unwrap();
+        let call_expr = tree
+            .get_chunk_node()
+            .descendants::<LuaCallExpr>()
+            .find(|call_expr: &LuaCallExpr| {
+                call_expr
+                    .syntax()
+                    .text()
+                    .to_string()
+                    .contains("get_trigger")
+            })
+            .unwrap();
+
+        (ws, file_id, call_expr)
+    }
+
+    #[test]
+    fn test_infer_expr_no_flow_uses_bound_type_cache_for_unsupported_expr() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            local value = {} --[[@as integer]]
+            "#,
+        );
+        let expected = ws.ty("integer");
+        let table_expr = ws.get_node::<LuaTableExpr>(file_id);
+        let result = infer_expr_type(&ws, file_id, LuaExpr::TableExpr(table_expr), true);
+        assert_eq!(result.unwrap(), expected);
+    }
 
     #[test]
     fn test_custom_binary() {
@@ -111,5 +231,253 @@ mod test {
         );
 
         assert_eq!(ws.expr_ty("R"), ws.ty("nil"));
+    }
+
+    #[test]
+    fn test_infer_expr_no_flow_caches_binary_expr_result() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def("local t = 1 + 2\n");
+        let binary_expr = ws.get_node::<LuaBinaryExpr>(file_id);
+        let semantic_model = ws.analysis.compilation.get_semantic_model(file_id).unwrap();
+        let db = semantic_model.get_db();
+        let mut cache = semantic_model.get_cache().borrow_mut();
+
+        let result = infer_expr_no_flow(db, &mut cache, binary_expr.clone().into()).unwrap();
+        assert_eq!(result, crate::LuaType::IntegerConst(3));
+        assert!(matches!(
+            cache.expr_no_flow_cache.get(&binary_expr.get_syntax_id()),
+            Some(NoFlowCacheEntry::Cache(_))
+        ));
+    }
+
+    #[test]
+    fn test_infer_expr_no_flow_declines_index_with_unsupported_prefix() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def("local t = ({}).x\n");
+        let index_expr = ws.get_node::<LuaIndexExpr>(file_id);
+        let semantic_model = ws.analysis.compilation.get_semantic_model(file_id).unwrap();
+        let db = semantic_model.get_db();
+        let mut cache = semantic_model.get_cache().borrow_mut();
+
+        let result = infer_expr_no_flow(db, &mut cache, LuaExpr::IndexExpr(index_expr.clone()));
+        assert!(matches!(result, Err(InferFailReason::None)));
+        assert!(matches!(
+            cache.expr_no_flow_cache.get(&index_expr.get_syntax_id()),
+            Some(NoFlowCacheEntry::Declined)
+        ));
+    }
+
+    #[test]
+    fn test_infer_expr_no_flow_declines_require_with_unsupported_path() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def("local m = require(1 + 2)\n");
+        let call_expr = ws.get_node::<LuaCallExpr>(file_id);
+        let semantic_model = ws.analysis.compilation.get_semantic_model(file_id).unwrap();
+        let db = semantic_model.get_db();
+        let mut cache = semantic_model.get_cache().borrow_mut();
+
+        let result = infer_expr_no_flow(db, &mut cache, LuaExpr::CallExpr(call_expr.clone()));
+        assert!(matches!(result, Err(InferFailReason::None)));
+        assert!(matches!(
+            cache.expr_no_flow_cache.get(&call_expr.get_syntax_id()),
+            Some(NoFlowCacheEntry::Declined)
+        ));
+    }
+
+    #[test]
+    fn test_no_flow_issue_416_method_call_returns_method_type() {
+        let (ws, file_id, call_expr) = setup_issue_416_workspace();
+        let result = infer_expr_type(&ws, file_id, LuaExpr::CallExpr(call_expr), true);
+        assert_eq!(ws.humanize_type(result.unwrap()), "Trigger");
+    }
+
+    #[test]
+    fn test_no_flow_generic_call_supports_binary_arg_expr() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            ---@generic T
+            ---@param x T
+            ---@return T
+            local function id(x) end
+
+            local value = id(1 + 2)
+            "#,
+        );
+        let call_expr = ws.get_node::<LuaCallExpr>(file_id);
+        let expected = ws.ty("integer");
+        assert_infer_expr_type_matches(&ws, file_id, LuaExpr::CallExpr(call_expr), &expected, true);
+    }
+
+    #[test]
+    fn test_no_flow_overload_resolution_supports_binary_arg_expr() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            ---@overload fun(x: string): string
+            ---@param x integer
+            ---@return integer
+            local function pick(x) end
+
+            local value = pick(1 + 2)
+            "#,
+        );
+        let call_expr = ws.get_node::<LuaCallExpr>(file_id);
+        let expected = ws.ty("integer");
+        assert_infer_expr_type_matches(&ws, file_id, LuaExpr::CallExpr(call_expr), &expected, true);
+    }
+
+    #[test]
+    fn test_no_flow_overload_resolution_keeps_mixed_return_when_known_args_pick_row() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            ---@overload fun(kind: "a", opts: table): integer
+            ---@param kind "b"
+            ---@param opts table
+            ---@return boolean
+            local function pick(kind, opts) end
+
+            local value = pick("a", {})
+            "#,
+        );
+        let call_expr = ws.get_node::<LuaCallExpr>(file_id);
+        let expected = ws.ty("integer");
+        assert_infer_expr_type_matches(&ws, file_id, LuaExpr::CallExpr(call_expr), &expected, true);
+    }
+
+    #[test]
+    fn test_no_flow_overload_resolution_declines_ambiguous_mixed_returns_with_unknown_arg() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            ---@overload fun(kind: "a", opts: integer): integer
+            ---@param kind "a"
+            ---@param opts string
+            ---@return boolean
+            local function pick(kind, opts) end
+
+            local value = pick("a", {})
+            "#,
+        );
+        let call_expr = ws.get_node::<LuaCallExpr>(file_id);
+        let result = infer_expr_type(&ws, file_id, LuaExpr::CallExpr(call_expr), true);
+        assert!(matches!(result, Err(InferFailReason::None)));
+    }
+
+    #[test]
+    fn test_no_flow_overload_resolution_declines_ambiguous_optional_tail_with_unknown_arg() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            ---@overload fun(x: integer): integer
+            ---@param x string
+            ---@param y string?
+            ---@return boolean
+            local function pick(x, y) end
+
+            local value = pick({})
+            "#,
+        );
+        let call_expr = ws.get_node::<LuaCallExpr>(file_id);
+        let result = infer_expr_type(&ws, file_id, LuaExpr::CallExpr(call_expr), true);
+        assert!(matches!(result, Err(InferFailReason::None)));
+    }
+
+    #[test]
+    fn test_no_flow_overload_resolution_uses_unknown_for_same_return_overloads() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            ---@overload fun(x: string): boolean
+            ---@param x integer
+            ---@return boolean
+            local function pick(x) end
+
+            local value = pick({})
+            "#,
+        );
+        let call_expr = ws.get_node::<LuaCallExpr>(file_id);
+        let result = infer_expr_type(&ws, file_id, LuaExpr::CallExpr(call_expr), true);
+        assert_eq!(result.unwrap(), ws.ty("boolean"));
+    }
+
+    #[test]
+    fn test_no_flow_setmetatable_declines_unsupported_metatable_expr() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def("local t = {}\nlocal value = setmetatable(t, 1 + 2)\n");
+        let call_expr = ws.get_node::<LuaCallExpr>(file_id);
+        let result = infer_expr_type(&ws, file_id, LuaExpr::CallExpr(call_expr), true);
+        assert!(matches!(result, Err(InferFailReason::None)));
+    }
+
+    #[test]
+    fn test_infer_expr_no_flow_supports_table_const_index_with_union_key_expr() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            local t = {
+                foo = 1,
+                bar = 2,
+            }
+
+            ---@type 'foo' | 'bar'
+            local k
+            local value = t[k]
+            "#,
+        );
+        let index_expr = ws.get_node::<LuaIndexExpr>(file_id);
+        let expected = ws.ty("1 | 2");
+        assert_infer_expr_type_matches(
+            &ws,
+            file_id,
+            LuaExpr::IndexExpr(index_expr),
+            &expected,
+            true,
+        );
+    }
+
+    #[test]
+    fn test_infer_expr_no_flow_supports_inherited_custom_index_with_name_key_expr() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            ---@class Base
+            ---@field [integer] string
+
+            ---@class Child: Base
+
+            ---@type Child
+            local child
+            ---@type integer
+            local i
+            local value = child[i]
+            "#,
+        );
+        let index_expr = ws.get_node::<LuaIndexExpr>(file_id);
+        let expected = ws.ty("string");
+        let result = infer_expr_type(&ws, file_id, LuaExpr::IndexExpr(index_expr), true);
+        assert_eq!(result.unwrap(), expected);
+    }
+
+    #[test]
+    fn test_infer_expr_no_flow_supports_table_generic_index_with_binary_key_expr() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            ---@type table<integer, string>
+            local map
+            local value = map[1 + 2]
+            "#,
+        );
+        let index_expr = ws.get_node::<LuaIndexExpr>(file_id);
+        let expected = ws.ty("string");
+        assert_infer_expr_type_matches(
+            &ws,
+            file_id,
+            LuaExpr::IndexExpr(index_expr),
+            &expected,
+            true,
+        );
     }
 }

--- a/crates/emmylua_code_analysis/src/semantic/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/mod.rs
@@ -14,7 +14,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-pub use cache::{CacheEntry, CacheOptions, LuaAnalysisPhase, LuaInferCache};
+pub use cache::{CacheEntry, CacheOptions, LuaAnalysisPhase, LuaInferCache, NoFlowCacheEntry};
 pub use decl::{enum_variable_is_param, parse_require_module_info};
 use emmylua_parser::{
     LuaCallExpr, LuaChunk, LuaExpr, LuaIndexExpr, LuaIndexKey, LuaParseError, LuaSyntaxNode,
@@ -57,7 +57,8 @@ pub use infer::InferFailReason;
 pub use infer::infer_call_expr_func;
 pub(crate) use infer::infer_expr;
 pub use infer::infer_param;
-use overload_resolve::resolve_signature;
+pub(crate) use infer::try_infer_expr_for_index;
+pub(crate) use overload_resolve::resolve_signature;
 pub use semantic_info::SemanticDeclLevel;
 pub use type_check::{TypeCheckFailReason, TypeCheckResult};
 

--- a/crates/emmylua_code_analysis/src/semantic/overload_resolve/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/overload_resolve/mod.rs
@@ -1,19 +1,15 @@
 mod resolve_signature_by_args;
 
-use std::{ops::Deref, sync::Arc};
+use std::sync::Arc;
 
-use emmylua_parser::{LuaCallExpr, LuaExpr};
+use emmylua_parser::LuaCallExpr;
 
-use crate::{
-    VariadicType,
-    db_index::{DbIndex, LuaFunctionType, LuaType},
-    infer_expr,
-};
+use crate::db_index::{DbIndex, LuaFunctionType, LuaType};
 
 use super::{
     LuaInferCache,
     generic::instantiate_func_generic,
-    infer::{InferCallFuncResult, InferFailReason},
+    infer::{InferCallFuncResult, InferFailReason, infer_expr_list_types, try_infer_expr_no_flow},
 };
 
 use resolve_signature_by_args::resolve_signature_by_args;
@@ -27,12 +23,31 @@ pub fn resolve_signature(
     arg_count: Option<usize>,
 ) -> InferCallFuncResult {
     let args = call_expr.get_args_list().ok_or(InferFailReason::None)?;
-    let expr_types = infer_expr_list_types(
+    let mut has_unknown_no_flow_arg = false;
+    let expr_types: Vec<_> = infer_expr_list_types(
         db,
         cache,
         args.get_args().collect::<Vec<_>>().as_slice(),
         arg_count,
-    );
+        |db, cache, expr| {
+            if cache.is_no_flow() {
+                let Some(expr_type) = try_infer_expr_no_flow(db, cache, expr)? else {
+                    if !is_generic {
+                        has_unknown_no_flow_arg = true;
+                        return Ok(LuaType::Unknown);
+                    }
+                    return Err(InferFailReason::None);
+                };
+                Ok(expr_type)
+            } else {
+                Ok(crate::infer_expr(db, cache, expr).unwrap_or(LuaType::Unknown))
+            }
+        },
+    )?
+    .into_iter()
+    .map(|(ty, _)| ty)
+    .collect();
+
     if is_generic {
         resolve_signature_by_generic(db, cache, overloads, call_expr, expr_types, arg_count)
     } else {
@@ -42,6 +57,7 @@ pub fn resolve_signature(
             &expr_types,
             call_expr.is_colon_call(),
             arg_count,
+            has_unknown_no_flow_arg,
         )
     }
 }
@@ -65,48 +81,6 @@ fn resolve_signature_by_generic(
         &expr_types,
         call_expr.is_colon_call(),
         arg_count,
+        false,
     )
-}
-
-fn infer_expr_list_types(
-    db: &DbIndex,
-    cache: &mut LuaInferCache,
-    exprs: &[LuaExpr],
-    var_count: Option<usize>,
-) -> Vec<LuaType> {
-    let mut value_types = Vec::new();
-    for (idx, expr) in exprs.iter().enumerate() {
-        let expr_type = infer_expr(db, cache, expr.clone()).unwrap_or(LuaType::Unknown);
-        match expr_type {
-            LuaType::Variadic(variadic) => {
-                if let Some(var_count) = var_count {
-                    if idx < var_count {
-                        for i in idx..var_count {
-                            if let Some(typ) = variadic.get_type(i - idx) {
-                                value_types.push(typ.clone());
-                            } else {
-                                break;
-                            }
-                        }
-                    }
-                } else {
-                    match variadic.deref() {
-                        VariadicType::Base(base) => {
-                            value_types.push(base.clone());
-                        }
-                        VariadicType::Multi(vecs) => {
-                            for typ in vecs {
-                                value_types.push(typ.clone());
-                            }
-                        }
-                    }
-                }
-
-                break;
-            }
-            _ => value_types.push(expr_type.clone()),
-        }
-    }
-
-    value_types
 }

--- a/crates/emmylua_code_analysis/src/semantic/overload_resolve/resolve_signature_by_args.rs
+++ b/crates/emmylua_code_analysis/src/semantic/overload_resolve/resolve_signature_by_args.rs
@@ -12,6 +12,7 @@ pub fn resolve_signature_by_args(
     expr_types: &[LuaType],
     is_colon_call: bool,
     arg_count: Option<usize>,
+    unknown_as_any: bool,
 ) -> InferCallFuncResult {
     let expr_len = expr_types.len();
     let arg_count = arg_count.unwrap_or(expr_len);
@@ -49,38 +50,19 @@ pub fn resolve_signature_by_args(
                 continue;
             }
 
-            let colon_define = func.is_colon_define();
-            let mut param_index = arg_index;
-            match (colon_define, is_colon_call) {
-                (true, false) => {
-                    if param_index == 0 {
-                        continue;
-                    }
-                    param_index -= 1;
-                }
-                (false, true) => {
-                    param_index += 1;
-                }
-                _ => {}
-            }
-            let param_type = if param_index < param_len {
-                let param_info = func.get_params().get(param_index);
-                param_info
-                    .map(|it| it.1.clone().unwrap_or(LuaType::Any))
-                    .unwrap_or(LuaType::Any)
-            } else if let Some(last_param_info) = func.get_params().last() {
-                if last_param_info.0 == "..." {
-                    last_param_info.1.clone().unwrap_or(LuaType::Any)
-                } else {
-                    *opt_func = None;
-                    continue;
-                }
-            } else {
+            let Some(param_index) = get_call_param_index(func, arg_index, is_colon_call) else {
+                continue;
+            };
+            let Some(param_type) = get_call_arg_param_type(func, param_index) else {
                 *opt_func = None;
                 continue;
             };
 
-            let match_result = if param_type.is_any() {
+            let match_result = if unknown_as_any && expr_type.is_unknown() {
+                // Declined no-flow args are compatible with any overload, but they do
+                // not prove that a specific row won.
+                ParamMatchResult::Any
+            } else if param_type.is_any() {
                 ParamMatchResult::Any
             } else if check_type_compact(db, &param_type, expr_type).is_ok() {
                 ParamMatchResult::Type
@@ -98,7 +80,8 @@ pub fn resolve_signature_by_args(
                 continue;
             }
 
-            if match_result > ParamMatchResult::Any
+            if !unknown_as_any
+                && match_result > ParamMatchResult::Any
                 && arg_index + 1 == expr_len
                 && param_index + 1 == func.get_params().len()
             {
@@ -119,7 +102,12 @@ pub fn resolve_signature_by_args(
 
     let rest_len = rest_need_resolve_funcs.len();
     match rest_len {
-        0 => return Ok(best_match_result),
+        0 => {
+            if unknown_as_any {
+                return Err(InferFailReason::None);
+            }
+            return Ok(best_match_result);
+        }
         1 => {
             return Ok(rest_need_resolve_funcs[0]
                 .clone()
@@ -145,41 +133,34 @@ pub fn resolve_signature_by_args(
                 Some(func) => func,
             };
             let param_len = func.get_params().len();
-            let colon_define = func.is_colon_define();
-            let mut param_index = param_index;
-            match (colon_define, is_colon_call) {
-                (true, false) => {
-                    if param_index == 0 {
-                        continue;
-                    }
-                    param_index -= 1;
-                }
-                (false, true) => {
-                    param_index += 1;
-                }
-                _ => {}
-            }
-            let param_type = if param_index < param_len {
-                let param_info = func.get_params().get(param_index);
-                param_info
-                    .map(|it| it.1.clone().unwrap_or(LuaType::Any))
-                    .unwrap_or(LuaType::Any)
-            } else if let Some(last_param_info) = func.get_params().last() {
-                if last_param_info.0 == "..." {
-                    last_param_info.1.clone().unwrap_or(LuaType::Any)
+            let Some(param_index) = get_call_param_index(func, param_index, is_colon_call) else {
+                continue;
+            };
+            let match_result = if param_index >= param_len {
+                if func
+                    .get_params()
+                    .last()
+                    .is_some_and(|last_param_info| last_param_info.0 == "...")
+                {
+                    ParamMatchResult::Any
+                } else if unknown_as_any {
+                    ParamMatchResult::Type
                 } else {
                     return Ok(func.clone());
                 }
             } else {
-                return Ok(func.clone());
-            };
-
-            let match_result = if param_type.is_any() {
-                ParamMatchResult::Any
-            } else if param_type.is_nullable() {
-                ParamMatchResult::Type
-            } else {
-                ParamMatchResult::Not
+                let param_info = func
+                    .get_params()
+                    .get(param_index)
+                    .expect("Param index should exist");
+                let param_type = param_info.1.clone().unwrap_or(LuaType::Any);
+                if param_type.is_any() {
+                    ParamMatchResult::Any
+                } else if param_type.is_nullable() {
+                    ParamMatchResult::Type
+                } else {
+                    ParamMatchResult::Not
+                }
             };
 
             if match_result > current_match_result {
@@ -192,7 +173,8 @@ pub fn resolve_signature_by_args(
                 continue;
             }
 
-            if match_result >= ParamMatchResult::Any
+            if !unknown_as_any
+                && match_result >= ParamMatchResult::Any
                 && i + 1 == rest_len
                 && param_index + 1 == func.get_params().len()
             {
@@ -205,7 +187,20 @@ pub fn resolve_signature_by_args(
         }
     }
 
-    Ok(best_match_result)
+    if !unknown_as_any {
+        return Ok(best_match_result);
+    }
+
+    let mut remaining_funcs = rest_need_resolve_funcs.into_iter().flatten();
+    let Some(first) = remaining_funcs.next() else {
+        return Err(InferFailReason::None);
+    };
+
+    if remaining_funcs.all(|func| func.get_ret() == first.get_ret()) {
+        Ok(first)
+    } else {
+        Err(InferFailReason::None)
+    }
 }
 
 fn is_func_last_param_variadic(func: &LuaFunctionType) -> bool {
@@ -213,6 +208,40 @@ fn is_func_last_param_variadic(func: &LuaFunctionType) -> bool {
         last_param.0 == "..."
     } else {
         false
+    }
+}
+
+fn get_call_param_index(
+    func: &LuaFunctionType,
+    arg_index: usize,
+    is_colon_call: bool,
+) -> Option<usize> {
+    let mut param_index = arg_index;
+    match (func.is_colon_define(), is_colon_call) {
+        (true, false) => {
+            if param_index == 0 {
+                return None;
+            }
+            param_index -= 1;
+        }
+        (false, true) => {
+            param_index += 1;
+        }
+        _ => {}
+    }
+    Some(param_index)
+}
+
+fn get_call_arg_param_type(func: &LuaFunctionType, param_index: usize) -> Option<LuaType> {
+    if let Some(param_info) = func.get_params().get(param_index) {
+        return Some(param_info.1.clone().unwrap_or(LuaType::Any));
+    }
+
+    let last_param_info = func.get_params().last()?;
+    if last_param_info.0 == "..." {
+        Some(last_param_info.1.clone().unwrap_or(LuaType::Any))
+    } else {
+        None
     }
 }
 


### PR DESCRIPTION
Flow sensitive narrowing previously reached back into top level
expression and call inference from inside the flow engine. Condition
handling, correlated call lookup, initializer recovery, and call probing
could ask questions that were already in flight, which opened a
recursion path and forced conservative bailouts around the hot spots.

Fix that by splitting normal and no flow expression and call caches.
Ready remains the in flight sentinel, while Declined is scoped to no
flow caches and records that a static probe already failed and must not
recurse. This makes failed no flow lookups sticky and lets static
callers stop cleanly instead of re entering full inference.

Recover the lost precision by routing flow sensitive leaf evaluation
back through the existing flow scheduler. NameExpr and IndexExpr now
resolve through get_type_at_flow first, then fall back to no flow only
when the scheduler cannot answer. Reuse that bridge from binary
condition narrowing, call condition narrowing, correlated signature
lookup, and declaration initializer recovery so branch local facts still
apply to equality checks, aliased pcall and rawget guards, and local y =
x inside narrowed branches.

Keep the remaining ambiguity policy local to overload resolution. When a
no flow argument declines, treat it as compatible but non
disambiguating. Only choose an overload when the surviving set is unique
or every remaining candidate returns the same type, and decline mixed
return ambiguity instead of guessing.
