### PR TITLE
test: make diagnostic helper name match behavior

### DIFF
--- a/crates/emmylua_code_analysis/src/compilation/test/and_or_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/and_or_test.rs
@@ -6,7 +6,7 @@ mod test {
     fn test_issue_221() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::NeedCheckNil,
             r#"
         --- @param opts table|nil
@@ -30,7 +30,7 @@ mod test {
     fn test_issue_222() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
             local a --- @type boolean
@@ -111,7 +111,7 @@ mod test {
     fn test_issue_482() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
             local command_provider --- @type {commands: string[]}?
@@ -126,7 +126,7 @@ mod test {
     fn test_issue_644() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::NeedCheckNil,
             r#"
             --- @alias mapfn fun()

--- a/crates/emmylua_code_analysis/src/compilation/test/annotation_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/annotation_test.rs
@@ -6,7 +6,7 @@ mod test {
     fn test_issue_223() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        ws.check_code_for(
+        ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
         --- @return integer
@@ -117,7 +117,7 @@ mod test {
     fn test_generic_type_inference() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::TypeNotFound,
             r#"
             ---@class AnonymousObserver<T>: Observer<T>
@@ -129,7 +129,7 @@ mod test {
     fn test_class_super_cycle_filters_query_supers() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::CircleDocClass,
             r#"
             ---@class ClassCycleA: ClassCycleB
@@ -142,7 +142,7 @@ mod test {
     fn test_generic_class_super_cycle_reports_diagnostic() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::CircleDocClass,
             r#"
             ---@class GenericCycleA<T>: GenericCycleB<T>
@@ -322,7 +322,7 @@ mod test {
     fn test_type_return_usage() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AnnotationUsageError,
             r#"
             ---@type string

--- a/crates/emmylua_code_analysis/src/compilation/test/array_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/array_test.rs
@@ -22,7 +22,7 @@ mod test {
         "#,
         );
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::NeedCheckNil,
             r#"
                 local a = items[index]
@@ -54,7 +54,7 @@ mod test {
     #[test]
     fn test_array_for_flow() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::NeedCheckNil,
             r#"
         --- @param _x string

--- a/crates/emmylua_code_analysis/src/compilation/test/attribute_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/attribute_test.rs
@@ -33,7 +33,7 @@ mod test {
     fn test_def_attribute() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        ws.check_code_for(
+        ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
         ---@[lsp_optimization("check_table_field")]

--- a/crates/emmylua_code_analysis/src/compilation/test/closure_generic.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/closure_generic.rs
@@ -6,7 +6,7 @@ mod test {
     fn test_generic() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        ws.check_code_for(
+        ws.has_no_diagnostic(
             DiagnosticCode::TypeNotFound,
             r#"
         --- @generic T

--- a/crates/emmylua_code_analysis/src/compilation/test/closure_return_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/closure_return_test.rs
@@ -43,7 +43,7 @@ mod test {
     fn test_issue_265() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
         local function bar()
@@ -62,7 +62,7 @@ mod test {
     #[test]
     fn test_issue_464() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for_namespace(
+        assert!(!ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
                 ---@class D31
@@ -77,7 +77,7 @@ mod test {
         "#,
         ));
 
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
                 ---@class D31

--- a/crates/emmylua_code_analysis/src/compilation/test/decl_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/decl_test.rs
@@ -41,7 +41,7 @@ mod test {
     #[test]
     fn test_3() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                 ---@return any ...

--- a/crates/emmylua_code_analysis/src/compilation/test/diagnostic_disable_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/diagnostic_disable_test.rs
@@ -6,7 +6,7 @@ mod test {
     fn test_disable_nextline() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::SyntaxError,
             r#"
         ---@diagnostic disable-next-line: syntax-error

--- a/crates/emmylua_code_analysis/src/compilation/test/flow.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/flow.rs
@@ -60,7 +60,7 @@ mod test {
     fn test_issue_140_2() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::NeedCheckNil,
             r#"
         local msgBody ---@type { _hgQuiteMsg : 1 }?
@@ -74,7 +74,7 @@ mod test {
     fn test_issue_140_3() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::NeedCheckNil,
             r#"
         local SELF ---@type unknown
@@ -88,7 +88,7 @@ mod test {
     #[test]
     fn test_issue_107() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::NeedCheckNil,
             r#"
         ---@type {bar?: fun():string}
@@ -130,7 +130,7 @@ mod test {
                 .is_some(),
             "expected semantic model for stacked same-variable type guard repro"
         );
-        assert!(ws.check_code_for(DiagnosticCode::AssignTypeMismatch, &block));
+        assert!(ws.has_no_diagnostic(DiagnosticCode::AssignTypeMismatch, &block));
     }
 
     #[test]
@@ -739,7 +739,7 @@ mod test {
     #[test]
     fn test_issue_100() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::NeedCheckNil,
             r#"
         local f = io.open('', 'wb')
@@ -755,7 +755,7 @@ mod test {
     #[test]
     fn test_issue_93() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
         local text    --- @type string[]?
@@ -782,7 +782,7 @@ mod test {
     #[test]
     fn test_null_function_field() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::NeedCheckNil,
             r#"
         ---@class A
@@ -801,7 +801,7 @@ mod test {
     #[test]
     fn test_issue_162() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             --- @class Foo
@@ -818,7 +818,7 @@ mod test {
     #[test]
     fn test_redefine() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
             ---@class AA
@@ -839,7 +839,7 @@ mod test {
     fn test_issue_165() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::NeedCheckNil,
             r#"
 local a --- @type table?
@@ -856,7 +856,7 @@ print(a.h)
     fn test_issue_160() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::NeedCheckNil,
             r#"
 local a --- @type table?
@@ -874,7 +874,7 @@ print(a.field)
     fn test_issue_210() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
         --- @class A
@@ -971,8 +971,8 @@ print(a.field)
 
         ws.def(code);
 
-        assert!(ws.check_code_for(DiagnosticCode::CallNonCallable, code));
-        assert!(ws.check_code_for(DiagnosticCode::NeedCheckNil, code));
+        assert!(ws.has_no_diagnostic(DiagnosticCode::CallNonCallable, code));
+        assert!(ws.has_no_diagnostic(DiagnosticCode::NeedCheckNil, code));
 
         let a = ws.expr_ty("A");
         let a_desc = ws.humanize_type_detailed(a);
@@ -983,7 +983,7 @@ print(a.field)
     fn test_issue_224() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
         --- @class A
@@ -1002,7 +1002,7 @@ print(a.field)
     fn test_elseif() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::NeedCheckNil,
             r#"
 ---@class D11
@@ -1024,7 +1024,7 @@ end
     fn test_issue_266() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
         --- @return string
@@ -1371,7 +1371,7 @@ end
     fn test_issue_347() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
         --- @param x 'a'|'b'
@@ -1520,7 +1520,7 @@ end
     fn test_issue_364() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::NeedCheckNil,
             r#"
             ---@param k integer
@@ -1542,7 +1542,7 @@ end
     #[test]
     fn test_issue_382() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::NeedCheckNil,
             r#"
             ---@class Trigger
@@ -1705,7 +1705,7 @@ end
     fn test_issue_423() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
         --- @return string?
@@ -1729,7 +1729,7 @@ end
     fn test_issue_472() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UnnecessaryIf,
             r#"
             worldLightLevel = 0
@@ -1756,7 +1756,7 @@ end
     fn test_issue_478() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
             --- @param line string
@@ -1773,7 +1773,7 @@ end
     fn test_issue_491() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
             ---@param srow integer?
@@ -1815,7 +1815,7 @@ end
     fn test_issue_480() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        ws.check_code_for(
+        ws.has_no_diagnostic(
             DiagnosticCode::UnnecessaryAssert,
             r#"
             --- @param a integer?
@@ -1863,7 +1863,7 @@ end
     fn test_issue_583() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        ws.check_code_for(
+        ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
             --- @param sha string
@@ -1882,7 +1882,7 @@ end
     fn test_issue_584() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        ws.check_code_for(
+        ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
             local function foo()
@@ -1993,7 +1993,7 @@ end
             end
             "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
                 ---@param observer fun(value: T) | B<T>
@@ -2013,7 +2013,7 @@ end
             "#,
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
                 ---@param observer fun(value: T) | B<T>
@@ -2068,7 +2068,7 @@ end
     #[test]
     fn test_issue_600() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::NeedCheckNil,
             r#"
             ---@class Test2
@@ -2085,7 +2085,7 @@ end
     #[test]
     fn test_issue_585() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
             local a --- @type type?
@@ -2118,7 +2118,7 @@ end
             end
             "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                 ---@param target A | B
@@ -2255,7 +2255,7 @@ end
     #[test]
     fn test_error_function() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::NeedCheckNil,
             r#"
                 ---@class Result
@@ -2277,7 +2277,7 @@ end
     #[test]
     fn test_array_flow() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::NeedCheckNil,
             r#"
             for i = 1, #_G.arg do
@@ -2290,7 +2290,7 @@ end
     #[test]
     fn test_issue_641() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
             local b --- @type boolean
@@ -2365,7 +2365,7 @@ end
     #[test]
     fn test_issue_734() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 local a --- @type string[]
@@ -2494,7 +2494,7 @@ _2 = a[1]
     fn test_issue_868() {
         let mut ws = VirtualWorkspace::new();
 
-        ws.check_code_for(
+        ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
             local a --- @type string|{foo:boolean, bar:string}

--- a/crates/emmylua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/generic_test.rs
@@ -169,8 +169,8 @@ mod test {
             pred = function() end
             "#,
         );
-        assert!(ws.check_code_for(DiagnosticCode::ParamTypeMismatch, r#"pred('hello', 1, {})"#));
-        assert!(!ws.check_code_for(
+        assert!(ws.has_no_diagnostic(DiagnosticCode::ParamTypeMismatch, r#"pred('hello', 1, {})"#));
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"pred('hello',"1", {})"#
         ));
@@ -188,7 +188,7 @@ mod test {
             end
             "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@type A01<number>
@@ -210,7 +210,7 @@ mod test {
             end
             "#,
         );
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@type A02<number>
@@ -232,7 +232,7 @@ mod test {
             end
             "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@type A02<fun(v0: number, v1: number)>
@@ -254,7 +254,7 @@ mod test {
             end
             "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@type A01<number>
@@ -278,7 +278,7 @@ mod test {
             end
             "#,
         );
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@type fun(name: string, age: number)
@@ -287,7 +287,7 @@ mod test {
             "#,
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@type fun(name: string, age: number)
@@ -311,7 +311,7 @@ mod test {
             end
             "#,
         );
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@type A01<fun(a: A02, b: string)>
@@ -340,7 +340,7 @@ mod test {
             end
             "#,
         );
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@type fun(): number
@@ -350,7 +350,7 @@ mod test {
             "#,
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@type fun(): string
@@ -374,7 +374,7 @@ mod test {
             end
             "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@type Pick<{name: string, age: number, email: string}, "name" | "age">
@@ -397,7 +397,7 @@ mod test {
             end
             "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@type Partial<{name: string, age: number}>
@@ -423,7 +423,7 @@ mod test {
             function unwrap(...) end
             "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@type Wrapper<int>, Wrapper<int>, Wrapper<string>
@@ -451,7 +451,7 @@ mod test {
             end
             "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@class A
@@ -463,7 +463,7 @@ mod test {
 
             "#,
         ));
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             f("A", "b", "1")
@@ -483,7 +483,7 @@ mod test {
             function f1(...) end
             "#,
             );
-            assert!(ws.check_code_for(
+            assert!(ws.has_no_diagnostic(
                 DiagnosticCode::ParamTypeMismatch,
                 r#"
               A, B, C =  f1(1, "2", true)
@@ -502,7 +502,7 @@ mod test {
                 function f2(...) end
             "#,
             );
-            assert!(ws.check_code_for(
+            assert!(ws.has_no_diagnostic(
                 DiagnosticCode::ParamTypeMismatch,
                 r#"
               D, E, F =  f2(1, "2", true)
@@ -522,7 +522,7 @@ mod test {
             function f3(...) end
             "#,
             );
-            assert!(!ws.check_code_for(
+            assert!(!ws.has_no_diagnostic(
                 DiagnosticCode::ParamTypeMismatch,
                 r#"
               G, H =  f3(1, "2")
@@ -541,7 +541,7 @@ mod test {
             function f4(...) end
             "#,
             );
-            assert!(!ws.check_code_for(
+            assert!(!ws.has_no_diagnostic(
                 DiagnosticCode::ParamTypeMismatch,
                 r#"
               I, J, K =  f4(1, "2")
@@ -571,7 +571,7 @@ mod test {
             end
             "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@type IsTypeGuard<"number">
@@ -621,7 +621,7 @@ mod test {
             end
             "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             local a
@@ -651,7 +651,7 @@ mod test {
             function return_params(f) end
             "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             result = return_params(pow)
@@ -665,7 +665,7 @@ mod test {
     fn test_overload() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@class Expect
@@ -838,7 +838,7 @@ mod test {
     #[test]
     fn test_extends_true() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::TypeNotFound,
             r#"
             ---@alias TestA<T> T extends "test" and number or string

--- a/crates/emmylua_code_analysis/src/compilation/test/metatable_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/metatable_test.rs
@@ -21,21 +21,21 @@ mod test {
             "#,
         );
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             cmd(1)
         "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             cmd("hello)
         "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             cmd({ "hello", "world" })

--- a/crates/emmylua_code_analysis/src/compilation/test/module_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/module_test.rs
@@ -162,7 +162,7 @@ mod test {
         );
 
         // `AccessInvisible` only fires if the export still points at `export`.
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::AccessInvisible,
             r#"
                 local export = require("virtual_0")

--- a/crates/emmylua_code_analysis/src/compilation/test/multi_return.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/multi_return.rs
@@ -64,7 +64,7 @@ mod test {
     fn test_issue_237() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             crate::DiagnosticCode::UnbalancedAssignments,
             r#"
         local fmt = ""

--- a/crates/emmylua_code_analysis/src/compilation/test/overload_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/overload_test.rs
@@ -7,7 +7,7 @@ mod test {
     fn test_table() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
         table.concat({'', ''}, ' ')
@@ -19,7 +19,7 @@ mod test {
     fn test_sub_string() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingParameter,
             r#"
         local t = ("m2"):sub(1)
@@ -62,7 +62,7 @@ mod test {
     #[test]
     fn test_issue_770() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::RedundantParameter,
             r#"
         local table = {1,2}

--- a/crates/emmylua_code_analysis/src/compilation/test/pcall_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/pcall_test.rs
@@ -28,7 +28,7 @@ mod test {
     fn test_issue_280() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
         ---@class D11.AAA

--- a/crates/emmylua_code_analysis/src/compilation/test/return_overload_flow_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/return_overload_flow_test.rs
@@ -565,7 +565,7 @@ mod test {
     fn test_swapped_literal_eq_narrow_without_return_overload() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
             ---@return "x"
@@ -584,7 +584,7 @@ mod test {
     fn test_var_eq_var_narrow_right_operand_without_return_overload() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
             ---@return "x"

--- a/crates/emmylua_code_analysis/src/compilation/test/return_unwrap_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/return_unwrap_test.rs
@@ -29,7 +29,7 @@ mod test {
     fn test_issue_476() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             crate::DiagnosticCode::ParamTypeMismatch,
             r#"
         ---Converts hex to char
@@ -46,7 +46,7 @@ mod test {
     fn test_issue_659() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
         --- @async
@@ -76,7 +76,7 @@ mod test {
     fn test_issue_643() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
             local function foo(b)

--- a/crates/emmylua_code_analysis/src/compilation/test/static_cal_cmp.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/static_cal_cmp.rs
@@ -54,7 +54,7 @@ mod test {
     fn test_issue_219() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UnnecessaryAssert,
             r#"
         local a --- @type integer?

--- a/crates/emmylua_code_analysis/src/compilation/test/syntax_error_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/syntax_error_test.rs
@@ -5,7 +5,7 @@ mod tests {
     #[test]
     fn test_if_number_then() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::SyntaxError,
             r#"
             if 0then

--- a/crates/emmylua_code_analysis/src/compilation/test/tuple_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/tuple_test.rs
@@ -5,7 +5,7 @@ mod tests {
     #[test]
     fn test_issue_231() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 
@@ -51,7 +51,7 @@ mod tests {
     #[test]
     fn test_issue_595() {
         let mut ws = VirtualWorkspace::new();
-        ws.check_code_for(
+        ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
                 local ret           --- @type [integer?]

--- a/crates/emmylua_code_analysis/src/compilation/test/type_check_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/type_check_test.rs
@@ -7,7 +7,7 @@ mod test {
     fn test_issue_421() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
         local a         --- @type string?
@@ -22,7 +22,7 @@ mod test {
     fn test_issue_645() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
         --- @alias Dir -1|1
@@ -39,7 +39,7 @@ mod test {
     fn test_issue_925() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::TypeNotFound,
             r#"
             ---@alias Pick<T, K extends keyof T> { [P in K]: T[P]; }

--- a/crates/emmylua_code_analysis/src/compilation/test/unpack_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/unpack_test.rs
@@ -134,7 +134,7 @@ mod test {
     fn test_issue_484() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
         --- @type integer,integer,integer
@@ -149,7 +149,7 @@ mod test {
         let mut emmyrc = ws.get_emmyrc();
         emmyrc.runtime.version = EmmyrcLuaVersion::Lua51;
         ws.analysis.update_config(emmyrc.into());
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
         --- @type string[]

--- a/crates/emmylua_code_analysis/src/db_index/type/type_ops/test.rs
+++ b/crates/emmylua_code_analysis/src/db_index/type/type_ops/test.rs
@@ -207,7 +207,7 @@ mod tests {
     #[test]
     fn test_remove_type() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
             ---@return string[]

--- a/crates/emmylua_code_analysis/src/diagnostic/test/access_invisible_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/access_invisible_test.rs
@@ -8,7 +8,7 @@ mod tests {
         let mut config = Emmyrc::default();
         config.runtime.version = EmmyrcLuaVersion::LuaJIT;
         ws.analysis.update_config(config.into());
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AccessInvisible,
             r#"
             local file = io.open("test.txt", "r")
@@ -22,7 +22,7 @@ mod tests {
     #[test]
     fn test_1() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AccessInvisible,
             r#"
                 ---@class (partial) Log
@@ -56,7 +56,7 @@ mod tests {
         "#,
         );
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::AccessInvisible,
             r#"
                 local Log = require("test")
@@ -68,7 +68,7 @@ mod tests {
     #[test]
     fn test_3() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AccessInvisible,
             r#"
                 local M = {}

--- a/crates/emmylua_code_analysis/src/diagnostic/test/assign_type_mismatch_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/assign_type_mismatch_test.rs
@@ -5,7 +5,7 @@ mod tests {
     #[test]
     fn test_1() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for_namespace(
+        assert!(!ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
             ---@generic T: string
@@ -24,7 +24,7 @@ mod tests {
     #[test]
     fn test_2() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
             ---@class Diagnostic.Test7
@@ -45,7 +45,7 @@ mod tests {
     // #[test]
     // fn test_3() {
     //     let mut ws = VirtualWorkspace::new();
-    //     assert!(ws.check_code_for_namespace(
+    //     assert!(ws.has_no_diagnostic_in_namespace(
     //         DiagnosticCode::AssignTypeMismatch,
     //         r#"
     //             ---@param s    string
@@ -67,7 +67,7 @@ mod tests {
     #[test]
     fn test_enum() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
                 ---@enum SubscriberFlags
@@ -90,7 +90,7 @@ mod tests {
 
         // TODO: 解决枚举值运算结果的推断问题
         // 暂时没有好的方式去处理这个警告, 在 ts 中, 枚举值运算的结果不是实际值, 但我们目前的结果是实际值, 所以难以处理
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
                 ---@enum SubscriberFlags
@@ -115,7 +115,7 @@ mod tests {
     #[test]
     fn test_intersection_assign_to_class() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for_namespace(
+        assert!(!ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
             --- @class A
@@ -142,7 +142,7 @@ mod tests {
     #[test]
     fn test_intersection_assign_from_class() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for_namespace(
+        assert!(!ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
             --- @class A
@@ -169,7 +169,7 @@ mod tests {
     #[test]
     fn test_intersection_assign_from_class_inherited_members() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
             ---@class Base
@@ -196,7 +196,7 @@ mod tests {
     fn test_intersection_assign_tableconst_conflict() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for_namespace(
+        assert!(!ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
             ---@class A
@@ -215,7 +215,7 @@ mod tests {
     fn test_intersection_assign_tableconst_requires_right_only_members() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for_namespace(
+        assert!(!ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
             ---@class A
@@ -233,7 +233,7 @@ mod tests {
     #[test]
     fn test_issue_193() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
                 --- @return string?
@@ -248,7 +248,7 @@ mod tests {
     #[test]
     fn test_issue_196() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
                 ---@class A
@@ -265,7 +265,7 @@ mod tests {
     #[test]
     fn test_issue_197() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
                 local a = setmetatable({}, {})
@@ -279,7 +279,7 @@ mod tests {
         // let mut ws = VirtualWorkspace::new();
 
         // 推断类型异常
-        // assert!(ws.check_code_for_namespace(
+        // assert!(ws.has_no_diagnostic_in_namespace(
         //     DiagnosticCode::AssignTypeMismatch,
         //     r#"
         // local n
@@ -302,7 +302,7 @@ mod tests {
         let mut ws = VirtualWorkspace::new();
 
         // Test cases that should pass (no type mismatch)
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 local m = {}
@@ -311,7 +311,7 @@ m.ints = {}
             "#
         ));
 
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 ---@class A
@@ -325,7 +325,7 @@ t.x = {}
         ));
 
         // Test cases that should fail (type mismatch)
-        assert!(!ws.check_code_for_namespace(
+        assert!(!ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 ---@class A
@@ -338,7 +338,7 @@ t.x = true
             "#
         ));
 
-        assert!(!ws.check_code_for_namespace(
+        assert!(!ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 ---@class A
@@ -354,7 +354,7 @@ t.x = y
             "#
         ));
 
-        assert!(!ws.check_code_for_namespace(
+        assert!(!ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 ---@class A
@@ -369,7 +369,7 @@ t.x = true
             "#
         ));
 
-        assert!(!ws.check_code_for_namespace(
+        assert!(!ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 ---@class A
@@ -382,7 +382,7 @@ m.x = true
             "#
         ));
 
-        assert!(!ws.check_code_for_namespace(
+        assert!(!ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 ---@class A
@@ -397,7 +397,7 @@ end
             "#
         ));
 
-        assert!(!ws.check_code_for_namespace(
+        assert!(!ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 ---@class A
@@ -410,7 +410,7 @@ local t = {
             "#
         ));
 
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 ---@type boolean[]
@@ -419,7 +419,7 @@ local t = {}
 t[5] = nil
             "#
         ));
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 ---@type table<string, true>
@@ -429,7 +429,7 @@ t['x'] = nil
             "#
         ));
 
-        assert!(!ws.check_code_for_namespace(
+        assert!(!ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 ---@type [boolean]
@@ -439,7 +439,7 @@ t = nil
             "#
         ));
 
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 local t = { true }
@@ -448,7 +448,7 @@ t[1] = nil
             "#
         ));
 
-        assert!(!ws.check_code_for_namespace(
+        assert!(!ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 ---@class A
@@ -460,7 +460,7 @@ t.x = true
             "#
         ));
 
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 ---@type number
@@ -470,7 +470,7 @@ t = 1
             "#
         ));
 
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 ---@type number
@@ -483,7 +483,7 @@ t = y
             "#
         ));
 
-        assert!(!ws.check_code_for_namespace(
+        assert!(!ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 ---@class A
@@ -496,7 +496,7 @@ m.x = {}
             "#
         ));
 
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 ---@type boolean[]
@@ -510,7 +510,7 @@ t[#t+1] = x
         ));
 
         // Additional test cases
-        assert!(!ws.check_code_for_namespace(
+        assert!(!ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 ---@type number
@@ -522,7 +522,7 @@ i = n
             "#
         ));
 
-        assert!(!ws.check_code_for_namespace(
+        assert!(!ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 ---@type number|boolean
@@ -535,7 +535,7 @@ n = nb
             "#
         ));
 
-        assert!(!ws.check_code_for_namespace(
+        assert!(!ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 ---@type number
@@ -543,7 +543,7 @@ local x = 'aaa'
             "#
         ));
 
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 ---@class X
@@ -555,7 +555,7 @@ local mt = G
 mt._x = nil
             "#
         ));
-        assert!(!ws.check_code_for_namespace(
+        assert!(!ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 ---@class A
@@ -566,7 +566,7 @@ local b = a
             "#
         ));
 
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 ---@class A
@@ -579,7 +579,7 @@ local b = setmetatable({}, a)
         ));
 
         // Continue with more test cases as needed
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 ---@class A
@@ -594,7 +594,7 @@ b.x = a.x
             "#
         ));
 
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 local mt = {}
@@ -603,7 +603,7 @@ mt.x = nil
             "#
         ));
 
-        assert!(!ws.check_code_for_namespace(
+        assert!(!ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 ---@alias test boolean
@@ -613,7 +613,7 @@ local test = 4
             "#
         ));
 
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 ---@class MyClass
@@ -630,7 +630,7 @@ end
             "#
         ));
 
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 ---@class T
@@ -642,7 +642,7 @@ t.x = 1
             "#
         ));
 
-        assert!(!ws.check_code_for_namespace(
+        assert!(!ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 ---@type {[1]: string, [10]: number, xx: boolean}
@@ -654,7 +654,7 @@ local t = {
             "#
         ));
 
-        assert!(!ws.check_code_for_namespace(
+        assert!(!ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 ---@type boolean[]
@@ -662,7 +662,7 @@ local t = { 1, 2, 3 }
             "#
         ));
 
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 local t = {}
@@ -672,7 +672,7 @@ return t
             "#
         ));
 
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
             local function name()
@@ -688,7 +688,7 @@ return t
     #[test]
     fn test_pending() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
             ---@class A
@@ -701,7 +701,7 @@ return t
 
         // 允许接受父类.
         // TODO: 接受父类时应该检查是否具有子类的所有非可空成员.
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
             ---@class Option: string
@@ -717,7 +717,7 @@ return t
         ));
 
         // 数组类型匹配允许可空, 但在初始化赋值时, 不允许直接赋值`nil`(其实是偷懒了, table_expr 推断没有处理边缘情况, 可能后续会做处理允许)
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
         ---@type boolean[]
@@ -729,7 +729,7 @@ return t
     #[test]
     fn test_issue_247() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
         local a --- @type boolean
@@ -742,7 +742,7 @@ return t
     #[test]
     fn test_issue_246() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
         --- @alias Type1 'add' | 'change' | 'delete'
@@ -761,7 +761,7 @@ return t
         let mut ws = VirtualWorkspace::new();
         // TODO: 解决枚举值运算结果的推断问题
         // 暂时没有好的方式去处理这个警告, 在 ts 中, 枚举值运算的结果不是实际值, 但我们目前的结果是实际值, 所以难以处理
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 
@@ -785,7 +785,7 @@ return t
     #[test]
     fn test_issue_285() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
                 --- @return string, integer
@@ -803,7 +803,7 @@ return t
     #[test]
     fn test_issue_338() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
             local t ---@type 0|-1
@@ -816,7 +816,7 @@ return t
     #[test]
     fn test_return_self() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
             ---@class UI
@@ -832,7 +832,7 @@ return t
     #[test]
     fn test_table_pack_in_function() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
                 ---@param ... any
@@ -846,7 +846,7 @@ return t
     #[test]
     fn test_assign_field_with_flow() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
                 ---@class M
@@ -868,7 +868,7 @@ return t
     #[test]
     fn test_flow_1() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
                 ---@class Unit
@@ -891,7 +891,7 @@ return t
     #[test]
     fn test_flow_2() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
                 ---@class Unit
@@ -914,7 +914,7 @@ return t
     #[test]
     fn test_table_array() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
                 ---@type  { [1]: string, [integer]: any }
@@ -931,7 +931,7 @@ return t
     #[test]
     fn test_issue_330() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
             ---@enum MyEnum
@@ -948,7 +948,7 @@ return t
     #[test]
     fn test_issue_393() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
                 ---@alias SortByScoreCallback fun(o: any): integer
@@ -967,7 +967,7 @@ return t
     #[test]
     fn test_issue_374() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
                 --- @param x? integer
@@ -993,7 +993,7 @@ return t
             ---@field xx number
         "#,
         );
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
             ---@type T1
@@ -1015,7 +1015,7 @@ return t
             ---@field x number
         "#,
         );
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
             ---@type T1
@@ -1031,7 +1031,7 @@ return t
     #[test]
     fn test_issue_525() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
                 ---@type table<integer,true|string>
@@ -1048,7 +1048,7 @@ return t
     #[test]
     fn test_param_tbale() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
                 ---@class ability
@@ -1074,7 +1074,7 @@ return t
     #[test]
     fn test_table_field_type_mismatch() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
             local export = {
@@ -1097,7 +1097,7 @@ return t
         end
         "#,
         );
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
             name({
@@ -1115,7 +1115,7 @@ return t
             ---@alias array<T> T[]
         "#,
         );
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
             ---@type array<number>
@@ -1130,7 +1130,7 @@ return t
     fn test_ref_index_key_match_tuple() {
         let mut ws = crate::VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
                 ---@class Item
@@ -1153,7 +1153,7 @@ return t
     fn test_ref_index_access_assign_class_to_object_mismatch() {
         let mut ws = crate::VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
                 ---@class A
@@ -1171,7 +1171,7 @@ return t
     fn test_ref_index_access_assign_object_to_class_mismatch() {
         let mut ws = crate::VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
                 ---@class A
@@ -1189,7 +1189,7 @@ return t
     fn test_exact_string_reassignment_in_narrowed_branch_keeps_assign_literal() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
                 local x ---@type string|number
@@ -1208,7 +1208,7 @@ return t
     fn test_return_overload_mixed_guards_keep_assign_narrowing() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
                 ---@generic T, E

--- a/crates/emmylua_code_analysis/src/diagnostic/test/await_in_sync_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/await_in_sync_test.rs
@@ -6,7 +6,7 @@ mod test {
     fn test_await_in_sync() {
         let mut ws = crate::VirtualWorkspace::new_with_init_std_lib();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::AwaitInSync,
             r#"
         local function name(callback)
@@ -19,7 +19,7 @@ mod test {
         "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AwaitInSync,
             r#"
         local function name(callback)
@@ -33,7 +33,7 @@ mod test {
         "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AwaitInSync,
             r#"
         ---@param callback async fun()
@@ -47,7 +47,7 @@ mod test {
         "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AwaitInSync,
             r#"
             ---@generic T, R
@@ -63,7 +63,7 @@ mod test {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::AwaitInSync,
             r#"
         ---@param callback async fun()
@@ -78,7 +78,7 @@ mod test {
     fn test_issue_99() {
         let mut ws = crate::VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AwaitInSync,
             r#"
         ---@async
@@ -105,7 +105,7 @@ mod test {
         "#,
         );
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AwaitInSync,
             r#"
         --- @async
@@ -117,7 +117,7 @@ mod test {
         "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::AwaitInSync,
             r#"
         function baz()
@@ -130,7 +130,7 @@ mod test {
     #[test]
     fn test_issue_161() {
         let mut ws = crate::VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AwaitInSync,
             r#"
         local function create(_f) end
@@ -153,7 +153,7 @@ mod test {
     #[test]
     fn test_issue_721() {
         let mut ws = crate::VirtualWorkspace::new();
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::AwaitInSync,
             r#"
             --- @param f sync fun()

--- a/crates/emmylua_code_analysis/src/diagnostic/test/call_non_callable_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/call_non_callable_test.rs
@@ -8,7 +8,7 @@ mod test {
     fn test_call_non_callable() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::CallNonCallable,
             r#"
                 local i = 1
@@ -16,7 +16,7 @@ mod test {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::CallNonCallable,
             r#"
                 local s = "hi"
@@ -24,7 +24,7 @@ mod test {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::CallNonCallable,
             r#"
                 local b = true
@@ -32,7 +32,7 @@ mod test {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::CallNonCallable,
             r#"
                 ---@type thread
@@ -41,7 +41,7 @@ mod test {
             "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::CallNonCallable,
             r#"
                 local function f() end
@@ -49,7 +49,7 @@ mod test {
             "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::CallNonCallable,
             r#"
                 ---@type function
@@ -58,7 +58,7 @@ mod test {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::CallNonCallable,
             r#"
                 ---@type function|integer
@@ -67,7 +67,7 @@ mod test {
             "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::CallNonCallable,
             r#"
                 local f ---@type { field: string } & fun()
@@ -76,7 +76,7 @@ mod test {
         ));
 
         // nil is covered by need-check-nil instead of call-non-callable
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::CallNonCallable,
             r#"
                 ---@type function|nil
@@ -85,35 +85,35 @@ mod test {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::CallNonCallable,
             r#"
                 (1)()
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::CallNonCallable,
             r#"
                 ("hi")()
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::CallNonCallable,
             r#"
                 (true)()
             "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::CallNonCallable,
             r#"
                 (function() end)()
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::CallNonCallable,
             r#"
                 local i --- @type integer|fun():string
@@ -121,7 +121,7 @@ mod test {
             "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::CallNonCallable,
             r#"
                 ---@class Callable
@@ -132,7 +132,7 @@ mod test {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::CallNonCallable,
             r#"
                 local c = {}
@@ -140,7 +140,7 @@ mod test {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::CallNonCallable,
             r#"
                 ---@class NonCallable
@@ -150,7 +150,7 @@ mod test {
             "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::CallNonCallable,
             r#"
                 ---@type any
@@ -182,7 +182,7 @@ mod test {
     #[test]
     fn test_no_call_non_callable_on_undefined_type() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::CallNonCallable,
             r#"
             local a --- @type NotDefined
@@ -194,7 +194,7 @@ mod test {
     #[test]
     fn test_no_call_non_callable_on_alias() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::CallNonCallable,
             r#"
             ---@alias FunAlias function
@@ -207,7 +207,7 @@ mod test {
     #[test]
     fn test_no_call_non_callable_for_generic_function_param_in_a_lua() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::CallNonCallable,
             r#"
             --- @generic F: function

--- a/crates/emmylua_code_analysis/src/diagnostic/test/cast_type_mismatch_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/cast_type_mismatch_test.rs
@@ -13,7 +13,7 @@ mod tests {
 ---@cast -?
         "#;
 
-        assert!(ws.check_code_for(DiagnosticCode::CastTypeMismatch, code));
+        assert!(ws.has_no_diagnostic(DiagnosticCode::CastTypeMismatch, code));
     }
 
     #[test]
@@ -25,7 +25,7 @@ mod tests {
             A = "1"
             "#,
         );
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::CastTypeMismatch,
             r#"
             ---@cast A number
@@ -36,7 +36,7 @@ mod tests {
     #[test]
     fn test_valid_cast_from_union_to_member() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::CastTypeMismatch,
             r#"
             ---@type string|number|boolean
@@ -50,7 +50,7 @@ mod tests {
     #[test]
     fn test_invalid_cast_to_non_member() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::CastTypeMismatch,
             r#"
             ---@type string|boolean
@@ -64,7 +64,7 @@ mod tests {
     #[test]
     fn test_cast_with_nil() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::CastTypeMismatch,
             r#"
             ---@type string?
@@ -78,7 +78,7 @@ mod tests {
     #[test]
     fn test_cast_same_type() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::CastTypeMismatch,
             r#"
             ---@type string
@@ -92,7 +92,7 @@ mod tests {
     #[test]
     fn test_cast_multiple_operations() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::CastTypeMismatch,
             r#"
             ---@type string|boolean
@@ -112,7 +112,7 @@ mod tests {
             ---@class Dog : Animal
             "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::CastTypeMismatch,
             r#"
             ---@type Animal
@@ -132,7 +132,7 @@ mod tests {
             ---@class Car
             "#,
         );
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::CastTypeMismatch,
             r#"
             ---@type Animal
@@ -151,7 +151,7 @@ mod tests {
             ---@class Animal.Dog
             "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::CastTypeMismatch,
             r#"
             ---@type any
@@ -165,7 +165,7 @@ mod tests {
     #[test]
     fn test_cast_alias_1() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::CastTypeMismatch,
             r#"
                 ---@alias KV.SupportType
@@ -193,7 +193,7 @@ mod tests {
     #[test]
     fn test_cast_alias_2() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::CastTypeMismatch,
             r#"
                 ---@alias KeyAlias
@@ -207,7 +207,7 @@ mod tests {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::CastTypeMismatch,
             r#"
                 ---@alias IdAlias
@@ -221,7 +221,7 @@ mod tests {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::CastTypeMismatch,
             r#"
                 ---@alias IdAndKeyAlias IdAlias|KeyAlias
@@ -237,7 +237,7 @@ mod tests {
     #[test]
     fn test_issue_565() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::CastTypeMismatch,
             r#"
                 local a --- @type table?

--- a/crates/emmylua_code_analysis/src/diagnostic/test/check_return_count_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/check_return_count_test.rs
@@ -4,19 +4,19 @@ mod tests {
 
     fn assert_missing_return_ok(code: &str) {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(DiagnosticCode::MissingReturn, code));
+        assert!(ws.has_no_diagnostic(DiagnosticCode::MissingReturn, code));
     }
 
     fn assert_missing_return_error(code: &str) {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for(DiagnosticCode::MissingReturn, code));
+        assert!(!ws.has_no_diagnostic(DiagnosticCode::MissingReturn, code));
     }
 
     #[test]
     fn test_1() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::RedundantReturnValue,
             r#"
             ---@class Completion2.A
@@ -36,7 +36,7 @@ mod tests {
     fn test_2() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::MissingReturnValue,
             r#"
             ---@return integer a
@@ -53,7 +53,7 @@ mod tests {
     fn test_missing_return_value() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::MissingReturnValue,
             r#"
             ---@return number
@@ -63,7 +63,7 @@ mod tests {
         "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingReturnValue,
             r#"
             ---@return number
@@ -79,7 +79,7 @@ mod tests {
     fn test_missing_return_value_variadic() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingReturnValue,
             r#"
             --- @return integer?
@@ -95,7 +95,7 @@ mod tests {
     fn test_return_expr_list_missing() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingReturnValue,
             r#"
             ---@return integer, integer
@@ -108,7 +108,7 @@ mod tests {
             end
         "#
         ));
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::MissingReturnValue,
             r#"
             ---@return integer
@@ -127,7 +127,7 @@ mod tests {
     fn test_dots() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::RedundantReturnValue,
             r#"
             ---@return number, any...
@@ -142,7 +142,7 @@ mod tests {
     fn test_redundant_return_value() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::RedundantReturnValue,
             r#"
             ---@return number
@@ -157,7 +157,7 @@ mod tests {
     fn test_not_return_anno() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingReturnValue,
             r#"
             local function baz()
@@ -169,7 +169,7 @@ mod tests {
         "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::RedundantReturnValue,
             r#"
             function bar(a)
@@ -183,7 +183,7 @@ mod tests {
     fn test_return_expr_list_redundant() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::RedundantReturnValue,
             r#"
             ---@return integer, integer
@@ -197,7 +197,7 @@ mod tests {
         "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::RedundantReturnValue,
             r#"
             ---@return integer, integer, integer
@@ -216,7 +216,7 @@ mod tests {
     fn test_missing_return() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::MissingReturn,
             r#"
             local A
@@ -231,7 +231,7 @@ mod tests {
             "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingReturn,
             r#"
             ---@return number
@@ -243,7 +243,7 @@ mod tests {
             "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingReturn,
             r#"
             local A
@@ -260,7 +260,7 @@ mod tests {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::MissingReturn,
             r#"
             local A
@@ -277,7 +277,7 @@ mod tests {
             "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingReturn,
             r#"
             ---@return number
@@ -290,7 +290,7 @@ mod tests {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::MissingReturn,
             r#"
             local A
@@ -305,7 +305,7 @@ mod tests {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::MissingReturn,
             r#"
             local A
@@ -326,7 +326,7 @@ mod tests {
             "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingReturn,
             r#"
             local A
@@ -343,7 +343,7 @@ mod tests {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::MissingReturn,
             r#"
             local A
@@ -362,7 +362,7 @@ mod tests {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::MissingReturn,
             r#"
             local A
@@ -379,7 +379,7 @@ mod tests {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::MissingReturn,
             r#"
             ---@return number
@@ -388,7 +388,7 @@ mod tests {
             "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingReturn,
             r#"
 
@@ -398,7 +398,7 @@ mod tests {
             "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingReturn,
             r#"
             ---@return any ...
@@ -407,7 +407,7 @@ mod tests {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::MissingReturn,
             r#"
             ---@return number
@@ -417,7 +417,7 @@ mod tests {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::MissingReturn,
             r#"
             local A
@@ -430,7 +430,7 @@ mod tests {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::MissingReturn,
             r#"
             local A, B
@@ -445,7 +445,7 @@ mod tests {
             "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingReturn,
             r#"
             local A, B
@@ -462,7 +462,7 @@ mod tests {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::MissingReturn,
             r#"
             local A, B
@@ -478,7 +478,7 @@ mod tests {
             "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingReturn,
             r#"
             ---@return any
@@ -488,7 +488,7 @@ mod tests {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::MissingReturn,
             r#"
             ---@return any, number
@@ -498,7 +498,7 @@ mod tests {
             "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingReturn,
             r#"
             ---@return any, any
@@ -508,7 +508,7 @@ mod tests {
             "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingReturn,
             r#"
             local A
@@ -825,7 +825,7 @@ mod tests {
     #[test]
     fn test_issue_236() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::MissingReturn,
             r#"
             --- @param a number
@@ -861,7 +861,7 @@ mod tests {
         "#,
         );
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingReturn,
             r#"
             local M = {}
@@ -877,7 +877,7 @@ mod tests {
     fn test_miss_return_2() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingReturn,
             r#"
             os.exit = function(...)
@@ -890,7 +890,7 @@ mod tests {
     fn test_miss_return_3() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingReturn,
             r#"
                 ---@class Point
@@ -924,7 +924,7 @@ mod tests {
     fn test_pcall_missing_return() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingReturn,
             r#"
                 pcall(function() end)
@@ -935,7 +935,7 @@ mod tests {
     #[test]
     fn test_missing_return_1() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::MissingReturn,
             r#"
                 ---@generic T
@@ -951,7 +951,7 @@ mod tests {
     #[test]
     fn test_issue_567() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::RedundantReturnValue,
             r#"
                 local function fnil()
@@ -964,7 +964,7 @@ mod tests {
         "#,
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::RedundantReturnValue,
             r#"
                 --- @return nil

--- a/crates/emmylua_code_analysis/src/diagnostic/test/code_style/non_literal_expressions_in_assert_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/code_style/non_literal_expressions_in_assert_test.rs
@@ -7,7 +7,7 @@ mod test {
         let mut ws = crate::VirtualWorkspace::new();
         ws.enable_check(DiagnosticCode::NonLiteralExpressionsInAssert);
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::NonLiteralExpressionsInAssert,
             r#"
             -- msg is global or unknown
@@ -15,7 +15,7 @@ mod test {
             "#,
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::NonLiteralExpressionsInAssert,
             r#"
             local msg = "msg"
@@ -24,21 +24,21 @@ mod test {
             "#,
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::NonLiteralExpressionsInAssert,
             r#"
             local a = assert(foo(), "msg")
             "#,
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::NonLiteralExpressionsInAssert,
             r#"
             local a = assert(foo(), "msg" .. "msg2")
             "#,
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::NonLiteralExpressionsInAssert,
             r#"
             local t = { a = "msg" }
@@ -47,7 +47,7 @@ mod test {
             "#,
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::NonLiteralExpressionsInAssert,
             r#"
             local function get_des() return "msg" end

--- a/crates/emmylua_code_analysis/src/diagnostic/test/code_style/preferred_local_alias_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/code_style/preferred_local_alias_test.rs
@@ -6,7 +6,7 @@ mod test {
     fn test_feat_724() {
         let mut ws = crate::VirtualWorkspace::new_with_init_std_lib();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::PreferredLocalAlias,
             r#"
             local gsub = string.gsub
@@ -14,7 +14,7 @@ mod test {
             "#,
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::PreferredLocalAlias,
             r#"
             local t = {

--- a/crates/emmylua_code_analysis/src/diagnostic/test/disable_line_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/disable_line_test.rs
@@ -12,7 +12,7 @@ mod test {
         "#,
         );
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::Deprecated,
             r#"
             ---@diagnostic disable-next-line: deprecated
@@ -20,14 +20,14 @@ mod test {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::Deprecated,
             r#"
             local _c = a ---@diagnostic disable-next-line: deprecated
             "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::Deprecated,
             r#"
             local _d = a ---@diagnostic disable-line: deprecated

--- a/crates/emmylua_code_analysis/src/diagnostic/test/duplicate_field_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/duplicate_field_test.rs
@@ -6,7 +6,7 @@ mod test {
     fn test_duplicate_field() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for_namespace(
+        assert!(!ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::DuplicateDocField,
             r#"
             ---@class Test
@@ -18,7 +18,7 @@ mod test {
             "#
         ));
 
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::DuplicateDocField,
             r#"
             ---@class Test
@@ -28,7 +28,7 @@ mod test {
             "#
         ));
 
-        assert!(!ws.check_code_for_namespace(
+        assert!(!ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::DuplicateDocField,
             r#"
             ---@class Test
@@ -38,7 +38,7 @@ mod test {
             "#
         ));
 
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::DuplicateDocField,
             r#"
             ---@class Test1
@@ -54,7 +54,7 @@ mod test {
     fn test_duplicate_function_1() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::DuplicateDocField,
             r#"
             ---@class Test
@@ -66,7 +66,7 @@ mod test {
             "#
         ));
 
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::DuplicateDocField,
             r#"
             ---@class Test
@@ -79,7 +79,7 @@ mod test {
             "#
         ));
 
-        assert!(!ws.check_code_for_namespace(
+        assert!(!ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::DuplicateSetField,
             r#"
             ---@class Test
@@ -113,7 +113,7 @@ mod test {
                 return A
             "#,
         );
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::DuplicateSetField,
             r#"
             local A = require("1")
@@ -127,7 +127,7 @@ mod test {
     #[test]
     fn test_duplicate_function_3() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::DuplicateSetField,
             r#"
                 ---@class D31.A
@@ -146,7 +146,7 @@ mod test {
     fn test_duplicate_function_4() {
         let mut ws = VirtualWorkspace::new();
         // 如果是 .member = 参数, 则不报错
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::DuplicateSetField,
             r#"
                 ---@class D31.A
@@ -164,7 +164,7 @@ mod test {
     #[test]
     fn test_return_self() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::DuplicateSetField,
             r#"
                 ---@class test

--- a/crates/emmylua_code_analysis/src/diagnostic/test/duplicate_index_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/duplicate_index_test.rs
@@ -6,7 +6,7 @@ mod test {
     fn test_duplicate_index() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::DuplicateIndex,
             r#"
                 local a = {
@@ -16,7 +16,7 @@ mod test {
             "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::DuplicateIndex,
             r#"
                 local a = {

--- a/crates/emmylua_code_analysis/src/diagnostic/test/duplicate_require_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/duplicate_require_test.rs
@@ -6,7 +6,7 @@ mod tests {
     fn test() {
         let mut ws = VirtualWorkspace::new();
         // 作用域不同
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::DuplicateRequire,
             r#"
             if true then
@@ -18,7 +18,7 @@ mod tests {
         ));
 
         // 父作用域已存在
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::DuplicateRequire,
             r#"
             require("a")
@@ -34,7 +34,7 @@ mod tests {
     #[test]
     fn test_field() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::DuplicateRequire,
             r#"
             require("a").a

--- a/crates/emmylua_code_analysis/src/diagnostic/test/enum_value_mismatch_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/enum_value_mismatch_test.rs
@@ -6,7 +6,7 @@ mod tests {
     fn test_enum_value_mismatch_string() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::EnumValueMismatch,
             r#"
                 ---@enum Status
@@ -29,7 +29,7 @@ mod tests {
     fn test_enum_value_mismatch_number() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::EnumValueMismatch,
             r#"
                 ---@enum ErrorCode
@@ -52,7 +52,7 @@ mod tests {
     fn test_enum_value_mismatch_elseif() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::EnumValueMismatch,
             r#"
             ---@enum State
@@ -75,7 +75,7 @@ mod tests {
     fn test_enum_value_mismatch_reverse_order() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::EnumValueMismatch,
             r#"
             ---@enum Color
@@ -98,7 +98,7 @@ mod tests {
     fn test_enum_value_valid_cases() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::EnumValueMismatch,
             r#"
                 ---@enum Status
@@ -121,7 +121,7 @@ mod tests {
     fn test_enum_value_valid_exact_matches() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::EnumValueMismatch,
             r#"
                 ---@enum Numbers

--- a/crates/emmylua_code_analysis/src/diagnostic/test/generic_constraint_mismatch_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/generic_constraint_mismatch_test.rs
@@ -6,7 +6,7 @@ mod test {
     #[test]
     fn test_1() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::GenericConstraintMismatch,
             r#"
                 ---@class Component
@@ -28,7 +28,7 @@ mod test {
     #[test]
     fn test_2() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::GenericConstraintMismatch,
             r#"
                 ---@class Component
@@ -50,7 +50,7 @@ mod test {
     #[test]
     fn test_3() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::GenericConstraintMismatch,
             r#"
             local nargs = select('#')
@@ -61,7 +61,7 @@ mod test {
     #[test]
     fn test_4() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::GenericConstraintMismatch,
             r#"
                 ---@class Component
@@ -84,7 +84,7 @@ mod test {
     #[test]
     fn test_class_1() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::GenericConstraintMismatch,
             r#"
                 ---@class Component
@@ -105,7 +105,7 @@ mod test {
         "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::GenericConstraintMismatch,
             r#"
 
@@ -123,7 +123,7 @@ mod test {
     #[test]
     fn test_class_2() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::GenericConstraintMismatch,
             r#"
             ---@class Component
@@ -146,7 +146,7 @@ mod test {
     #[test]
     fn test_extend_string() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::GenericConstraintMismatch,
             r#"
                 ---@class ABC1
@@ -165,7 +165,7 @@ mod test {
     #[test]
     fn test_str_tpl_ref_param() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::GenericConstraintMismatch,
             r#"
                 ---@generic T
@@ -185,7 +185,7 @@ mod test {
     #[test]
     fn test_issue_516() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::GenericConstraintMismatch,
             r#"
                 ---@generic T: table
@@ -216,7 +216,7 @@ mod test {
             end
         "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::GenericConstraintMismatch,
             r#"
             ---@type ab
@@ -225,14 +225,14 @@ mod test {
             name(a)
         "#
         ));
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::GenericConstraintMismatch,
             r#"
             name("ab")
         "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::GenericConstraintMismatch,
             r#"
             name("a")
@@ -253,7 +253,7 @@ mod test {
             ---@class GCNode
         "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::GenericConstraintMismatch,
             r#"
             ---@generic T: table
@@ -284,7 +284,7 @@ mod test {
 
         "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::GenericConstraintMismatch,
             r#"
 
@@ -305,7 +305,7 @@ mod test {
         let mut ws = VirtualWorkspace::new();
         // A @class whose inferred Def type (e.g. from `return self`) should satisfy
         // an object constraint via structural duck typing, same as Ref types do.
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::GenericConstraintMismatch,
             r#"
                 ---@class MyPos
@@ -357,7 +357,7 @@ mod test {
                 ---@field name string
             "#,
         );
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::GenericConstraintMismatch,
             r#"
             ---@type Person
@@ -367,7 +367,7 @@ mod test {
         "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::GenericConstraintMismatch,
             r#"
             ---@type Person
@@ -398,7 +398,7 @@ mod test {
             return M
         "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::GenericConstraintMismatch,
             r#"
             local m = require("mylib")

--- a/crates/emmylua_code_analysis/src/diagnostic/test/global_in_non_module_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/global_in_non_module_test.rs
@@ -5,7 +5,7 @@ mod tests {
     #[test]
     fn test_global_in_non_module() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::GlobalInNonModule,
             r#"
             local function name()

--- a/crates/emmylua_code_analysis/src/diagnostic/test/incomplete_signature_doc_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/incomplete_signature_doc_test.rs
@@ -8,7 +8,7 @@ mod tests {
         let mut ws = VirtualWorkspace::new();
         ws.enable_full_diagnostic();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::IncompleteSignatureDoc,
             r#"
                 ---@param a string
@@ -24,7 +24,7 @@ mod tests {
         let mut ws = VirtualWorkspace::new();
         ws.enable_full_diagnostic();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::IncompleteSignatureDoc,
             r#"
             local c = function(x, y)
@@ -33,7 +33,7 @@ mod tests {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::IncompleteSignatureDoc,
             r#"
             local function do_add(x, y)
@@ -42,7 +42,7 @@ mod tests {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::IncompleteSignatureDoc,
             r#"
             local function noop()
@@ -50,7 +50,7 @@ mod tests {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::IncompleteSignatureDoc,
             r#"
             ---@param p number
@@ -60,7 +60,7 @@ mod tests {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::IncompleteSignatureDoc,
             r#"
             ---@param p number
@@ -70,7 +70,7 @@ mod tests {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::IncompleteSignatureDoc,
             r#"
             --- function without param signature
@@ -80,7 +80,7 @@ mod tests {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::IncompleteSignatureDoc,
             r#"
 
@@ -99,7 +99,7 @@ mod tests {
         let mut ws = VirtualWorkspace::new();
         ws.enable_full_diagnostic();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::IncompleteSignatureDoc,
             r#"
             ---@return_overload true, integer
@@ -110,7 +110,7 @@ mod tests {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::IncompleteSignatureDoc,
             r#"
             ---@return_overload true, integer
@@ -127,7 +127,7 @@ mod tests {
         let mut ws = VirtualWorkspace::new();
         ws.enable_full_diagnostic();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::IncompleteSignatureDoc,
             r#"
             ---@return_overload true, integer...
@@ -144,7 +144,7 @@ mod tests {
         let mut ws = VirtualWorkspace::new();
         ws.enable_full_diagnostic();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::MissingGlobalDoc,
             r#"
                 function FLPR1()
@@ -152,7 +152,7 @@ mod tests {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::MissingGlobalDoc,
             r#"
                 ---
@@ -160,7 +160,7 @@ mod tests {
                 end
             "#
         ));
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::MissingGlobalDoc,
             r#"
                 ---
@@ -170,7 +170,7 @@ mod tests {
             "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingGlobalDoc,
             r#"
                 ---

--- a/crates/emmylua_code_analysis/src/diagnostic/test/inject_field_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/inject_field_test.rs
@@ -5,7 +5,7 @@ mod test {
     #[test]
     fn test_issue_195() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::InjectField,
             r#"
             local ret = {} --- @type string[]
@@ -19,7 +19,7 @@ mod test {
     #[test]
     fn test_inject_field() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::InjectField,
             r#"
             ---@class test1
@@ -31,7 +31,7 @@ mod test {
         "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::InjectField,
             r#"
             ---@class test2
@@ -48,7 +48,7 @@ mod test {
     #[test]
     fn test_class_def_dynamic_key_in_method_is_allowed() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::InjectField,
             r#"
             ---@class TestBind
@@ -68,7 +68,7 @@ mod test {
     #[test]
     fn test_super_table() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::InjectField,
             r#"
             ---@class test1<T>: {[string]: number }, table<string, string>
@@ -84,7 +84,7 @@ mod test {
     #[test]
     fn test_object() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::InjectField,
             r#"
             ---@type { [number]: number }
@@ -98,7 +98,7 @@ mod test {
     #[test]
     fn test_self() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::InjectField,
             r#"
             ---@class Diagnostic.8_1
@@ -115,7 +115,7 @@ mod test {
     #[test]
     fn test_any_key() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::InjectField,
             r#"
             ---@type { [number]: number }
@@ -129,7 +129,7 @@ mod test {
     #[test]
     fn test_issue_264() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::InjectField,
             r#"
                 local a = { 'a' }
@@ -153,7 +153,7 @@ mod test {
     #[test]
     fn test_tuple() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::InjectField,
             r#"
                 local a = { 'a' }
@@ -161,7 +161,7 @@ mod test {
         "#
         ));
 
-        // assert!(!ws.check_code_for(
+        // assert!(!ws.has_no_diagnostic(
         //     DiagnosticCode::InjectField,
         //     r#"
         //         ---@type [ 'a' ]
@@ -184,14 +184,14 @@ mod test {
             return export
             "#,
         );
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::InjectField,
             r#"
             local a = require("a")
             a.newField = 1
             "#,
         ));
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::InjectField,
             r#"
             local a = require("a")
@@ -211,14 +211,14 @@ mod test {
             }
             "#,
         );
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::InjectField,
             r#"
             local a = require("a")
             a.newField = 1
             "#,
         ));
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::InjectField,
             r#"
             local a = require("a")
@@ -243,7 +243,7 @@ mod test {
             vim.g = {}
             "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::InjectField,
             r#"
             if vim.g.aaa then

--- a/crates/emmylua_code_analysis/src/diagnostic/test/missing_fields_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/missing_fields_test.rs
@@ -5,7 +5,7 @@ mod tests {
     #[test]
     fn test_missing_fields() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::MissingFields,
             r#"
             ---@class test
@@ -16,7 +16,7 @@ mod tests {
         "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::MissingFields,
             r#"
             ---@class test1
@@ -29,7 +29,7 @@ mod tests {
         "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingFields,
             r#"
             ---@class test3
@@ -46,7 +46,7 @@ mod tests {
         "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingFields,
             r#"
             ---@class test5
@@ -62,7 +62,7 @@ mod tests {
         "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingFields,
             r#"
             ---@class test7
@@ -72,7 +72,7 @@ mod tests {
         "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingFields,
             r#"
             ---@class test8
@@ -86,7 +86,7 @@ mod tests {
     #[test]
     fn test_override_optional() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::MissingFields,
             r#"
             ---@class test1
@@ -105,7 +105,7 @@ mod tests {
     #[test]
     fn test_generic() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::MissingFields,
             r#"
             ---@class test1<T>
@@ -121,7 +121,7 @@ mod tests {
     #[test]
     fn test_object_type() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::MissingFields,
             r#"
             ---@class test1: { a: number }
@@ -136,7 +136,7 @@ mod tests {
     #[test]
     fn test_issue_262() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingFields,
             r#"
 --- @class D11.Opts
@@ -153,7 +153,7 @@ foo({})
     #[test]
     fn test_1() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingFields,
             r#"
                 ---@type table
@@ -167,7 +167,7 @@ foo({})
     #[test]
     fn test_issue_296() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
                 ---@generic T
@@ -192,7 +192,7 @@ foo({})
     #[test]
     fn test_issue_302() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingFields,
             r#"
                 ---@class data
@@ -218,7 +218,7 @@ foo({})
     #[test]
     fn test_issue_449() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::MissingFields,
             r#"
             ---@class D31.A
@@ -249,7 +249,7 @@ foo({})
         ---@field list table<integer, T> | RingBuffer<T>
         "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingFields,
             r#"
             ---@type LiveList

--- a/crates/emmylua_code_analysis/src/diagnostic/test/missing_parameter_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/missing_parameter_test.rs
@@ -6,7 +6,7 @@ mod test {
     fn test_issue_276() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingParameter,
             r#"
                 --- @param a string
@@ -25,7 +25,7 @@ mod test {
     fn test_issue_249() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingParameter,
             r#"
             ---@param path string
@@ -45,7 +45,7 @@ mod test {
     fn test_1() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingParameter,
             r#"
             ---@class A
@@ -64,7 +64,7 @@ mod test {
     fn test_issue_98() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingParameter,
             r#"
         ---@param callback fun(i?: integer)
@@ -80,7 +80,7 @@ mod test {
     fn test_multi_return() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingParameter,
             r#"
             ---@param a number
@@ -100,7 +100,7 @@ mod test {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::MissingParameter,
             r#"
             ---@param a number
@@ -124,7 +124,7 @@ mod test {
     fn test_table_unpack() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingParameter,
             r#"
             local table = {}
@@ -151,7 +151,7 @@ mod test {
     #[test]
     fn test_alias() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingParameter,
             r#"
             ---@alias Serialization.SupportTypes
@@ -169,7 +169,7 @@ mod test {
     #[test]
     fn test_issue_450() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for_namespace(
+        assert!(!ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::MissingParameter,
             r#"
                 ---@class D31.A
@@ -182,7 +182,7 @@ mod test {
         "#
         ));
 
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::MissingParameter,
             r#"
                 ---@class D31.A
@@ -219,7 +219,7 @@ mod test {
         "#,
         );
 
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::MissingParameter,
             r#"
             test(1, getNumbers())
@@ -231,7 +231,7 @@ mod test {
     fn test_call_operator_implicit_self() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingParameter,
             r#"
                 ---@class Task
@@ -257,7 +257,7 @@ mod test {
     fn test_call_overload_named_self_is_not_stripped() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::MissingParameter,
             r#"
                 ---@class Callable
@@ -269,7 +269,7 @@ mod test {
         "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingParameter,
             r#"
                 ---@class Callable
@@ -286,7 +286,7 @@ mod test {
     fn test_call_overload_self_type_is_not_stripped() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::MissingParameter,
             r#"
                 ---@class Callable
@@ -298,7 +298,7 @@ mod test {
         "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::MissingParameter,
             r#"
                 ---@class Callable

--- a/crates/emmylua_code_analysis/src/diagnostic/test/need_check_nil_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/need_check_nil_test.rs
@@ -6,7 +6,7 @@ mod test {
     fn test_issue_245() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::NeedCheckNil,
             r#"
         local a --- @type table?
@@ -17,7 +17,7 @@ mod test {
     #[test]
     fn test_issue_402() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::NeedCheckNil,
             r#"
             ---@class A
@@ -36,7 +36,7 @@ mod test {
     #[test]
     fn test_issue_474() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::NeedCheckNil,
             r#"
             ---@class Range4
@@ -66,7 +66,7 @@ mod test {
             ---@field get2 fun(self: self, a: number): Cast1?
         "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::NeedCheckNil,
             r#"
                 ---@type Cast1
@@ -81,7 +81,7 @@ mod test {
     #[test]
     fn test_issue_895_891() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::NeedCheckNil,
             r#"
         local t = {
@@ -103,7 +103,7 @@ mod test {
     #[test]
     fn test_issue_886() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
         ---@type string[]

--- a/crates/emmylua_code_analysis/src/diagnostic/test/param_type_check_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/param_type_check_test.rs
@@ -8,7 +8,7 @@ mod test {
     fn test_issue_216() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@alias F1 fun(x: integer):integer
@@ -26,7 +26,7 @@ mod test {
     fn test_issue_82() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@generic F: function
@@ -45,14 +45,14 @@ mod test {
     fn test_issue_75() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             local a, b = pcall(string.rep, "a", "w")
         "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             local a, b = pcall(string.rep, "a", 10000)
@@ -64,7 +64,7 @@ mod test {
     fn test_issue_85() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
         ---@param a table | nil
@@ -86,7 +86,7 @@ mod test {
     fn test_issue_84() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
         ---@param _a string[]
@@ -114,7 +114,7 @@ mod test {
     fn test_issue_83() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
         ---@param _t table<any, string>
@@ -134,7 +134,7 @@ mod test {
     fn test_issue_113() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@enum Baz
@@ -160,7 +160,7 @@ mod test {
     fn test_issue_111() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
         local Table = {}
@@ -195,14 +195,14 @@ mod test {
         "#,
         );
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
         mergeInto({}, 1)
         "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
         mergeInto({}, {}, {})
@@ -214,7 +214,7 @@ mod test {
     fn test_issue_102() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
         ---@param _kind '' | 'Nr' | 'Ln' | 'Cul'
@@ -231,7 +231,7 @@ mod test {
     fn test_issue_95() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
         local range ---@type { [1]: integer, [2]: integer }
@@ -245,7 +245,7 @@ mod test {
     fn test_issue_135() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
         ---@alias A
@@ -264,7 +264,7 @@ mod test {
     fn test_colon_call_and_not_colon_define() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@class Test
@@ -278,7 +278,7 @@ mod test {
         "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@class Test
@@ -297,7 +297,7 @@ mod test {
     fn test_issue_148() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             local a = (''):format()
@@ -309,7 +309,7 @@ mod test {
     fn test_generic_dots_param() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             local d = select(1, 1, 2, 3)
@@ -321,7 +321,7 @@ mod test {
     fn test_bool_as_type() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
         --- @param _x string|true
@@ -336,7 +336,7 @@ mod test {
     fn test_function() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@param sorter function
@@ -354,7 +354,7 @@ mod test {
     fn test_table_array() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                 ---@generic K, V
@@ -376,7 +376,7 @@ mod test {
     fn test_table_class() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                 ---@param t table
@@ -397,7 +397,7 @@ mod test {
     fn test_table_1() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                 ---@param t table[]
@@ -416,7 +416,7 @@ mod test {
     fn test_pairs() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                 ---@diagnostic disable: missing-return
@@ -439,7 +439,7 @@ mod test {
     #[test]
     fn test_issue_278() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
         local a --- @type type|'callable'
@@ -451,7 +451,7 @@ mod test {
     #[test]
     fn test_issue_696() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
         local ty --- @type type|fun(x:any): boolean
@@ -470,7 +470,7 @@ mod test {
     fn test_4() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@class D13.Meta
@@ -490,7 +490,7 @@ mod test {
     #[test]
     fn test_issue_286() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                 local a --- @type boolean
@@ -516,7 +516,7 @@ mod test {
     #[test]
     fn test_issue_287() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                 ---@param a table
@@ -536,7 +536,7 @@ mod test {
     fn test_issue_336() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             --- @param b string
@@ -554,7 +554,7 @@ mod test {
     fn test_issue_348() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                 local a --- @type type|'a'
@@ -567,7 +567,7 @@ mod test {
     fn test_super() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                 ---@class py.ETypeMeta
@@ -595,7 +595,7 @@ mod test {
     fn test_union_type() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@class py.Area
@@ -617,7 +617,7 @@ mod test {
     #[test]
     fn test_super_1() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                 ---@class py.SlotType: integer
@@ -637,7 +637,7 @@ mod test {
     #[test]
     fn test_alias_union_enum() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                 ---@alias EventType
@@ -672,7 +672,7 @@ mod test {
     #[test]
     fn test_alias_union_enum_2() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                 ---@alias EventType
@@ -707,7 +707,7 @@ mod test {
     #[test]
     fn test_empty_class() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                 ---@class D4.A: table<integer, string>
@@ -728,7 +728,7 @@ mod test {
     #[test]
     fn test_super_and_enum_1() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                 ---@enum AbilityType
@@ -754,7 +754,7 @@ mod test {
     #[test]
     fn test_super_and_enum_2() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                 ---@enum AbilityType
@@ -780,7 +780,7 @@ mod test {
     #[test]
     fn test_generic_array() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@class LocalTimer
@@ -800,7 +800,7 @@ mod test {
     #[test]
     fn test_function_union() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                 ---@class (partial) D21.A
@@ -837,7 +837,7 @@ mod test {
     #[test]
     fn test_function_union_2() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                 ---@class (partial) D21.A
@@ -885,7 +885,7 @@ mod test {
                 ---@field event fun(self: self, event: "游戏-初始化")
             "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                 ---@class (partial) D21.A
@@ -919,7 +919,7 @@ mod test {
     #[test]
     fn test_function_self() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                 ---@class D23.A
@@ -956,7 +956,7 @@ mod test {
                 return A
             "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             local A = require("1")
@@ -981,7 +981,7 @@ mod test {
         emmyrc.strict.array_index = false;
         ws.analysis.update_config(Arc::new(emmyrc));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                 ---@class Trigger
@@ -1011,7 +1011,7 @@ mod test {
     #[test]
     fn test_issue_487() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@param start string
@@ -1026,7 +1026,7 @@ mod test {
     #[test]
     fn test_int() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@param count integer
@@ -1045,7 +1045,7 @@ mod test {
         emmyrc.strict.doc_base_const_match_base_type = true;
         ws.analysis.update_config(Arc::new(emmyrc));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                 ---@alias IdAlias
@@ -1070,7 +1070,7 @@ mod test {
         emmyrc.strict.doc_base_const_match_base_type = true;
         ws.analysis.update_config(Arc::new(emmyrc));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                 ---@enum SlotType
@@ -1100,7 +1100,7 @@ mod test {
     #[test]
     fn test_enum_value_matching_2() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                 ---@enum DamageType
@@ -1115,7 +1115,7 @@ mod test {
     #[test]
     fn test_super_type_match() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                 ---@class UnitKey: integer
@@ -1138,7 +1138,7 @@ mod test {
     #[test]
     fn test_self() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                 ---@class test
@@ -1171,7 +1171,7 @@ mod test {
                 end
         "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@type Observer<number>
@@ -1199,7 +1199,7 @@ mod test {
                 function takesArray(a) end
             "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                 takesArray({} --[[@as A]])
@@ -1216,14 +1216,14 @@ mod test {
                 function foo(x) end
             "#,
         );
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                foo({y = "", z = ""})
             "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                foo({y = 1, z = ""})
@@ -1244,7 +1244,7 @@ mod test {
                 end
             "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             local pairs = pairs
@@ -1258,7 +1258,7 @@ mod test {
         ));
 
         // 测试泛型
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@type RingBufferSpan<number>
@@ -1290,7 +1290,7 @@ mod test {
 
             "#,
         );
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                 test({})
@@ -1314,7 +1314,7 @@ mod test {
         "#,
         );
 
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@param attr_type EditorAttrTypeAlias
@@ -1343,7 +1343,7 @@ mod test {
         "#,
         );
 
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             function Observable:test()
@@ -1356,7 +1356,7 @@ mod test {
     #[test]
     fn test_issue_841() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
         --- @class B
@@ -1387,7 +1387,7 @@ mod test {
         function ipairs(t) end
         "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@param newTesters Tester[]
@@ -1414,7 +1414,7 @@ mod test {
         function pairs(t) end
         "#,
         );
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@type {[string]: number}
@@ -1424,7 +1424,7 @@ mod test {
             end
         "#
         ));
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@alias MatchersObject {[string]: number}
@@ -1451,19 +1451,19 @@ mod test {
             end
         "#,
         );
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             test("a")
         "#,
         ));
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             test("beforeAll")
         "#,
         ));
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@type keyof SuiteHooks
@@ -1486,7 +1486,7 @@ mod test {
 
         "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             local originOnCollectStart = runner.onCollectStart
@@ -1504,7 +1504,7 @@ mod test {
         emmyrc.strict.array_index = false;
         ws.update_emmyrc(emmyrc);
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@alias MyFnA fun(): number
@@ -1537,7 +1537,7 @@ mod test {
     fn test_call_operator_implicit_self_param_type() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                 ---@class Iter

--- a/crates/emmylua_code_analysis/src/diagnostic/test/readonly_check.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/readonly_check.rs
@@ -6,7 +6,7 @@ mod test {
     fn test_issue_760() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::ReadOnly,
             r#"
             ---@readonly

--- a/crates/emmylua_code_analysis/src/diagnostic/test/redefined_local_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/redefined_local_test.rs
@@ -4,7 +4,7 @@ mod tests {
     #[test]
     fn test_issue_226() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::RedefinedLocal,
             r#"
                 function foo(...)
@@ -20,7 +20,7 @@ mod tests {
     #[test]
     fn test() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::RedefinedLocal,
             r#"
                 local x = 1
@@ -28,7 +28,7 @@ mod tests {
         "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::RedefinedLocal,
             r#"
             local function aaa()
@@ -39,7 +39,7 @@ mod tests {
         "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::RedefinedLocal,
             r#"
             local function aaa(a, b)
@@ -49,7 +49,7 @@ mod tests {
         "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::RedefinedLocal,
             r#"
             ---@class Test
@@ -66,7 +66,7 @@ mod tests {
     #[test]
     fn test_do_end() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::RedefinedLocal,
             r#"
                 do
@@ -84,7 +84,7 @@ mod tests {
     #[test]
     fn test_for() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::RedefinedLocal,
             r#"
             local function aaa()
@@ -96,7 +96,7 @@ mod tests {
         "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::RedefinedLocal,
             r#"
                 for k, v in pairs({}) do
@@ -110,14 +110,14 @@ mod tests {
     #[test]
     fn test_issue_481() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::RedefinedLocal,
             r#"
                 local a = function(a) -- 不应该报错, 参数`a`先被定义, 然后再是局部变量`a`
                 end
         "#
         ));
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::RedefinedLocal,
             r#"
                 local a

--- a/crates/emmylua_code_analysis/src/diagnostic/test/redundant_parameter_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/redundant_parameter_test.rs
@@ -6,7 +6,7 @@ mod test {
     fn test() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::RedundantParameter,
             r#"
             ---@class Test
@@ -20,7 +20,7 @@ mod test {
         "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::RedundantParameter,
             r#"
             ---@class Test2
@@ -34,7 +34,7 @@ mod test {
         "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::RedundantParameter,
             r#"
             ---@class A
@@ -53,7 +53,7 @@ mod test {
     fn test_1() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::RedundantParameter,
             r#"
                 ---@type fun(...)[]
@@ -69,7 +69,7 @@ mod test {
     fn test_dots() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::RedundantParameter,
             r#"
             ---@class Test
@@ -91,7 +91,7 @@ mod test {
     fn test_issue_360() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::RedundantParameter,
             r#"
                 ---@alias buz number
@@ -109,7 +109,7 @@ mod test {
     #[test]
     fn test_function_param() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::RedundantParameter,
             r#"
                 ---@class D30
@@ -153,7 +153,7 @@ mod test {
         //     end)
         //     "#,
         // );
-        // assert!(!ws.check_code_for(
+        // assert!(!ws.has_no_diagnostic(
         //     DiagnosticCode::RedundantParameter,
         //     r#"
         //     sum(1, 2, 3)
@@ -169,7 +169,7 @@ mod test {
             _nop = function() end
             "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::RedundantParameter,
             r#"
             function a(...) _nop(...) end

--- a/crates/emmylua_code_analysis/src/diagnostic/test/require_module_visibility_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/require_module_visibility_test.rs
@@ -19,7 +19,7 @@ mod tests {
                 "#,
         );
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::RequireModuleNotVisible,
             r#"
                 local a = require("test")
@@ -48,7 +48,7 @@ mod tests {
                 "#,
             );
 
-            assert!(ws.check_code_for(
+            assert!(ws.has_no_diagnostic(
                 DiagnosticCode::RequireModuleNotVisible,
                 r#"
                 local a = require("testA")
@@ -67,7 +67,7 @@ mod tests {
                 "#,
             );
 
-            assert!(!ws.check_code_for(
+            assert!(!ws.has_no_diagnostic(
                 DiagnosticCode::RequireModuleNotVisible,
                 r#"
                 local a = require("testB")
@@ -95,7 +95,7 @@ mod tests {
                 "#,
         );
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::RequireModuleNotVisible,
             r#"
                 local a = require("test")
@@ -122,7 +122,7 @@ mod tests {
                 "#,
         );
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::RequireModuleNotVisible,
             r#"
                 local a = require("test")
@@ -148,7 +148,7 @@ mod tests {
                 "#,
         );
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::RequireModuleNotVisible,
             r#"
                 local a = require("test")
@@ -182,7 +182,7 @@ mod tests {
                 "#,
         );
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::RequireModuleNotVisible,
             r#"
                 local a = require("test")
@@ -218,7 +218,7 @@ mod tests {
                 "#,
         );
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::RequireModuleNotVisible,
             r#"
                 local a = require("test")
@@ -255,7 +255,7 @@ mod tests {
                 "#,
         );
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::RequireModuleNotVisible,
             r#"
                 local a = require("test")

--- a/crates/emmylua_code_analysis/src/diagnostic/test/return_type_mismatch_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/return_type_mismatch_test.rs
@@ -5,7 +5,7 @@ mod tests {
     #[test]
     fn test_issue_242() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
                 ---@class A
@@ -22,7 +22,7 @@ mod tests {
         "#
         ));
 
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
                 local setmetatable = setmetatable
@@ -38,7 +38,7 @@ mod tests {
         "#
         ));
 
-        assert!(ws.check_code_for_namespace(
+        assert!(ws.has_no_diagnostic_in_namespace(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
                 ---@class A
@@ -59,7 +59,7 @@ mod tests {
     fn test_issue_220() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
             --- @class A
@@ -80,7 +80,7 @@ mod tests {
     fn test_return_type_mismatch() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
             ---@class diagnostic.Test1
@@ -93,7 +93,7 @@ mod tests {
         "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
             ---@return string
@@ -103,7 +103,7 @@ mod tests {
         "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
             ---@class diagnostic.Test2
@@ -115,7 +115,7 @@ mod tests {
             end
         "#
         ));
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
             ---@return number
@@ -135,7 +135,7 @@ mod tests {
     fn test_discriminated_union_assignment_keeps_branch_narrowing() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
             ---@class Foo
@@ -164,7 +164,7 @@ mod tests {
     fn test_discriminated_union_partial_assignment_keeps_branch_narrowing() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
             ---@class Foo
@@ -195,7 +195,7 @@ mod tests {
     fn test_discriminated_union_partial_literal_assignment_keeps_branch_narrowing() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
             ---@class Foo
@@ -225,7 +225,7 @@ mod tests {
     fn test_exact_string_reassignment_in_narrowed_branch_keeps_return_literal() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
             ---@param x string|number
@@ -246,7 +246,7 @@ mod tests {
     fn test_return_overload_mixed_guards_keep_return_narrowing() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
             ---@generic T, E
@@ -287,7 +287,7 @@ mod tests {
     fn test_variadic_return_type_mismatch() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
             ---@return number, any...
@@ -302,7 +302,7 @@ mod tests {
     fn test_issue_146() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
             local function bar()
@@ -323,7 +323,7 @@ mod tests {
     fn test_issue_150() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::RedundantReturnValue,
             r#"
             function bar(a)
@@ -337,7 +337,7 @@ mod tests {
     fn test_return_dots_syntax_error() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::SyntaxError,
             r#"
             function bar()
@@ -345,7 +345,7 @@ mod tests {
             end
             "#
         ));
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::SyntaxError,
             r#"
             function bar()
@@ -359,7 +359,7 @@ mod tests {
     fn test_issue_167() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
             --- @return integer?, integer?
@@ -378,7 +378,7 @@ mod tests {
     fn test_as_return_type() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
             local function dd()
@@ -398,7 +398,7 @@ mod tests {
     fn test_1() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
                 ---@return string?
@@ -415,7 +415,7 @@ mod tests {
     fn test_2() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
                 ---@return any[]
@@ -432,7 +432,7 @@ mod tests {
     fn test_3() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
                 ---@return table<string, {old: any, new: any}>
@@ -449,7 +449,7 @@ mod tests {
     fn test_4() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
         // TODO 该测试被`setmetatable`强行覆盖, 未正常诊断`debug.setmetatable`
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
             ---@generic T
@@ -481,7 +481,7 @@ mod tests {
     fn test_issue_341() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
             --- @return integer
@@ -498,7 +498,7 @@ mod tests {
     fn test_supper() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
                 ---@class key: integer
@@ -515,7 +515,7 @@ mod tests {
     fn test_return_self() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
             ---@class UI
@@ -531,7 +531,7 @@ mod tests {
     #[test]
     fn test_issue_343() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
                 --- @return integer, integer
@@ -556,7 +556,7 @@ mod tests {
     #[test]
     fn test_issue_474() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
             ---@class Range4
@@ -579,7 +579,7 @@ mod tests {
     #[test]
     fn test_super_alias() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
                 ---@namespace Test
@@ -602,7 +602,7 @@ mod tests {
     #[test]
     fn test_generic_type_extends() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
                 ---@class AnonymousObserver<T>: Observer<T>
@@ -636,7 +636,7 @@ mod tests {
             end
             "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
 
@@ -662,7 +662,7 @@ mod tests {
                 end
             "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
                 ---@return Observable<integer>

--- a/crates/emmylua_code_analysis/src/diagnostic/test/syntax_error_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/syntax_error_test.rs
@@ -6,7 +6,7 @@ mod test {
     fn test_1() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::SyntaxError,
             r#"
             local function aaa(..., n)
@@ -21,7 +21,7 @@ mod test {
         let mut config = ws.get_emmyrc();
         config.runtime.version = EmmyrcLuaVersion::LuaJIT;
         ws.update_emmyrc(config);
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::SyntaxError,
             r#"
             local d = 0xFFFFFFFFFFFFFFFFULL

--- a/crates/emmylua_code_analysis/src/diagnostic/test/type_access_modifier.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/type_access_modifier.rs
@@ -26,7 +26,7 @@ mod tests {
     fn explicit_public_and_internal_access_modifiers_report_inconsistency() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::InconsistentTypeAccessModifier,
             r#"
                 ---@class (public) Foo
@@ -42,7 +42,7 @@ mod tests {
     fn implicit_and_explicit_public_access_modifiers_stay_consistent() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::InconsistentTypeAccessModifier,
             r#"
                 ---@class Foo
@@ -58,7 +58,7 @@ mod tests {
     fn implicit_public_and_internal_access_modifiers_report_inconsistency() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::InconsistentTypeAccessModifier,
             r#"
                 ---@class Foo
@@ -74,7 +74,7 @@ mod tests {
     fn private_and_implicit_public_access_modifiers_report_inconsistency() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::InconsistentTypeAccessModifier,
             r#"
                 ---@class (private) Foo
@@ -90,7 +90,7 @@ mod tests {
     fn partial_internal_access_modifiers_stay_consistent_within_same_workspace() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::InconsistentTypeAccessModifier,
             r#"
                 ---@class (partial,internal) Foo
@@ -106,7 +106,7 @@ mod tests {
     fn partial_public_and_internal_access_modifiers_report_inconsistency() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::InconsistentTypeAccessModifier,
             r#"
                 ---@class (partial,public) Foo

--- a/crates/emmylua_code_analysis/src/diagnostic/test/unbalanced_assignments_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/unbalanced_assignments_test.rs
@@ -6,14 +6,14 @@ mod tests {
     fn test() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UnbalancedAssignments,
             r#"
             local x, y, z = print()
         "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UnbalancedAssignments,
             r#"
             local x, y, z
@@ -21,21 +21,21 @@ mod tests {
         "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UnbalancedAssignments,
             r#"
             local x, y, z = 1
         "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UnbalancedAssignments,
             r#"
             local x, y, z
         "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UnbalancedAssignments,
             r#"
                 local x, y, z
@@ -43,14 +43,14 @@ mod tests {
         "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UnbalancedAssignments,
             r#"
                 X, Y, Z = 1
         "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UnbalancedAssignments,
             r#"
             T = {}
@@ -58,7 +58,7 @@ mod tests {
         "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UnbalancedAssignments,
             r#"
             T = {}
@@ -70,7 +70,7 @@ mod tests {
     #[test]
     fn test_issue_232() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UnbalancedAssignments,
             r#"
             local a, b, c = string.match("hello world", "(%w+) (%w+)")
@@ -81,7 +81,7 @@ mod tests {
     #[test]
     fn test_2() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UnbalancedAssignments,
             r#"
             ---@return any
@@ -96,7 +96,7 @@ mod tests {
     #[test]
     fn test_3() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UnbalancedAssignments,
             r#"
             ---@class D18
@@ -111,7 +111,7 @@ mod tests {
     #[test]
     fn test_pcall() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UnbalancedAssignments,
             r#"
                 ---@type any
@@ -120,7 +120,7 @@ mod tests {
             "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UnbalancedAssignments,
             r#"
                 ---@type any

--- a/crates/emmylua_code_analysis/src/diagnostic/test/undefined_doc_param_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/undefined_doc_param_test.rs
@@ -5,7 +5,7 @@ mod tests {
     #[test]
     fn test_undefined_doc_param() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UndefinedDocParam,
             r#"
             ---@param a number
@@ -15,7 +15,7 @@ mod tests {
         "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UndefinedDocParam,
             r#"
             ---@param a string

--- a/crates/emmylua_code_analysis/src/diagnostic/test/undefined_field_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/undefined_field_test.rs
@@ -7,7 +7,7 @@ mod test {
     #[test]
     fn test_1() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
                 ---@alias std.NotNull<T> T - ?
@@ -30,7 +30,7 @@ mod test {
     #[test]
     fn test() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
                 ---@class diagnostic.test3
@@ -43,7 +43,7 @@ mod test {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
                 ---@class diagnostic.test3
@@ -58,7 +58,7 @@ mod test {
     #[test]
     fn test_enum() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
                 ---@enum diagnostic.enum
@@ -73,7 +73,7 @@ mod test {
     #[test]
     fn test_issue_194() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
             local a ---@type 'A'
@@ -85,7 +85,7 @@ mod test {
     #[test]
     fn test_issue_917() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
                 ---@alias Required917<T> { [K in keyof T]: T[K]; }
@@ -103,7 +103,7 @@ mod test {
     #[test]
     fn test_any_key() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
                 ---@class LogicalOperators
@@ -121,7 +121,7 @@ mod test {
     fn test_class_key_to_class_key() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
                 --- @type table<string, integer>
@@ -136,7 +136,7 @@ mod test {
             "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
                 ---@generic K, V
@@ -165,7 +165,7 @@ mod test {
     fn test_2() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
                 local function sortCallbackOfIndex()
@@ -183,7 +183,7 @@ mod test {
     fn test_index_key_define() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
                 local Flags = {
@@ -204,7 +204,7 @@ mod test {
     fn test_issue_292() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
             --- @type {head:string}[]?
@@ -218,7 +218,7 @@ mod test {
     #[test]
     fn test_issue_317() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
                 --- @class A
@@ -234,7 +234,7 @@ mod test {
     #[test]
     fn test_issue_345() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
                 --- @class C
@@ -256,7 +256,7 @@ mod test {
     #[test]
     fn test_index_key_by_string() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
             ---@enum (key) K1
@@ -270,7 +270,7 @@ mod test {
         "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
             ---@enum (key) K2
@@ -284,7 +284,7 @@ mod test {
         "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
             ---@enum K3
@@ -302,7 +302,7 @@ mod test {
     #[test]
     fn test_unknown_type() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
                 local function test(...)
@@ -312,7 +312,7 @@ mod test {
         "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::InjectField,
             r#"
                 local function test(...)
@@ -326,7 +326,7 @@ mod test {
     #[test]
     fn test_g() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
                 print(_G['game_lua_files'])
@@ -337,7 +337,7 @@ mod test {
     #[test]
     fn test_def() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::InjectField,
             r#"
                 ---@class ECABind
@@ -360,7 +360,7 @@ mod test {
     #[test]
     fn test_enum_1() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
                 ---@enum (key) UnitAttr
@@ -380,7 +380,7 @@ mod test {
     #[test]
     fn test_enum_2() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
             ---@enum AbilityType
@@ -407,7 +407,7 @@ mod test {
     #[test]
     fn test_enum_3() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
             ---@enum (key) PlayerAttr
@@ -424,7 +424,7 @@ mod test {
     #[test]
     fn test_enum_alias() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
                 ---@enum EA
@@ -456,7 +456,7 @@ mod test {
     #[test]
     fn test_userdata() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
             ---@type any
@@ -475,7 +475,7 @@ mod test {
     #[test]
     fn test_has_nil() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
 
@@ -494,7 +494,7 @@ mod test {
     #[test]
     fn test_super_integer() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
             ---@type table<integer, string>
@@ -514,7 +514,7 @@ mod test {
     #[test]
     fn test_generic_super() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
             ---@generic Super: string
@@ -532,7 +532,7 @@ mod test {
     #[test]
     fn test_ref_field() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
                 ---@enum ReactiveFlags
@@ -562,7 +562,7 @@ mod test {
     #[test]
     fn test_string_add_enum_key() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
                 ---@class py.GameAPI
@@ -606,7 +606,7 @@ mod test {
         arg = lua_get_start_args()
         "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
             local function isDebuggerValid()
@@ -620,7 +620,7 @@ mod test {
     #[test]
     fn test_if_1() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
             ---@type table<int, string>
@@ -642,7 +642,7 @@ mod test {
                 }
         "#,
         );
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
                 ---@param p Enum
@@ -652,7 +652,7 @@ mod test {
         "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
                 ---@param p Enum
@@ -663,7 +663,7 @@ mod test {
         "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
                 ---@param p Enum
@@ -687,7 +687,7 @@ mod test {
                 }
             "#,
         );
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
 
@@ -696,7 +696,7 @@ mod test {
         "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
 
@@ -717,7 +717,7 @@ mod test {
             "#,
         );
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
                 if Flags.b then
@@ -725,7 +725,7 @@ mod test {
         "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
                 if Flags["b"] then
@@ -733,7 +733,7 @@ mod test {
         "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
                 ---@type string
@@ -743,7 +743,7 @@ mod test {
         "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
                 ---@type string
@@ -765,7 +765,7 @@ mod test {
             return export
             "#,
         );
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
             local a = require("a")
@@ -773,14 +773,14 @@ mod test {
             "#,
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
             local a = require("a").ABC
             "#,
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
             local export = {}
@@ -808,7 +808,7 @@ mod test {
         name = "beforeAll"
             "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
         local a = hooks[name]
@@ -821,7 +821,7 @@ mod test {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
         // Accessing [1] on an intersection type containing an array should not report undefined-field
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
             function test(...)
@@ -832,7 +832,7 @@ mod test {
         ));
 
         // Explicit intersection type annotation
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedField,
             r#"
             ---@type integer[] & { n: integer }

--- a/crates/emmylua_code_analysis/src/diagnostic/test/undefined_global_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/undefined_global_test.rs
@@ -5,7 +5,7 @@ mod test {
     #[test]
     fn test_issue_250() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedGlobal,
             r#"
             --- @class A
@@ -24,7 +24,7 @@ mod test {
     #[test]
     fn test_globals() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UndefinedGlobal,
             r#"
             local fact = function(n)

--- a/crates/emmylua_code_analysis/src/diagnostic/test/unknown_doc_tag.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/unknown_doc_tag.rs
@@ -13,7 +13,7 @@ mod tests {
             .enables
             .push(DiagnosticCode::UnknownDocTag);
         ws.analysis.update_config(Arc::new(emmyrc));
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UnknownDocTag,
             r#"
             ---@foobar
@@ -30,7 +30,7 @@ mod tests {
         emmyrc.doc.known_tags.push("foobar".into());
         ws.analysis.update_config(Arc::new(emmyrc));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UnknownDocTag,
             r#"
             ---@foobar

--- a/crates/emmylua_code_analysis/src/diagnostic/test/unnecessary_assert_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/unnecessary_assert_test.rs
@@ -9,7 +9,7 @@ mod test {
         config.strict.array_index = true;
         ws.analysis.update_config(config.into());
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UnnecessaryAssert,
             r#"
             ---@type boolean
@@ -47,14 +47,14 @@ mod test {
     fn test_2() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UnnecessaryAssert,
             r#"
             assert(true)
         "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UnnecessaryAssert,
             r#"
             ---@return integer
@@ -65,14 +65,14 @@ mod test {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UnnecessaryAssert,
             r#"
             assert({}, 'hi')
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UnnecessaryAssert,
             r#"
             ---@type [integer, integer]
@@ -86,28 +86,28 @@ mod test {
     fn test_impossible_assert() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UnnecessaryAssert,
             r#"
             assert(false)
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UnnecessaryAssert,
             r#"
             assert(nil)
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UnnecessaryAssert,
             r#"
             assert(nil and 5)
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UnnecessaryAssert,
             r#"
             local a = false ---@type false
@@ -115,7 +115,7 @@ mod test {
             "#
         ));
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UnnecessaryAssert,
             r#"
             ---@type integer[]

--- a/crates/emmylua_code_analysis/src/diagnostic/test/unnecessary_if_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/unnecessary_if_test.rs
@@ -5,7 +5,7 @@ mod test {
     #[test]
     fn test_issue_392() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(DiagnosticCode::UnnecessaryIf,
+        assert!(ws.has_no_diagnostic(DiagnosticCode::UnnecessaryIf,
         r#"
         local a = false ---@type boolean|nil
         if a == nil or a then -- Unnecessary `if` statement: this condition is always truthy [unnecessary-if]
@@ -18,7 +18,7 @@ mod test {
     #[test]
     fn test_issue_396() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(DiagnosticCode::UnnecessaryIf,
+        assert!(ws.has_no_diagnostic(DiagnosticCode::UnnecessaryIf,
         r#"
         local a = false ---@type 'a'|'b'
         if a ~= 'a' then -- Unnecessary `if` statement: this condition is always truthy [unnecessary-if]

--- a/crates/emmylua_code_analysis/src/diagnostic/test/unresolved_require_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/unresolved_require_test.rs
@@ -5,7 +5,7 @@ mod tests {
     #[test]
     fn test_unresolved_require() {
         let mut ws = VirtualWorkspace::new();
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::UnresolvedRequire,
             r#"
             local a = require("missing.module")
@@ -24,7 +24,7 @@ mod tests {
             "#,
         );
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UnresolvedRequire,
             r#"
             local a = require("test")
@@ -35,7 +35,7 @@ mod tests {
     #[test]
     fn test_non_literal_require() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::UnresolvedRequire,
             r#"
             local function module_name()

--- a/crates/emmylua_code_analysis/src/diagnostic/test/unused_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/unused_test.rs
@@ -5,7 +5,7 @@ mod test {
     #[test]
     fn test_749() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::Unused,
             r#"
             --- @alias Timer {start: fun(timer, delay: integer, cb: function), stop: fun()}

--- a/crates/emmylua_code_analysis/src/semantic/generic/test.rs
+++ b/crates/emmylua_code_analysis/src/semantic/generic/test.rs
@@ -222,7 +222,7 @@ result = {
         "#,
         );
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@type Warp<number>, Warp<string>
@@ -231,7 +231,7 @@ result = {
         "#,
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@type Warp<number>, Warp<string>
@@ -287,7 +287,7 @@ result = {
             end
         "#,
         );
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
 

--- a/crates/emmylua_code_analysis/src/semantic/infer/test.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/test.rs
@@ -94,8 +94,8 @@ mod test {
             x, y = t.b, 1
         "#;
 
-        assert!(!ws.check_code_for(DiagnosticCode::UndefinedField, code));
-        assert!(!ws.check_code_for(DiagnosticCode::AssignTypeMismatch, code));
+        assert!(!ws.has_no_diagnostic(DiagnosticCode::UndefinedField, code));
+        assert!(!ws.has_no_diagnostic(DiagnosticCode::AssignTypeMismatch, code));
     }
 
     #[test]

--- a/crates/emmylua_code_analysis/src/semantic/type_check/test.rs
+++ b/crates/emmylua_code_analysis/src/semantic/type_check/test.rs
@@ -155,7 +155,7 @@ mod test {
     fn test_issue_634() {
         let mut ws = VirtualWorkspace::new();
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             --- @class A
@@ -190,7 +190,7 @@ mod test {
         "#,
         );
 
-        assert!(!ws.check_code_for(
+        assert!(!ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@type Holder<string>, NumberHolder
@@ -199,7 +199,7 @@ mod test {
         "#
         ));
 
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@type Holder<string>, StringHolderWith<table>
@@ -222,7 +222,7 @@ mod test {
         );
 
         // Verify via diagnostic: passing intersection type to a table parameter should not error
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@param t table
@@ -235,7 +235,7 @@ mod test {
         ));
 
         // Also verify: assigning intersection to table should not error
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::AssignTypeMismatch,
             r#"
             ---@type integer[] & { n: integer }
@@ -254,7 +254,7 @@ mod test {
         );
 
         // Intersection type should be assignable to an array parameter (non-generic)
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@param t integer[]
@@ -267,7 +267,7 @@ mod test {
         ));
 
         // Intersection type should be assignable to a generic array parameter
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@generic V
@@ -282,7 +282,7 @@ mod test {
         ));
 
         // Intersection type should be assignable to table<int, V>
-        assert!(ws.check_code_for(
+        assert!(ws.has_no_diagnostic(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@generic V

--- a/crates/emmylua_code_analysis/src/test_lib/mod.rs
+++ b/crates/emmylua_code_analysis/src/test_lib/mod.rs
@@ -152,7 +152,7 @@ impl VirtualWorkspace {
     }
 
     /// 只执行对应诊断代码的检查, 必须要在对应的`Checker`中为`const CODES`添加对应的诊断代码
-    pub fn check_code_for(&mut self, diagnostic_code: DiagnosticCode, block_str: &str) -> bool {
+    pub fn has_no_diagnostic(&mut self, diagnostic_code: DiagnosticCode, block_str: &str) -> bool {
         // 只启用对应的诊断
         self.analysis.diagnostic.enable_only(diagnostic_code);
         let file_id = self.def(block_str);
@@ -173,12 +173,12 @@ impl VirtualWorkspace {
         true
     }
 
-    pub fn check_code_for_namespace(
+    pub fn has_no_diagnostic_in_namespace(
         &mut self,
         diagnostic_code: DiagnosticCode,
         block_str: &str,
     ) -> bool {
-        self.check_code_for(
+        self.has_no_diagnostic(
             diagnostic_code,
             &format!(
                 "---@namespace TestNamespace{}\n{}",


### PR DESCRIPTION
Rename check_code_for to has_no_diagnostic so assertions describe the
existing behavior directly.

Assisted-by: Codex