### PR TITLE
fix(semantic): narrow rawget doc-function guards

### DIFF
--- a/crates/emmylua_code_analysis/src/compilation/test/member_infer_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/member_infer_test.rs
@@ -391,6 +391,33 @@ mod test {
     }
 
     #[test]
+    fn test_rawget_doc_function_guard_narrows_matching_index_expr() {
+        let mut ws = VirtualWorkspace::new_with_init_std_lib();
+
+        ws.def(
+            r#"
+        ---@class T
+        ---@field x? integer
+
+        ---@type T
+        local t = {}
+
+        ---@class Utils
+        ---@field get fun(tbl: T, key: "x"): std.RawGet<T, "x">
+
+        ---@type Utils
+        local utils = { get = rawget }
+
+        if utils.get(t, "x") then
+            result = t.x
+        end
+        "#,
+        );
+
+        assert_eq!(ws.expr_ty("result"), LuaType::Integer);
+    }
+
+    #[test]
     fn test_type_guard_call_narrows_matching_index_expr() {
         let mut ws = VirtualWorkspace::new();
 

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/call_flow.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/call_flow.rs
@@ -76,6 +76,14 @@ pub fn get_type_at_call_expr(
                     f,
                     condition_flow,
                 ),
+                LuaType::Call(call) => get_type_at_call_expr_by_call(
+                    db,
+                    cache,
+                    var_ref_id,
+                    call_expr,
+                    call,
+                    condition_flow,
+                ),
                 _ => Ok(ConditionFlowAction::Continue),
             }
         }


### PR DESCRIPTION
Rawget guards already narrow matching index expressions when the callee
is the built-in signature. The same helper can be exposed through a
documented function field, where its return type is stored directly on
the doc function.

Handle std.RawGet returns from doc functions in guard flow so
utils.get(t, "x") narrows t.x like rawget(t, "x").
