### PR TITLE
perf: recover scripts.zip load regression

### DIFF
--- a/crates/emmylua_code_analysis/src/compilation/analyzer/lua/stats.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/lua/stats.rs
@@ -205,7 +205,14 @@ fn set_index_expr_owner(analyzer: &mut LuaAnalyzer, var_expr: LuaVarExpr) -> Opt
     let index_expr = LuaIndexExpr::cast(var_expr.syntax().clone())?;
     let prefix_expr = index_expr.get_prefix_expr()?;
 
-    match analyzer.infer_expr(&prefix_expr.clone()) {
+    let prefix_type = match analyzer.infer_expr_no_flow(&prefix_expr) {
+        Ok(Some(prefix_type)) => Ok(prefix_type),
+        // `None` can hide nested unresolved prefixes; fall back so we keep the retry.
+        Ok(None) => analyzer.infer_expr(&prefix_expr),
+        Err(reason) => Err(reason),
+    };
+
+    match prefix_type {
         Ok(prefix_type) => {
             // Prefer declared global types for name prefixes when choosing a member owner.
             // This keeps stdlib members (like table.unpack) attached to their type defs.

--- a/crates/emmylua_code_analysis/src/compilation/analyzer/unresolve/resolve.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/unresolve/resolve.rs
@@ -18,7 +18,7 @@ use crate::{
     },
     db_index::{DbIndex, LuaMemberOwner, LuaType},
     find_members_with_key,
-    semantic::{LuaInferCache, infer_expr},
+    semantic::{LuaInferCache, infer_expr, try_infer_expr_no_flow},
 };
 
 use super::{
@@ -48,7 +48,11 @@ pub fn try_resolve_member(
     unresolve_member: &mut UnResolveMember,
 ) -> ResolveResult {
     if let Some(prefix_expr) = &unresolve_member.prefix {
-        let prefix_type = infer_expr(db, cache, prefix_expr.clone())?;
+        let prefix_type = match try_infer_expr_no_flow(db, cache, prefix_expr.clone())? {
+            Some(prefix_type) => prefix_type,
+            // `None` can hide nested unresolved prefixes; fall back so we keep the retry.
+            None => infer_expr(db, cache, prefix_expr.clone())?,
+        };
         let member_owner = match prefix_type {
             LuaType::TableConst(in_file_range) => LuaMemberOwner::Element(in_file_range),
             LuaType::Def(def_id) => {
@@ -65,7 +69,7 @@ pub fn try_resolve_member(
             LuaType::Instance(instance) => LuaMemberOwner::Element(instance.get_range().clone()),
             // is ref need extend field?
             _ => {
-                return Ok(()); // Changed from return None to return Ok(())
+                return Ok(());
             }
         };
         let member_id = unresolve_member.member_id;

--- a/crates/emmylua_code_analysis/src/compilation/test/member_infer_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/member_infer_test.rs
@@ -339,6 +339,22 @@ mod test {
     }
 
     #[test]
+    fn test_nested_unresolved_prefix_keeps_member_owner_retry() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+        M.child.leaf = 1
+        M = {
+            child = {},
+        }
+        A = M.child.leaf
+        "#,
+        );
+
+        assert_eq!(ws.expr_ty("A"), LuaType::IntegerConst(1));
+    }
+
+    #[test]
     fn test_table_expr_key_string() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 

--- a/crates/emmylua_code_analysis/src/db_index/type/type_ops/intersect_type.rs
+++ b/crates/emmylua_code_analysis/src/db_index/type/type_ops/intersect_type.rs
@@ -47,6 +47,8 @@ pub fn intersect_type(db: &DbIndex, source: LuaType, target: LuaType) -> LuaType
         // TODO: Intersecting two non-identical function types currently falls back to `never`.
         // Consider implementing a proper intersection (or overload-set semantics) for function
         // signatures instead of treating it as incompatible.
+        // same type
+        (left, right) if *left == right => source.clone(),
         // class references
         (LuaType::Ref(id1), LuaType::Ref(id2)) => {
             if id1 == id2 {
@@ -135,8 +137,6 @@ pub fn intersect_type(db: &DbIndex, source: LuaType, target: LuaType) -> LuaType
             }
         }
 
-        // same type
-        (left, right) if *left == right => source.clone(),
         _ => LuaType::Never,
     }
 }

--- a/crates/emmylua_code_analysis/src/db_index/type/types/predicates.rs
+++ b/crates/emmylua_code_analysis/src/db_index/type/types/predicates.rs
@@ -206,7 +206,7 @@ impl LuaType {
     pub fn contain_multi_return(&self) -> bool {
         match self {
             LuaType::Variadic(_) => true,
-            LuaType::Union(union) => union.into_vec().iter().any(LuaType::contain_multi_return),
+            LuaType::Union(union) => union_contains_multi_return(union),
             _ => false,
         }
     }
@@ -226,6 +226,9 @@ impl LuaType {
                     last_type.get_result_slot_type(offset)
                 }
             },
+            LuaType::Union(union) if idx == 0 && !union_contains_multi_return(union) => {
+                Some(self.clone())
+            }
             LuaType::Union(union) => {
                 let slot_types = union
                     .into_vec()
@@ -323,5 +326,13 @@ impl LuaType {
 
     pub fn is_module_ref(&self) -> bool {
         matches!(self, LuaType::ModuleRef(_))
+    }
+}
+
+fn union_contains_multi_return(union: &LuaUnionType) -> bool {
+    match union {
+        LuaUnionType::Basic(_) => false,
+        LuaUnionType::Nullable(ty) => ty.contain_multi_return(),
+        LuaUnionType::Multi(types) => types.iter().any(LuaType::contain_multi_return),
     }
 }

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/get_type_at_flow.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/get_type_at_flow.rs
@@ -1058,9 +1058,8 @@ impl<'a> FlowTypeEngine<'a> {
         explicit_var_type: Option<LuaType>,
         expr_type: LuaType,
     ) -> Result<SchedulerStep, InferFailReason> {
-        let var_ref_id = walk.query.var_ref_id.clone();
-
         if let Some(explicit_var_type) = explicit_var_type {
+            let var_ref_id = walk.query.var_ref_id.clone();
             let result_type = finish_assignment_result(
                 self.db,
                 self.cache,
@@ -1073,7 +1072,13 @@ impl<'a> FlowTypeEngine<'a> {
             return Ok(self.finish_walk(walk, result_type));
         }
 
+        // Broad RHS types replace the previous runtime type. The old path still
+        // queried the antecedent and then discarded it in finish_assignment_result.
         let reuse_antecedent_narrowing = preserves_assignment_expr_type(&expr_type);
+        if !expr_type.is_unknown() && !reuse_antecedent_narrowing {
+            return Ok(self.finish_walk(walk, expr_type));
+        }
+
         let mode = if reuse_antecedent_narrowing {
             FlowMode::WithConditions
         } else {

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/get_type_at_flow.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/get_type_at_flow.rs
@@ -206,7 +206,7 @@ impl FlowReplayQuery {
             .get(self.next_dependency_idx)
             .ok_or(InferFailReason::None)?;
 
-        match dependency_result {
+        let next_dependency_idx_on_success = match dependency_result {
             Ok(mut expr_type) => {
                 if let Some(literal_shape_type) = &dependency_query.literal_shape_type {
                     expr_type = literal_equivalent_type(literal_shape_type, &expr_type)
@@ -215,16 +215,18 @@ impl FlowReplayQuery {
 
                 self.dependency_types
                     .push((dependency_query.syntax_id, expr_type));
+                dependency_query.next_dependency_idx_on_success
             }
             Err(
                 InferFailReason::None
                 | InferFailReason::RecursiveInfer
                 | InferFailReason::FieldNotFound,
-            ) => {}
+            ) => None,
             Err(err) => return Err(err),
-        }
+        };
 
-        self.next_dependency_idx += 1;
+        self.next_dependency_idx =
+            next_dependency_idx_on_success.unwrap_or(self.next_dependency_idx + 1);
         Ok(())
     }
 
@@ -266,6 +268,7 @@ struct FlowExprTypeQuery {
     flow_id: FlowId,
     syntax_id: LuaSyntaxId,
     literal_shape_type: Option<LuaType>,
+    next_dependency_idx_on_success: Option<usize>,
 }
 
 fn collect_expr_dependency_queries(
@@ -290,12 +293,32 @@ fn collect_expr_dependency_queries(
                 flow_id,
                 syntax_id: expr.get_syntax_id(),
                 literal_shape_type: None,
+                next_dependency_idx_on_success: None,
             });
         }
         return;
     }
 
     if let LuaExpr::IndexExpr(index_expr) = expr {
+        // A resolved IndexRef overlay lets replay short-circuit the whole
+        // expression; if it fails, prefix/key overlays are still available.
+        let direct_query_idx =
+            if let Some(var_ref_id) = get_var_expr_var_ref_id(db, cache, expr.clone()) {
+                let literal_shape_type = try_infer_expr_no_flow(db, cache, expr.clone())
+                    .ok()
+                    .flatten();
+                let query_idx = dependency_queries.len();
+                dependency_queries.push(FlowExprTypeQuery {
+                    var_ref_id,
+                    flow_id: fallback_flow_id,
+                    syntax_id: expr.get_syntax_id(),
+                    literal_shape_type,
+                    next_dependency_idx_on_success: None,
+                });
+                Some(query_idx)
+            } else {
+                None
+            };
         if let Some(prefix_expr) = index_expr.get_prefix_expr() {
             collect_expr_dependency_queries(
                 db,
@@ -316,18 +339,9 @@ fn collect_expr_dependency_queries(
                 dependency_queries,
             );
         }
-        // Keep prefix/key deps first. The direct IndexRef repairs guards on
-        // the member itself, and should use the replay point's flow.
-        if let Some(var_ref_id) = get_var_expr_var_ref_id(db, cache, expr.clone()) {
-            let literal_shape_type = try_infer_expr_no_flow(db, cache, expr.clone())
-                .ok()
-                .flatten();
-            dependency_queries.push(FlowExprTypeQuery {
-                var_ref_id,
-                flow_id: fallback_flow_id,
-                syntax_id: expr.get_syntax_id(),
-                literal_shape_type,
-            });
+        if let Some(query_idx) = direct_query_idx {
+            dependency_queries[query_idx].next_dependency_idx_on_success =
+                Some(dependency_queries.len());
         }
         return;
     }


### PR DESCRIPTION
## Problem

The `scripts.zip` workload regressed heavily after `0.21.0`. On current `upstream/main`, loading the extracted `scripts/` workspace is about 3.28x slower than `0.21.0`.

This PR targets the hot paths from that workload without changing the broader inference result model:

- avoid repeated full-flow owner inference for indexed assignments
- skip assignment antecedent queries when the RHS type will replace the old flow type anyway
- short-circuit direct index replay dependencies when the direct replay succeeds
- short-circuit identical intersections before expanding union intersections

## Performance

Benchmark command shape:

```sh
target/debug/emmylua_perf compare --baseline upstream/main --head HEAD --project /tmp/emmylua-scripts/scripts --iterations 5 --no-fetch
target/debug/emmylua_perf compare --baseline 0.21.0 --head HEAD --project /tmp/emmylua-scripts/scripts --iterations 5 --no-fetch
```

The project is the extracted `scripts/` directory from `https://github.com/user-attachments/files/27706685/scripts.zip`. Times are mean ± 95% CI from release `emmylua_ls` builds.

Against current `upstream/main`:

```text
upstream/main (8c01eeca):        total 9.009s ± 0.850s, index 8.708s ± 0.915s, rss 397.5 MB ± 2.6 MB
perf/issue-1075-followups clean: total 2.073s ± 0.103s, index 1.800s ± 0.013s, rss 391.1 MB ± 5.4 MB
```

That is a 77.0% total load-time improvement and a 79.3% index-time improvement, or about 4.35x faster total load time on this workload.

Relative to `0.21.0`:

```text
0.21.0:                          total 2.744s ± 0.076s, index 2.452s ± 0.032s, rss 377.4 MB ± 3.6 MB
perf/issue-1075-followups clean: total 2.117s ± 0.109s, index 1.830s ± 0.037s, rss 392.4 MB ± 4.6 MB
```

This closes the previous 0.21.0 gap for this workload. The branch is about 22.8% faster than `0.21.0` in total load time and about 25.4% faster in index time. RSS is listed for completeness; against current `upstream/main`, this branch is lower RSS in this run.

## Tests

```sh
cargo test -p emmylua_code_analysis
cargo build --release -p emmylua_ls
target/debug/emmylua_perf compare --baseline upstream/main --head HEAD --project /tmp/emmylua-scripts/scripts --iterations 5 --no-fetch
target/debug/emmylua_perf compare --baseline 0.21.0 --head HEAD --project /tmp/emmylua-scripts/scripts --iterations 5 --no-fetch
```
