### PR TITLE
fix: make code actions follow formatter tag spacing

### DIFF
--- a/crates/emmylua_code_analysis/resources/schema.json
+++ b/crates/emmylua_code_analysis/resources/schema.json
@@ -12,7 +12,7 @@
     "codeAction": {
       "$ref": "#/$defs/EmmyrcCodeAction",
       "default": {
-        "insertSpace": false
+        "insertSpace": null
       }
     },
     "codeLens": {
@@ -491,9 +491,12 @@
       "type": "object",
       "properties": {
         "insertSpace": {
-          "description": "Add space after `---` comments when inserting `@diagnostic disable-next-line`.",
-          "type": "boolean",
-          "default": false,
+          "description": "Add space after `---` comments when inserting `@diagnostic disable-next-line`.\n\nWhen omitted, this follows the formatter's resolved\n`emmy_doc.space_between_tag_columns` setting.",
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": null,
           "x-vscode-setting": true
         }
       }

--- a/crates/emmylua_code_analysis/src/config/configs/code_action.rs
+++ b/crates/emmylua_code_analysis/src/config/configs/code_action.rs
@@ -1,23 +1,14 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct EmmyrcCodeAction {
     /// Add space after `---` comments when inserting `@diagnostic disable-next-line`.
-    #[serde(default = "default_false")]
+    ///
+    /// When omitted, this follows the formatter's resolved
+    /// `emmy_doc.space_between_tag_columns` setting.
+    #[serde(default)]
     #[schemars(extend("x-vscode-setting" = true))]
-    pub insert_space: bool,
-}
-
-impl Default for EmmyrcCodeAction {
-    fn default() -> Self {
-        Self {
-            insert_space: default_false(),
-        }
-    }
-}
-
-fn default_false() -> bool {
-    false
+    pub insert_space: Option<bool>,
 }

--- a/crates/emmylua_ls/src/handlers/code_actions/actions/build_disable_code.rs
+++ b/crates/emmylua_ls/src/handlers/code_actions/actions/build_disable_code.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use emmylua_code_analysis::{DiagnosticCode, Emmyrc, LuaDocument, SemanticModel};
+use emmylua_formatter::resolve_config_for_path;
 use emmylua_parser::{
     LuaAst, LuaAstNode, LuaComment, LuaCommentOwner, LuaDocTag, LuaDocTagDiagnostic, LuaExpr,
     LuaKind, LuaStat, LuaSyntaxNode, LuaTokenKind,
@@ -176,7 +177,7 @@ fn get_disable_next_line_text_edit(
     };
 
     let line = document.get_line(offset)?;
-    let space = if emmyrc.code_action.insert_space {
+    let space = if code_action_insert_space(emmyrc, document) {
         " "
     } else {
         ""
@@ -210,7 +211,7 @@ pub fn build_disable_file_changes(
     let first_child = first_block.children::<LuaAst>().next()?;
     let document = semantic_model.get_document();
     let emmyrc = semantic_model.get_emmyrc();
-    let space = if emmyrc.code_action.insert_space {
+    let space = if code_action_insert_space(emmyrc, &document) {
         " "
     } else {
         ""
@@ -276,6 +277,14 @@ pub fn build_disable_file_changes(
     changes.insert(uri, vec![text_edit]);
 
     Some(changes)
+}
+
+fn code_action_insert_space(emmyrc: &Emmyrc, document: &LuaDocument) -> bool {
+    emmyrc.code_action.insert_space.unwrap_or_else(|| {
+        resolve_config_for_path(Some(document.get_file_path().as_path()), None)
+            .map(|resolved| resolved.config.emmy_doc.space_between_tag_columns)
+            .unwrap_or(false)
+    })
 }
 
 fn find_diagnostic_disable_tag(

--- a/docs/config/emmyrc_json_CN.md
+++ b/docs/config/emmyrc_json_CN.md
@@ -110,7 +110,7 @@ EmmyLua Analyzer Rust 推荐把配置写在项目根目录的 `.emmyrc.json` 中
 {
   "$schema": "https://raw.githubusercontent.com/EmmyLuaLs/emmylua-analyzer-rust/refs/heads/main/crates/emmylua_code_analysis/resources/schema.json",
   "codeAction": {
-    "insertSpace": false
+    "insertSpace": null
   },
   "codeLens": {
     "enable": true
@@ -469,7 +469,7 @@ EmmyLua Analyzer Rust 推荐把配置写在项目根目录的 `.emmyrc.json` 中
 
 | 分组 | 字段 | 默认值 | 说明 |
 | --- | --- | --- | --- |
-| `codeAction` | `insertSpace` | `false` | 插入 `@diagnostic disable-next-line` 时在 `---` 后补空格 |
+| `codeAction` | `insertSpace` | `null` | 插入 `@diagnostic disable-next-line` 时覆盖格式化器的 `emmy_doc.space_between_tag_columns` 设置 |
 | `codeLens` | `enable` | `true` | 启用 CodeLens |
 | `documentColor` | `enable` | `true` | 识别颜色字符串并显示颜色预览 |
 | `hint` | `enable` | `true` | 总开关 |

--- a/docs/config/emmyrc_json_EN.md
+++ b/docs/config/emmyrc_json_EN.md
@@ -110,7 +110,7 @@ This template is a good starting point for most Lua projects:
 {
   "$schema": "https://raw.githubusercontent.com/EmmyLuaLs/emmylua-analyzer-rust/refs/heads/main/crates/emmylua_code_analysis/resources/schema.json",
   "codeAction": {
-    "insertSpace": false
+    "insertSpace": null
   },
   "codeLens": {
     "enable": true
@@ -469,7 +469,7 @@ External tool object:
 
 | Section | Field | Default | Description |
 | --- | --- | --- | --- |
-| `codeAction` | `insertSpace` | `false` | Add a space after `---` when inserting `@diagnostic disable-next-line` |
+| `codeAction` | `insertSpace` | `null` | Override formatter `emmy_doc.space_between_tag_columns` when inserting `@diagnostic disable-next-line` |
 | `codeLens` | `enable` | `true` | Enable CodeLens |
 | `documentColor` | `enable` | `true` | Detect color-like strings and show color previews |
 | `hint` | `enable` | `true` | Master switch |


### PR DESCRIPTION
## Problem

`codeAction.insertSpace` is currently a boolean defaulting to false, so generated diagnostic comments cannot follow the formatter configured EmmyLua tag spacing.

## Solution

Make `codeAction.insertSpace` optional. When omitted, generated diagnostic comments resolve the formatter config for the current file and use `emmy_doc.space_between_tag_columns`. Explicit `codeAction.insertSpace` still overrides the formatter setting.

Update the generated schema and config docs.
