### PR TITLE
fix(flow): honor explicit @cast when source is unresolved

### DIFF
--- a/crates/emmylua_code_analysis/src/compilation/test/flow.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/flow.rs
@@ -1498,6 +1498,25 @@ end
     }
 
     #[test]
+    fn test_issue_1045() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            local f = {
+                [8] = function(aaa)
+                    ---@cast aaa number
+                    b = aaa
+                end
+            }
+            "#,
+        );
+
+        let b = ws.expr_ty("b");
+        let b_desc = ws.humanize_type(b);
+        assert_eq!(b_desc, "number");
+    }
+
+    #[test]
     fn test_issue_364() {
         let mut ws = VirtualWorkspace::new();
 

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/get_type_at_flow.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/get_type_at_flow.rs
@@ -363,7 +363,9 @@ impl<'a> FlowTypeEngine<'a> {
     ) -> Result<SchedulerStep, InferFailReason> {
         let mut cast_input_type = match antecedent_result {
             Ok(resolved_type) => resolved_type,
-            Err(err) => return self.fail_query(&walk.query, err),
+            // `---@cast` is an explicit assertion, so unresolved source types
+            // should still be narrowed by applying the cast from `unknown`.
+            Err(_) => LuaType::Unknown,
         };
         for cast_op_type in cast_op_types {
             cast_input_type = match cast_type(


### PR DESCRIPTION
Fixes #1045.

## Problem
- `---@cast aaa number` inside a function stored in a table field did not narrow `aaa`
- the semantic type at the use site stayed `unknown`

## Root Cause
- standalone `@cast` flow handling only applied the cast after successfully resolving the antecedent type
- in this shape the antecedent query for the parameter could not resolve, so the explicit cast was dropped

## Fix
- treat an unresolved antecedent for standalone `@cast` as `unknown`
- still replay the cast operators so the explicit cast narrows the value