### PR TITLE
fix: batch large member unions

### DIFF
--- a/crates/emmylua_code_analysis/src/compilation/analyzer/unresolve/find_decl_function.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/unresolve/find_decl_function.rs
@@ -205,14 +205,15 @@ fn find_custom_type_function_member(
     let key = LuaMemberKey::from_index_key(db, cache, &index_key)?;
     if let Some(member_item) = db.get_member_index().get_member_item(&owner, &key) {
         let index_member_id = get_member_id(cache, &index_expr);
-        let mut result_type = LuaType::Never;
+        let mut result_types = Vec::new();
         for member_id in member_item.get_member_ids() {
             if index_member_id != member_id
                 && let Some(type_cache) = db.get_type_index().get_type_cache(&member_id.into())
             {
-                result_type = TypeOps::Union.apply(db, &result_type, type_cache.as_type());
+                result_types.push(type_cache.as_type().clone());
             }
         }
+        let result_type = TypeOps::union_all(db, result_types);
         if !result_type.is_never() {
             return Ok(result_type);
         }
@@ -540,7 +541,7 @@ fn find_member_by_index_table(
                     .get_member_index()
                     .get_members(&LuaMemberOwner::Element(table_range.clone()));
                 if let Some(members) = members {
-                    let mut result_type = LuaType::Never;
+                    let mut result_types = Vec::new();
                     for member in members {
                         let member_key_type = match member.get_key() {
                             LuaMemberKey::Name(s) => LuaType::StringConst(s.clone().into()),
@@ -554,10 +555,11 @@ fn find_member_by_index_table(
                                 .map(|it| it.as_type())
                                 .unwrap_or(&LuaType::Unknown);
 
-                            result_type = TypeOps::Union.apply(db, &result_type, member_type);
+                            result_types.push(member_type.clone());
                         }
                     }
 
+                    let mut result_type = TypeOps::union_all(db, result_types);
                     if !result_type.is_never() {
                         if matches!(
                             key_type,
@@ -698,7 +700,7 @@ fn find_member_by_index_union(
     infer_guard: &InferGuardRef,
     deep_guard: &mut DeepLevel,
 ) -> FunctionTypeResult {
-    let mut member_type = LuaType::Never;
+    let mut member_types = Vec::new();
     for member in union.into_vec() {
         let result = find_function_type_by_operator(
             db,
@@ -710,7 +712,7 @@ fn find_member_by_index_union(
         );
         match result {
             Ok(typ) => {
-                member_type = TypeOps::Union.apply(db, &member_type, &typ);
+                member_types.push(typ);
             }
             Err(InferFailReason::FieldNotFound) => {}
             Err(err) => {
@@ -719,6 +721,7 @@ fn find_member_by_index_union(
         }
     }
 
+    let member_type = TypeOps::union_all(db, member_types);
     if member_type.is_never() {
         return Err(InferFailReason::FieldNotFound);
     }

--- a/crates/emmylua_code_analysis/src/compilation/test/member_infer_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/member_infer_test.rs
@@ -37,6 +37,42 @@ mod test {
     }
 
     #[test]
+    fn test_issue_1075_large_table_dynamic_string_key() {
+        let mut ws = VirtualWorkspace::new_with_init_std_lib();
+        let names = (0..256)
+            .map(|i| format!("            ITEM_{i} = \"Item {i}\","))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let strings = format!(
+            r#"
+        STRINGS = {{
+            NAMES = {{
+{names}
+            }}
+        }}
+        "#
+        );
+
+        ws.def_files(vec![
+            ("strings.lua", &strings),
+            (
+                "skinsutils.lua",
+                r#"
+        function get_skin_name(name)
+            return STRINGS.NAMES[string.upper(name)]
+        end
+
+        Result = get_skin_name("item_1")
+        "#,
+            ),
+        ]);
+
+        let result_ty = ws.expr_ty("Result");
+        let expected_ty = ws.ty("string?");
+        assert!(ws.check_type(&result_ty, &expected_ty));
+    }
+
+    #[test]
     fn test_exact_missing_table_key_does_not_scan_broad_members() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 

--- a/crates/emmylua_code_analysis/src/db_index/member/lua_member_item.rs
+++ b/crates/emmylua_code_analysis/src/db_index/member/lua_member_item.rs
@@ -70,22 +70,21 @@ fn resolve_member_type(
 
             match resolve_state {
                 MemberTypeResolveState::All => {
-                    let mut typ = LuaType::Never;
+                    let mut types = Vec::new();
                     for member in members {
-                        typ = TypeOps::Union.apply(
-                            db,
-                            &typ,
+                        types.push(
                             db.get_type_index()
                                 .get_type_cache(&member.get_id().into())
                                 .ok_or(InferFailReason::UnResolveMemberType(member.get_id()))?
-                                .as_type(),
+                                .as_type()
+                                .clone(),
                         );
                     }
-                    Ok(typ)
+                    Ok(TypeOps::union_all(db, types))
                 }
                 MemberTypeResolveState::Meta => {
-                    let mut typ = LuaType::Never;
-                    let mut last_meta_type = LuaType::Never;
+                    let mut types = Vec::new();
+                    let mut last_meta_types = Vec::new();
                     for member in &members {
                         let feature = member.get_feature();
                         if feature.is_meta_decl() {
@@ -94,36 +93,35 @@ fn resolve_member_type(
                                 .get_type_cache(&member.get_id().into())
                                 .ok_or(InferFailReason::UnResolveMemberType(member.get_id()))?
                                 .as_type();
-                            last_meta_type =
-                                TypeOps::Union.apply(db, &last_meta_type, &member_type);
+                            last_meta_types.push(member_type.clone());
                             if check_member_version(db, LuaSemanticDeclId::Member(member.get_id()))
                             {
-                                typ = TypeOps::Union.apply(db, &typ, &member_type);
+                                types.push(member_type.clone());
                             }
                         }
                     }
+                    let typ = TypeOps::union_all(db, types);
                     if typ == LuaType::Never {
-                        Ok(last_meta_type)
+                        Ok(TypeOps::union_all(db, last_meta_types))
                     } else {
                         Ok(typ)
                     }
                 }
                 MemberTypeResolveState::FileDecl => {
-                    let mut typ = LuaType::Never;
+                    let mut types = Vec::new();
                     for member in &members {
                         let feature = member.get_feature();
                         if feature.is_file_decl() {
-                            typ = TypeOps::Union.apply(
-                                db,
-                                &typ,
+                            types.push(
                                 db.get_type_index()
                                     .get_type_cache(&member.get_id().into())
                                     .ok_or(InferFailReason::UnResolveMemberType(member.get_id()))?
-                                    .as_type(),
+                                    .as_type()
+                                    .clone(),
                             );
                         }
                     }
-                    Ok(typ)
+                    Ok(TypeOps::union_all(db, types))
                 }
             }
         }

--- a/crates/emmylua_code_analysis/src/db_index/type/type_ops/intersect_type.rs
+++ b/crates/emmylua_code_analysis/src/db_index/type/type_ops/intersect_type.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use crate::{DbIndex, LuaType, get_real_type};
 
 pub fn intersect_type(db: &DbIndex, source: LuaType, target: LuaType) -> LuaType {
@@ -81,7 +79,7 @@ pub fn intersect_type(db: &DbIndex, source: LuaType, target: LuaType) -> LuaType
         }
         // union ∩ non-union: (A | B) ∩ C = (A ∩ C) | (B ∩ C)
         (LuaType::Union(left), right) if !right.is_union() => {
-            let left_types = left.deref().clone().into_vec();
+            let left_types = left.into_vec();
             let mut result_types = Vec::new();
 
             for left_type in left_types {
@@ -99,7 +97,7 @@ pub fn intersect_type(db: &DbIndex, source: LuaType, target: LuaType) -> LuaType
         }
         // non-union ∩ union: A ∩ (B | C) = (A ∩ B) | (A ∩ C)
         (left, LuaType::Union(right)) if !left.is_union() => {
-            let right_types = right.deref().clone().into_vec();
+            let right_types = right.into_vec();
             let mut result_types = Vec::new();
 
             for right_type in right_types {
@@ -117,8 +115,8 @@ pub fn intersect_type(db: &DbIndex, source: LuaType, target: LuaType) -> LuaType
         }
         // union ∩ union: (A | B) ∩ (C | D) = (A ∩ C) | (A ∩ D) | (B ∩ C) | (B ∩ D)
         (LuaType::Union(left), LuaType::Union(right)) => {
-            let left_types = left.deref().clone().into_vec();
-            let right_types = right.deref().clone().into_vec();
+            let left_types = left.into_vec();
+            let right_types = right.into_vec();
             let mut result_types = Vec::new();
 
             for left_type in left_types {

--- a/crates/emmylua_code_analysis/src/db_index/type/type_ops/mod.rs
+++ b/crates/emmylua_code_analysis/src/db_index/type/type_ops/mod.rs
@@ -37,4 +37,11 @@ impl TypeOps {
             }
         }
     }
+
+    pub fn union_all<I>(db: &DbIndex, types: I) -> LuaType
+    where
+        I: IntoIterator<Item = LuaType>,
+    {
+        union_type::union_type_all(db, types)
+    }
 }

--- a/crates/emmylua_code_analysis/src/db_index/type/type_ops/test.rs
+++ b/crates/emmylua_code_analysis/src/db_index/type/type_ops/test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use crate::{DiagnosticCode, TypeOps, VirtualWorkspace};
+    use crate::{DiagnosticCode, LuaType, TypeOps, VirtualWorkspace};
 
     #[test]
     fn test_custom_ops() {
@@ -202,6 +202,61 @@ mod tests {
         let sig_first = TypeOps::Union.apply(ws.get_db_mut(), &sig, &doc);
         assert!(!sig_first.is_union());
         assert_eq!(ws.humanize_type(sig_first), "fun() -> boolean");
+    }
+
+    #[test]
+    fn test_union_all_keeps_union_semantics() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+        ---@return boolean
+        function foo()
+            return true
+        end
+        "#,
+        );
+
+        assert_eq!(
+            TypeOps::union_all(ws.get_db_mut(), Vec::new()),
+            LuaType::Never
+        );
+
+        let number = ws.ty("number");
+        let integer = ws.ty("integer");
+        assert_eq!(
+            TypeOps::union_all(ws.get_db_mut(), vec![number, integer]),
+            ws.ty("number")
+        );
+        let number = ws.ty("number");
+        assert_eq!(
+            TypeOps::union_all(ws.get_db_mut(), vec![number, LuaType::DocIntegerConst(1)]),
+            ws.ty("number")
+        );
+
+        let integer = ws.ty("integer");
+        let one = ws.ty("1");
+        assert_eq!(
+            TypeOps::union_all(ws.get_db_mut(), vec![integer, one]),
+            ws.ty("integer")
+        );
+
+        let a = ws.ty("'a'");
+        let b = ws.ty("'b'");
+        assert_eq!(
+            TypeOps::union_all(ws.get_db_mut(), vec![a.clone(), b, a]),
+            ws.ty("'a'|'b'")
+        );
+
+        let doc = ws.ty("fun(): boolean");
+        let sig = ws.expr_ty("foo");
+        let callable = TypeOps::union_all(ws.get_db_mut(), vec![doc.clone(), sig.clone()]);
+        assert!(!callable.is_union());
+        assert_eq!(ws.humanize_type(callable), "fun() -> boolean");
+
+        let single_union = LuaType::from_vec(vec![doc, sig]);
+        let callable = TypeOps::union_all(ws.get_db_mut(), vec![single_union]);
+        assert!(!callable.is_union());
+        assert_eq!(ws.humanize_type(callable), "fun() -> boolean");
     }
 
     #[test]

--- a/crates/emmylua_code_analysis/src/db_index/type/type_ops/union_type.rs
+++ b/crates/emmylua_code_analysis/src/db_index/type/type_ops/union_type.rs
@@ -1,4 +1,4 @@
-use std::{ops::Deref, sync::Arc};
+use std::sync::Arc;
 
 use crate::{DbIndex, LuaFunctionType, LuaType, LuaUnionType, get_real_type};
 
@@ -9,9 +9,104 @@ pub fn union_type(db: &DbIndex, source: LuaType, target: LuaType) -> LuaType {
     canonicalize_callable_union(db, union_type_impl(&match_source, source, target))
 }
 
+/// Union a batch of types with the same semantics as repeated `union_type`.
+///
+/// Empty batches return `Never`.
+pub fn union_type_all<I>(db: &DbIndex, types: I) -> LuaType
+where
+    I: IntoIterator<Item = LuaType>,
+{
+    let mut result_types = Vec::new();
+    for typ in types {
+        match typ {
+            LuaType::Never => {}
+            LuaType::Any => return LuaType::Any,
+            _ => result_types.push(typ),
+        }
+    }
+    if result_types.is_empty() {
+        return LuaType::Never;
+    }
+    // `LuaType::from_vec` only does structural normalization. Use it only when
+    // no pairwise union rule, alias lookup, or callable canonicalization can matter.
+    if can_use_structural_union(&result_types) {
+        return LuaType::from_vec(result_types);
+    }
+
+    let mut result = LuaType::Never;
+    for typ in result_types {
+        result = union_type(db, result, typ);
+    }
+    result
+}
+
 pub(crate) fn union_type_shallow(source: LuaType, target: LuaType) -> LuaType {
     let match_source = source.clone();
     union_type_impl(&match_source, source, target)
+}
+
+/// Return true when `LuaType::from_vec` is enough to match `Union.apply` folding.
+///
+/// This is a conservative whole-batch check. We can reject early when a member
+/// needs semantic handling (`Ref`, nested union, callable variants), but we cannot
+/// accept early because most union rules depend on pairs that may appear later:
+/// `number | integer`, `string | "x"`, `true | false`, and `table | table const`.
+fn can_use_structural_union(types: &[LuaType]) -> bool {
+    let mut has_number = false;
+    let mut has_number_variant = false;
+    let mut has_integer = false;
+    let mut has_integer_const = false;
+    let mut has_string = false;
+    let mut has_string_const = false;
+    let mut has_boolean = false;
+    let mut boolean_const_count = 0;
+    let mut has_table = false;
+    let mut has_table_const = false;
+
+    for typ in types {
+        match typ {
+            LuaType::Union(_)
+            | LuaType::Ref(_)
+            | LuaType::MultiLineUnion(_)
+            | LuaType::DocFunction(_)
+            | LuaType::Signature(_) => return false,
+            LuaType::Number => has_number = true,
+            LuaType::Integer => {
+                has_number_variant = true;
+                has_integer = true;
+            }
+            LuaType::IntegerConst(_) => {
+                has_number_variant = true;
+                has_integer_const = true;
+            }
+            LuaType::FloatConst(_) => {
+                has_number_variant = true;
+            }
+            LuaType::DocIntegerConst(_) => {
+                has_number_variant = true;
+                has_integer_const = true;
+            }
+            LuaType::String => has_string = true,
+            LuaType::StringConst(_) | LuaType::DocStringConst(_) => has_string_const = true,
+            LuaType::Boolean => has_boolean = true,
+            LuaType::BooleanConst(_) | LuaType::DocBooleanConst(_) => boolean_const_count += 1,
+            LuaType::Table => has_table = true,
+            LuaType::TableConst(_) => has_table_const = true,
+            _ => {}
+        }
+
+        if has_number && has_number_variant
+            || has_integer && has_integer_const
+            || has_string && has_string_const
+            || has_boolean && boolean_const_count > 0
+            || boolean_const_count > 1
+            || has_table && has_table_const
+        {
+            return false;
+        }
+    }
+
+    true
 }
 
 fn union_type_impl(match_source: &LuaType, source: LuaType, target: LuaType) -> LuaType {
@@ -85,7 +180,6 @@ fn union_type_impl(match_source: &LuaType, source: LuaType, target: LuaType) -> 
         }
         // union
         (LuaType::Union(left), right) if !right.is_union() => {
-            let left = left.deref().clone();
             let mut types = left.into_vec();
             if types.contains(right) {
                 return source.clone();
@@ -95,7 +189,6 @@ fn union_type_impl(match_source: &LuaType, source: LuaType, target: LuaType) -> 
             LuaType::Union(LuaUnionType::from_vec(types).into())
         }
         (left, LuaType::Union(right)) if !left.is_union() => {
-            let right = right.deref().clone();
             let mut types = right.into_vec();
             if types.contains(left) {
                 return target.clone();
@@ -129,8 +222,16 @@ fn canonicalize_callable_union(db: &DbIndex, ty: LuaType) -> LuaType {
         return ty;
     };
 
+    let members = union.into_vec();
+    if !members
+        .iter()
+        .any(|ty| matches!(ty, LuaType::DocFunction(_) | LuaType::Signature(_)))
+    {
+        return LuaType::from_vec(members);
+    }
+
     let mut types = Vec::new();
-    for member in union.into_vec() {
+    for member in members {
         let member_callable = as_callable_type(db, &member);
         if types.iter().any(|existing| {
             existing == &member

--- a/crates/emmylua_code_analysis/src/db_index/type/types/predicates.rs
+++ b/crates/emmylua_code_analysis/src/db_index/type/types/predicates.rs
@@ -63,7 +63,11 @@ impl LuaType {
     pub fn is_number(&self) -> bool {
         matches!(
             self,
-            LuaType::Number | LuaType::Integer | LuaType::IntegerConst(_) | LuaType::FloatConst(_)
+            LuaType::Number
+                | LuaType::Integer
+                | LuaType::IntegerConst(_)
+                | LuaType::DocIntegerConst(_)
+                | LuaType::FloatConst(_)
         )
     }
 

--- a/crates/emmylua_code_analysis/src/semantic/infer/infer_index/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/infer_index/mod.rs
@@ -448,8 +448,8 @@ fn infer_matching_member_key_type(
     let mut members = db.get_member_index().get_members(owner)?;
     members.sort_by(|a, b| a.get_key().cmp(b.get_key()));
 
-    let mut result_type = LuaType::Never;
-    let mut has_match = false;
+    // Build the union once; broad dynamic keys can match thousands of table members.
+    let mut result_types = Vec::new();
     for member in members {
         let member_key_type = match member.get_key() {
             LuaMemberKey::Name(s) => LuaType::StringConst(s.clone().into()),
@@ -463,12 +463,11 @@ fn infer_matching_member_key_type(
                 .map(|it| it.as_type())
                 .unwrap_or(&LuaType::Unknown);
 
-            has_match = true;
-            result_type = TypeOps::Union.apply(db, &result_type, member_type);
+            result_types.push(member_type.clone());
         }
     }
 
-    if !has_match {
+    if result_types.is_empty() {
         return None;
     }
 
@@ -476,10 +475,10 @@ fn infer_matching_member_key_type(
         key_type,
         LuaType::String | LuaType::Number | LuaType::Integer
     ) {
-        result_type = TypeOps::Union.apply(db, &result_type, &LuaType::Nil);
+        result_types.push(LuaType::Nil);
     }
 
-    Some(result_type)
+    Some(LuaType::from_vec(result_types))
 }
 
 fn get_type_member_key(db: &DbIndex, key_type: &LuaType) -> Option<Vec<LuaMemberKey>> {
@@ -521,32 +520,28 @@ fn infer_tuple_member(
                 };
             }
             LuaType::Integer => {
-                let mut result = LuaType::Never;
-                for typ in tuple_type.get_types() {
-                    result = TypeOps::Union.apply(db, &result, typ);
-                }
-
-                let index_prefix_expr = match &lookup.index_expr {
-                    LuaIndexMemberExpr::TableField(_) => {
-                        return Ok(result);
+                let mut result_types = tuple_type.get_types().to_vec();
+                let include_nil = match &lookup.index_expr {
+                    LuaIndexMemberExpr::TableField(_) => false,
+                    _ => {
+                        let index_prefix_expr = lookup
+                            .index_expr
+                            .get_prefix_expr()
+                            .ok_or(InferFailReason::None)?;
+                        match &index_key {
+                            LuaIndexKey::Expr(expr) => {
+                                !check_iter_var_range(db, cache, expr, index_prefix_expr)
+                                    .unwrap_or(false)
+                            }
+                            _ => false,
+                        }
                     }
-                    _ => lookup
-                        .index_expr
-                        .get_prefix_expr()
-                        .ok_or(InferFailReason::None)?,
                 };
-                let maybe_iter_var = match &index_key {
-                    LuaIndexKey::Expr(expr) => expr,
-                    _ => return Ok(result),
-                };
-                if check_iter_var_range(db, cache, maybe_iter_var, index_prefix_expr)
-                    .unwrap_or(false)
-                {
-                    return Ok(result);
+                if include_nil {
+                    result_types.push(LuaType::Nil);
                 }
 
-                result = TypeOps::Union.apply(db, &result, &LuaType::Nil);
-                return Ok(result);
+                return Ok(TypeOps::union_all(db, result_types));
             }
             _ => {}
         },
@@ -604,8 +599,7 @@ fn infer_union_member(
     lookup: &MemberLookupQuery,
     infer_guard: &InferGuardRef,
 ) -> InferResult {
-    let mut member_type = LuaType::Never;
-    let mut has_member = false;
+    let mut member_types = Vec::new();
     let mut has_missing_member = false;
     let mut meet_string = false;
     for sub_type in union_type.into_vec() {
@@ -618,8 +612,7 @@ fn infer_union_member(
         let result = infer_member_by_lookup(db, cache, &sub_type, lookup, &infer_guard.fork());
         match result {
             Ok(typ) => {
-                has_member = true;
-                member_type = TypeOps::Union.apply(db, &member_type, &typ);
+                member_types.push(typ);
             }
             Err(_) => {
                 has_missing_member = true;
@@ -627,15 +620,15 @@ fn infer_union_member(
         }
     }
 
-    if !has_member {
+    if member_types.is_empty() {
         return Err(InferFailReason::FieldNotFound);
     }
 
     if has_missing_member {
-        member_type = TypeOps::Union.apply(db, &member_type, &LuaType::Nil);
+        member_types.push(LuaType::Nil);
     }
 
-    Ok(member_type)
+    Ok(TypeOps::union_all(db, member_types))
 }
 
 fn infer_intersection_member(
@@ -929,15 +922,13 @@ fn infer_member_by_index_union(
     key_type: &LuaType,
     infer_guard: &InferGuardRef,
 ) -> InferResult {
-    let mut member_type = LuaType::Never;
-    let mut has_member = false;
+    let mut member_types = Vec::new();
     for member in union.into_vec() {
         let result =
             infer_member_by_operator_key_type(db, cache, &member, key_type, &infer_guard.fork());
         match result {
             Ok(typ) => {
-                has_member = true;
-                member_type = TypeOps::Union.apply(db, &member_type, &typ);
+                member_types.push(typ);
             }
             Err(InferFailReason::FieldNotFound) => {}
             Err(err) => {
@@ -946,11 +937,11 @@ fn infer_member_by_index_union(
         }
     }
 
-    if !has_member {
+    if member_types.is_empty() {
         return Err(InferFailReason::FieldNotFound);
     }
 
-    Ok(member_type)
+    Ok(TypeOps::union_all(db, member_types))
 }
 
 fn infer_member_by_index_intersection(

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/mod.rs
@@ -927,15 +927,13 @@ fn project_union_member_type(
     union_types: Vec<LuaType>,
     member_key: crate::LuaMemberKey,
 ) -> Result<Option<LuaType>, InferFailReason> {
-    let mut result_type = LuaType::Never;
-    let mut has_member = false;
+    let mut result_types = Vec::new();
     let mut has_missing_member = false;
 
     for sub_type in union_types {
         match project_member_type(db, &sub_type, member_key.clone())? {
             Some(member_type) => {
-                has_member = true;
-                result_type = TypeOps::Union.apply(db, &result_type, &member_type);
+                result_types.push(member_type);
             }
             None => {
                 has_missing_member = true;
@@ -943,13 +941,13 @@ fn project_union_member_type(
         }
     }
 
-    if !has_member {
+    if result_types.is_empty() {
         return Ok(None);
     }
     if has_missing_member {
-        result_type = TypeOps::Union.apply(db, &result_type, &LuaType::Nil);
+        result_types.push(LuaType::Nil);
     }
-    Ok(Some(result_type))
+    Ok(Some(TypeOps::union_all(db, result_types)))
 }
 
 impl CorrelatedSubquery {

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/narrow_type/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/narrow_type/mod.rs
@@ -210,11 +210,7 @@ pub fn narrow_down_type(
             if source_types.is_empty() {
                 return None;
             }
-            let mut result_type = LuaType::Never;
-            for source_type in source_types {
-                result_type = TypeOps::Union.apply(db, &result_type, &source_type);
-            }
-            return Some(result_type);
+            return Some(TypeOps::union_all(db, source_types));
         }
         LuaType::Variadic(_) => return Some(source),
         LuaType::Def(type_id) | LuaType::Ref(type_id) => match real_source_ref {


### PR DESCRIPTION
## Summary

- batch repeated member union folds through `TypeOps::union_all`
- keep the batch helper semantically equivalent to repeated `Union.apply`
- add regression coverage for the large dynamic-key table lookup from #1075

Fixes #1075

## Validation

- `cargo test -p emmylua_code_analysis test_union_all_keeps_union_semantics -- --nocapture`
- `cargo test -p emmylua_code_analysis test_issue_1075_large_table_dynamic_string_key -- --nocapture`
- `cargo test -p emmylua_code_analysis`
