### PR TITLE
chore(lints): deny unused qualifications

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,9 @@ similar = { version = "2.7.0", features = ["inline"] }
 hashbrown = "0.16.1"
 
 # Lint configuration for the entire workspace
+[workspace.lints.rust]
+unused_qualifications = "deny"
+
 [workspace.lints.clippy]
 # ==== Domain-Specific Allowances ====
 # These patterns are acceptable/necessary in parser/language-server projects

--- a/crates/emmylua_code_analysis/src/compilation/test/return_unwrap_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/return_unwrap_test.rs
@@ -30,7 +30,7 @@ mod test {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
         assert!(ws.has_no_diagnostic(
-            crate::DiagnosticCode::ParamTypeMismatch,
+            DiagnosticCode::ParamTypeMismatch,
             r#"
         ---Converts hex to char
         ---@param hex string

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/assign_type_mismatch.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/assign_type_mismatch.rs
@@ -75,7 +75,7 @@ fn check_name_expr(
     value_type: LuaType,
 ) -> Option<()> {
     let semantic_decl = semantic_model.find_decl(
-        rowan::NodeOrToken::Node(name_expr.syntax().clone()),
+        NodeOrToken::Node(name_expr.syntax().clone()),
         SemanticDeclLevel::default(),
     )?;
     let source_type = match semantic_decl.clone() {
@@ -116,7 +116,7 @@ fn check_name_expr(
         check_table_expr(
             context,
             semantic_model,
-            rowan::NodeOrToken::Node(name_expr.syntax().clone()),
+            NodeOrToken::Node(name_expr.syntax().clone()),
             &expr,
             source_type.as_ref(),
         );
@@ -152,7 +152,7 @@ fn check_index_expr(
         check_table_expr(
             context,
             semantic_model,
-            rowan::NodeOrToken::Node(index_expr.syntax().clone()),
+            NodeOrToken::Node(index_expr.syntax().clone()),
             &expr,
             source_type.as_ref(),
         );
@@ -195,7 +195,7 @@ fn check_local_stat(
             check_table_expr(
                 context,
                 semantic_model,
-                rowan::NodeOrToken::Node(var.syntax().clone()),
+                NodeOrToken::Node(var.syntax().clone()),
                 expr,
                 Some(&var_type),
             );

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/return_type_mismatch.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/return_type_mismatch.rs
@@ -94,7 +94,7 @@ fn check_return_stat(
                         check_table_expr(
                             context,
                             semantic_model,
-                            rowan::NodeOrToken::Node(return_expr.syntax().clone()),
+                            NodeOrToken::Node(return_expr.syntax().clone()),
                             return_expr,
                             Some(check_type),
                         );
@@ -132,7 +132,7 @@ fn check_return_stat(
                     if let Some(add_diagnostic) = check_table_expr(
                         context,
                         semantic_model,
-                        rowan::NodeOrToken::Node(return_expr.syntax().clone()),
+                        NodeOrToken::Node(return_expr.syntax().clone()),
                         return_expr,
                         Some(return_type),
                     ) && add_diagnostic

--- a/crates/emmylua_code_analysis/src/diagnostic/test/assign_type_mismatch_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/assign_type_mismatch_test.rs
@@ -1128,7 +1128,7 @@ return t
 
     #[test]
     fn test_ref_index_key_match_tuple() {
-        let mut ws = crate::VirtualWorkspace::new();
+        let mut ws = VirtualWorkspace::new();
 
         assert!(ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
@@ -1151,7 +1151,7 @@ return t
 
     #[test]
     fn test_ref_index_access_assign_class_to_object_mismatch() {
-        let mut ws = crate::VirtualWorkspace::new();
+        let mut ws = VirtualWorkspace::new();
 
         assert!(!ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
@@ -1169,7 +1169,7 @@ return t
 
     #[test]
     fn test_ref_index_access_assign_object_to_class_mismatch() {
-        let mut ws = crate::VirtualWorkspace::new();
+        let mut ws = VirtualWorkspace::new();
 
         assert!(!ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,

--- a/crates/emmylua_code_analysis/src/semantic/generic/test.rs
+++ b/crates/emmylua_code_analysis/src/semantic/generic/test.rs
@@ -4,7 +4,7 @@ mod test {
 
     #[test]
     fn test_variadic_func() {
-        let mut ws = crate::VirtualWorkspace::new();
+        let mut ws = VirtualWorkspace::new();
         ws.def(
             r#"
         ---@generic T, R
@@ -32,7 +32,7 @@ mod test {
 
     #[test]
     fn test_select_type() {
-        let mut ws = crate::VirtualWorkspace::new_with_init_std_lib();
+        let mut ws = VirtualWorkspace::new_with_init_std_lib();
         ws.def(
             r#"
         ---@param ... string
@@ -89,7 +89,7 @@ mod test {
 
     #[test]
     fn test_unpack() {
-        let mut ws = crate::VirtualWorkspace::new_with_init_std_lib();
+        let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
         ws.def(
             r#"
@@ -111,7 +111,7 @@ mod test {
 
     #[test]
     fn test_return() {
-        let mut ws = crate::VirtualWorkspace::new();
+        let mut ws = VirtualWorkspace::new();
         ws.def(
             r#"
                 ---@class ab
@@ -210,7 +210,7 @@ result = {
 
     #[test]
     fn test_call_generic() {
-        let mut ws = crate::VirtualWorkspace::new();
+        let mut ws = VirtualWorkspace::new();
         ws.def(
             r#"
             ---@alias Warp<T> T
@@ -243,7 +243,7 @@ result = {
 
     #[test]
     fn test_generic_alias_instantiation() {
-        let mut ws = crate::VirtualWorkspace::new();
+        let mut ws = VirtualWorkspace::new();
         ws.def(
             r#"
             ---@alias Arrayable<T> T | T[]
@@ -274,7 +274,7 @@ result = {
 
     #[test]
     fn test_generic_alias_instantiation2() {
-        let mut ws = crate::VirtualWorkspace::new();
+        let mut ws = VirtualWorkspace::new();
         ws.def(
             r#"
             ---@alias Arrayable<T> T | T[]

--- a/crates/emmylua_code_analysis/src/semantic/infer/infer_index/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/infer_index/mod.rs
@@ -27,7 +27,7 @@ use crate::{
         },
         member::get_buildin_type_map_type_id,
         member::intersect_member_types,
-        type_check::{self, check_type_compact},
+        type_check::check_type_compact,
     },
 };
 
@@ -957,7 +957,7 @@ fn infer_member_by_index_object(
         let expr = member_key.get_expr().ok_or(InferFailReason::None)?;
         let expr_type = infer_expr(db, cache, expr.clone())?;
         for (key, field) in access_member_type {
-            if type_check::check_type_compact(db, key, &expr_type).is_ok() {
+            if check_type_compact(db, key, &expr_type).is_ok() {
                 return Ok(field.clone());
             }
         }

--- a/crates/emmylua_code_analysis/src/semantic/infer/infer_table.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/infer_table.rs
@@ -26,7 +26,7 @@ pub fn infer_table_expr(
         return infer_table_tuple_or_array(db, cache, table);
     }
 
-    Ok(LuaType::TableConst(crate::InFiled {
+    Ok(LuaType::TableConst(InFiled {
         file_id: cache.get_file_id(),
         value: table.get_range(),
     }))

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/mod.rs
@@ -159,7 +159,7 @@ impl PendingConditionNarrow {
                         InferConditionFlow::TrueCondition => LuaType::from_vec(result),
                         InferConditionFlow::FalseCondition => {
                             let target = LuaType::from_vec(result);
-                            crate::TypeOps::Remove.apply(db, &antecedent_type, &target)
+                            TypeOps::Remove.apply(db, &antecedent_type, &target)
                         }
                     }
                 }
@@ -222,7 +222,7 @@ impl PendingConditionNarrow {
             } => match condition_flow.clone() {
                 InferConditionFlow::TrueCondition => {
                     let maybe_type =
-                        crate::TypeOps::Intersect.apply(db, &antecedent_type, right_expr_type);
+                        TypeOps::Intersect.apply(db, &antecedent_type, right_expr_type);
                     if maybe_type.is_never() {
                         antecedent_type
                     } else {
@@ -230,7 +230,7 @@ impl PendingConditionNarrow {
                     }
                 }
                 InferConditionFlow::FalseCondition => {
-                    crate::TypeOps::Remove.apply(db, &antecedent_type, right_expr_type)
+                    TypeOps::Remove.apply(db, &antecedent_type, right_expr_type)
                 }
             },
             PendingConditionNarrow::TypeGuard {
@@ -242,7 +242,7 @@ impl PendingConditionNarrow {
                         .unwrap_or_else(|| narrow.clone())
                 }
                 InferConditionFlow::FalseCondition => {
-                    crate::TypeOps::Remove.apply(db, &antecedent_type, narrow)
+                    TypeOps::Remove.apply(db, &antecedent_type, narrow)
                 }
             },
             PendingConditionNarrow::Correlated(correlated_narrowing) => {

--- a/crates/emmylua_code_analysis/src/vfs/collect_workspace_files.rs
+++ b/crates/emmylua_code_analysis/src/vfs/collect_workspace_files.rs
@@ -253,7 +253,7 @@ impl WorkspaceFileMatcher {
         build_workspace_file_matcher(&workspace_folders, emmyrc, None, None)
     }
 
-    pub fn is_match(&self, path: &std::path::Path) -> bool {
+    pub fn is_match(&self, path: &Path) -> bool {
         let include_set = match wax::any(self.include.iter().map(|s| s.as_str())) {
             Ok(include_set) => include_set,
             Err(_) => {

--- a/crates/emmylua_code_analysis/src/vfs/file_id.rs
+++ b/crates/emmylua_code_analysis/src/vfs/file_id.rs
@@ -40,13 +40,13 @@ impl From<u32> for FileId {
     }
 }
 
-impl cmp::PartialOrd for FileId {
+impl PartialOrd for FileId {
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl cmp::Ord for FileId {
+impl Ord for FileId {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
         self.id.cmp(&other.id)
     }

--- a/crates/emmylua_ls/src/context/file_diagnostic.rs
+++ b/crates/emmylua_ls/src/context/file_diagnostic.rs
@@ -86,7 +86,7 @@ impl FileDiagnostic {
     }
 
     /// 清除指定文件的诊断信息
-    pub fn clear_push_file_diagnostics(&self, uri: lsp_types::Uri) {
+    pub fn clear_push_file_diagnostics(&self, uri: Uri) {
         let diagnostic_param = lsp_types::PublishDiagnosticsParams {
             uri,
             diagnostics: vec![],

--- a/crates/emmylua_ls/src/context/workspace_manager/tests.rs
+++ b/crates/emmylua_ls/src/context/workspace_manager/tests.rs
@@ -112,7 +112,7 @@ fn collect_watch_registration_methods(client: &Connection, expected: usize) -> V
 
 fn recv_publish_diagnostics_for_uri(
     client: &Connection,
-    uri: &lsp_types::Uri,
+    uri: &Uri,
     timeout: Duration,
 ) -> Option<PublishDiagnosticsParams> {
     let deadline = Instant::now() + timeout;
@@ -136,7 +136,7 @@ fn recv_publish_diagnostics_for_uri(
     None
 }
 
-async fn file_text(snapshot: &ServerContextSnapshot, uri: &lsp_types::Uri) -> Option<String> {
+async fn file_text(snapshot: &ServerContextSnapshot, uri: &Uri) -> Option<String> {
     let analysis = snapshot.analysis().read().await;
     let file_id = analysis.get_file_id(uri)?;
     analysis

--- a/crates/emmylua_ls/src/handlers/command/mod.rs
+++ b/crates/emmylua_ls/src/handlers/command/mod.rs
@@ -19,7 +19,7 @@ pub async fn on_execute_command_handler(
 ) -> Option<Value> {
     let args = params.arguments;
     let command_name = params.command.as_str();
-    commands::dispatch_command(context, command_name, args).await;
+    dispatch_command(context, command_name, args).await;
     Some(Value::Null)
 }
 

--- a/crates/emmylua_ls/src/handlers/inlay_hint/build_inlay_hint.rs
+++ b/crates/emmylua_ls/src/handlers/inlay_hint/build_inlay_hint.rs
@@ -460,7 +460,7 @@ pub fn get_override_lsp_location(
     semantic_model: &SemanticModel,
     file_id: FileId,
     syntax_id: LuaSyntaxId,
-) -> Option<lsp_types::Location> {
+) -> Option<Location> {
     let document = semantic_model.get_document_by_file_id(file_id)?;
     let root = semantic_model.get_root_by_file_id(file_id)?;
     let node = syntax_id.to_node_from_root(root.syntax())?;

--- a/crates/emmylua_ls/src/handlers/semantic_token/language_injector.rs
+++ b/crates/emmylua_ls/src/handlers/semantic_token/language_injector.rs
@@ -152,10 +152,10 @@ fn divide_into_quote_and_code_block(str_token: &LuaStringToken) -> Option<CodeBl
 
         let end_pattern = format!("]{}]", "=".repeat(equal_count));
         if let Some(end_pos) = text.rfind(&end_pattern) {
-            let end_quote_start = range_start + rowan::TextSize::from(end_pos as u32);
+            let end_quote_start = range_start + TextSize::from(end_pos as u32);
             let end_quote_range = TextRange::new(
                 end_quote_start,
-                range_start + rowan::TextSize::from(text.len() as u32),
+                range_start + TextSize::from(text.len() as u32),
             );
             quote_ranges.push(end_quote_range);
             code_block_end = end_quote_range.start();

--- a/crates/emmylua_ls/src/handlers/signature_helper/build_signature_helper.rs
+++ b/crates/emmylua_ls/src/handlers/signature_helper/build_signature_helper.rs
@@ -196,7 +196,7 @@ fn build_sig_id_signature_help(
             None
         } else {
             Some(Documentation::MarkupContent(MarkupContent {
-                kind: lsp_types::MarkupKind::Markdown,
+                kind: MarkupKind::Markdown,
                 value: documentation_string,
             }))
         };

--- a/crates/emmylua_ls/src/logger/mod.rs
+++ b/crates/emmylua_ls/src/logger/mod.rs
@@ -57,7 +57,7 @@ pub fn init_logger(root: Option<&str>, cmd_args: &CmdArgs) {
 
     let log_file_path = log_dir.join(format!("{}.log", filename));
 
-    let log_file = match std::fs::OpenOptions::new()
+    let log_file = match fs::OpenOptions::new()
         .create(true)
         .write(true)
         .truncate(true)


### PR DESCRIPTION
Summary
- Enable the Rust unused_qualifications lint across the workspace.
- Remove existing redundant path qualifiers so the lint runs cleanly.
- Normalize one formatter temp-path assertion so tests pass on macOS.

Test
- cargo fmt --all
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features --no-fail-fast