### PR TITLE
fix: separate unreachable conditions from never types

### DIFF
--- a/crates/emmylua_code_analysis/src/compilation/analyzer/flow/bind_analyze/stats.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/flow/bind_analyze/stats.rs
@@ -199,7 +199,9 @@ pub fn bind_call_expr_stat(
         if let Some(ast) = LuaAst::cast(call_expr.syntax().clone()) {
             bind_each_child(binder, ast, current);
         }
-        current
+        let flow_id = binder.create_node(FlowNodeKind::CallExprStat(call_expr_stat.to_ptr()));
+        binder.add_antecedent(flow_id, current);
+        flow_id
     }
 }
 

--- a/crates/emmylua_code_analysis/src/compilation/test/flow.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/flow.rs
@@ -308,6 +308,180 @@ mod test {
     }
 
     #[test]
+    fn test_plain_call_condition_keeps_inner_call_prefix_type() {
+        let mut ws = VirtualWorkspace::new();
+        let code = r#"
+        local function a() end
+        local function b() end
+
+        b()
+        if a() then
+            b()
+            inner = b
+        end
+        "#;
+        ws.def(code);
+
+        let ty = ws.expr_ty("inner");
+        assert!(ty.is_function());
+
+        let mut diag_ws = VirtualWorkspace::new();
+        assert!(diag_ws.has_no_diagnostic(DiagnosticCode::CallNonCallable, code));
+    }
+
+    #[test]
+    fn test_false_call_condition_keeps_inner_unrelated_type() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+        ---@return false
+        local function always_false()
+            return false
+        end
+
+        ---@type string
+        local value = "ok"
+        if always_false() then
+            inner = value
+        end
+        "#,
+        );
+
+        assert_eq!(ws.expr_ty("inner"), ws.ty("string"));
+    }
+
+    #[test]
+    fn test_true_call_condition_keeps_else_call_prefix_type() {
+        let mut ws = VirtualWorkspace::new();
+        let code = r#"
+        ---@return true
+        local function always_true()
+            return true
+        end
+
+        local function b() end
+        if always_true() then
+        else
+            b()
+        end
+        "#;
+
+        assert!(ws.has_no_diagnostic(DiagnosticCode::CallNonCallable, code));
+    }
+
+    #[test]
+    fn test_false_call_condition_assignment_does_not_contribute_to_merge() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+        ---@return false
+        local function always_false()
+            return false
+        end
+
+        local value = "before"
+        if always_false() then
+            value = 1
+        end
+        after = value
+        "#,
+        );
+
+        let after = ws.expr_ty("after");
+        assert_eq!(ws.humanize_type(after), "string");
+    }
+
+    #[test]
+    fn test_false_call_condition_missing_field_assignment_does_not_contribute_to_merge() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+        ---@return false
+        local function is_windows()
+            return false
+        end
+
+        local command = "ls"
+        local config = {}
+        if is_windows() then
+            command = config.windows_command
+        end
+        after = command
+        "#,
+        );
+
+        let after = ws.expr_ty("after");
+        assert_eq!(ws.humanize_type(after), "string");
+    }
+
+    #[test]
+    fn test_reachable_assignment_over_never_value_contributes_to_merge() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+        ---@class NeverBox
+        ---@field value never
+
+        ---@return NeverBox
+        local function make_box() end
+
+        local value = make_box().value
+        local cond ---@type boolean
+        if cond then
+            value = 1
+        end
+        after = value
+        "#,
+        );
+
+        assert_eq!(ws.expr_ty("after"), LuaType::IntegerConst(1));
+    }
+
+    #[test]
+    fn test_false_call_condition_tag_cast_does_not_contribute_to_merge() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+        ---@return false
+        local function always_false()
+            return false
+        end
+
+        local value = "before"
+        if always_false() then
+            ---@cast value integer
+        end
+        after = value
+        "#,
+        );
+
+        let after = ws.expr_ty("after");
+        assert_eq!(ws.humanize_type(after), r#""before""#);
+    }
+
+    #[test]
+    fn test_false_call_condition_doc_assignment_does_not_contribute_to_merge() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+        ---@return false
+        local function always_false()
+            return false
+        end
+
+        local value = "before"
+        if always_false() then
+            ---@type integer
+            value = 1
+        end
+        after = value
+        "#,
+        );
+
+        assert_eq!(ws.expr_ty("after"), ws.ty("string"));
+    }
+
+    #[test]
     fn test_branch_join_keeps_union_when_only_one_side_narrows() {
         let mut ws = VirtualWorkspace::new();
         let block = r#"
@@ -1590,6 +1764,59 @@ end
 
         let b = ws.expr_ty("b");
         assert_eq!(b, LuaType::String);
+    }
+
+    #[test]
+    fn test_issue_877_never_return_call_narrows_after_guard() {
+        let mut ws = VirtualWorkspace::new();
+
+        let source = r#"
+        ---@param _num integer
+        local function accept_num(_num)
+        end
+
+        ---@return never
+        local function panic()
+            error("panic!")
+        end
+
+        ---@type integer?
+        local num
+        if num == nil then
+            panic()
+        end
+
+        accept_num(num)
+        after_guard = num
+        "#;
+
+        assert!(ws.has_no_diagnostic(DiagnosticCode::ParamTypeMismatch, source));
+        assert_eq!(ws.expr_ty("after_guard"), LuaType::Integer);
+    }
+
+    #[test]
+    fn test_never_return_call_after_branch_statement_narrows_after_guard() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+        ---@return never
+        local function panic()
+            error("panic!")
+        end
+
+        ---@type integer?
+        local num
+        if num == nil then
+            local reason = "bad"
+            panic()
+        end
+
+        after_guard = num
+        "#,
+        );
+
+        assert_eq!(ws.expr_ty("after_guard"), LuaType::Integer);
     }
 
     #[test]

--- a/crates/emmylua_code_analysis/src/db_index/flow/flow_node.rs
+++ b/crates/emmylua_code_analysis/src/db_index/flow/flow_node.rs
@@ -1,6 +1,6 @@
 use emmylua_parser::{
-    LuaAssignStat, LuaAstNode, LuaAstPtr, LuaChunk, LuaClosureExpr, LuaDocTagCast, LuaExpr,
-    LuaForStat, LuaFuncStat, LuaSyntaxKind, LuaSyntaxNode,
+    LuaAssignStat, LuaAstNode, LuaAstPtr, LuaCallExprStat, LuaChunk, LuaClosureExpr, LuaDocTagCast,
+    LuaExpr, LuaForStat, LuaFuncStat, LuaSyntaxKind, LuaSyntaxNode,
 };
 use internment::ArcIntern;
 use rowan::{TextRange, TextSize};
@@ -44,6 +44,8 @@ pub enum FlowNodeKind {
     DeclPosition(TextSize),
     /// Variable assignment
     Assignment(LuaAstPtr<LuaAssignStat>),
+    /// Call expression statement
+    CallExprStat(LuaAstPtr<LuaCallExprStat>),
     /// Conditional flow (type guards, existence checks)
     TrueCondition(LuaAstPtr<LuaExpr>),
     /// Conditional flow (type guards, existence checks)

--- a/crates/emmylua_code_analysis/src/db_index/flow/flow_tree.rs
+++ b/crates/emmylua_code_analysis/src/db_index/flow/flow_tree.rs
@@ -1,15 +1,18 @@
+use std::collections::VecDeque;
+
 use hashbrown::{HashMap, HashSet};
 
 use emmylua_parser::{LuaAstPtr, LuaCallExpr, LuaExpr, LuaSyntaxId};
 use rowan::TextSize;
 
-use crate::{FlowAntecedent, FlowId, FlowNode, LuaDeclId};
+use crate::{FlowAntecedent, FlowId, FlowNode, FlowNodeKind, LuaDeclId};
 
 #[derive(Debug)]
 pub struct FlowTree {
     decl_bind_expr_ref: HashMap<LuaDeclId, LuaAstPtr<LuaExpr>>,
     decl_multi_return_ref: HashMap<LuaDeclId, Vec<DeclMultiReturnRefAt>>,
     flow_nodes: Vec<FlowNode>,
+    has_tag_cast: bool,
     multiple_antecedents: Vec<Vec<FlowId>>,
     // labels: HashMap<LuaClosureId, HashMap<SmolStr, FlowId>>,
     bindings: HashMap<LuaSyntaxId, FlowId>,
@@ -24,10 +27,14 @@ impl FlowTree {
         // labels: HashMap<LuaClosureId, HashMap<SmolStr, FlowId>>,
         bindings: HashMap<LuaSyntaxId, FlowId>,
     ) -> Self {
+        let has_tag_cast = flow_nodes
+            .iter()
+            .any(|node| matches!(node.kind, FlowNodeKind::TagCast(_)));
         Self {
             decl_bind_expr_ref,
             decl_multi_return_ref,
             flow_nodes,
+            has_tag_cast,
             multiple_antecedents,
             bindings,
         }
@@ -41,10 +48,32 @@ impl FlowTree {
         self.flow_nodes.get(flow_id.0 as usize)
     }
 
+    pub fn has_tag_cast(&self) -> bool {
+        self.has_tag_cast
+    }
+
     pub fn get_multi_antecedents(&self, id: u32) -> Option<&[FlowId]> {
         self.multiple_antecedents
             .get(id as usize)
             .map(|v| v.as_slice())
+    }
+
+    /// Returns the first backward-reachable flow node shared by all starting flows.
+    pub fn get_nearest_common_antecedent(&self, flow_ids: &[FlowId]) -> Option<FlowId> {
+        let (first_flow_id, rest_flow_ids) = flow_ids.split_first()?;
+        let first_antecedents = self.collect_antecedents(*first_flow_id);
+        let rest_antecedents = rest_flow_ids
+            .iter()
+            .map(|flow_id| {
+                self.collect_antecedents(*flow_id)
+                    .into_iter()
+                    .collect::<HashSet<_>>()
+            })
+            .collect::<Vec<_>>();
+
+        first_antecedents
+            .into_iter()
+            .find(|flow_id| rest_antecedents.iter().all(|set| set.contains(flow_id)))
     }
 
     pub fn get_decl_ref_expr(&self, decl_id: &LuaDeclId) -> Option<LuaAstPtr<LuaExpr>> {
@@ -262,6 +291,35 @@ impl FlowTree {
                 None => return vec![start_flow_id],
             }
         }
+    }
+
+    fn collect_antecedents(&self, flow_id: FlowId) -> Vec<FlowId> {
+        let mut antecedents = Vec::new();
+        let mut pending = VecDeque::from([flow_id]);
+        let mut visited = HashSet::new();
+        while let Some(flow_id) = pending.pop_front() {
+            if !visited.insert(flow_id) {
+                continue;
+            }
+
+            antecedents.push(flow_id);
+            let Some(flow_node) = self.get_flow_node(flow_id) else {
+                continue;
+            };
+            match flow_node.antecedent.as_ref() {
+                Some(FlowAntecedent::Single(antecedent_flow_id)) => {
+                    pending.push_back(*antecedent_flow_id);
+                }
+                Some(FlowAntecedent::Multiple(multi_id)) => {
+                    if let Some(branch_flow_ids) = self.get_multi_antecedents(*multi_id) {
+                        pending.extend(branch_flow_ids.iter().copied());
+                    }
+                }
+                None => {}
+            }
+        }
+
+        antecedents
     }
 }
 

--- a/crates/emmylua_code_analysis/src/diagnostic/checker/assign_type_mismatch.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/assign_type_mismatch.rs
@@ -104,6 +104,10 @@ fn check_name_expr(
         }
         _ => None,
     };
+    let source_type = source_type.map(|source_type| {
+        semantic_model
+            .apply_assignment_target_casts(LuaExpr::NameExpr(name_expr.clone()), source_type)
+    });
     check_assign_type_mismatch(
         context,
         semantic_model,
@@ -139,6 +143,10 @@ fn check_index_expr(
         false,
     )
     .ok();
+    let source_type = source_type.map(|source_type| {
+        semantic_model
+            .apply_assignment_target_casts(LuaExpr::IndexExpr(index_expr.clone()), source_type)
+    });
 
     check_assign_type_mismatch(
         context,

--- a/crates/emmylua_code_analysis/src/diagnostic/test/assign_type_mismatch_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/assign_type_mismatch_test.rs
@@ -42,6 +42,96 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn test_cast_add_type_allows_assignment() {
+        let mut ws = VirtualWorkspace::new();
+        assert!(ws.has_no_diagnostic_in_namespace(
+            DiagnosticCode::AssignTypeMismatch,
+            r#"
+            ---@type string
+            local val
+
+            ---@cast val + boolean
+            local after_cast = 1
+            val = true
+            "#
+        ));
+    }
+
+    #[test]
+    fn test_cast_add_type_allows_assignment_from_declared_union_in_narrowed_branch() {
+        let mut ws = VirtualWorkspace::new();
+        assert!(ws.has_no_diagnostic_in_namespace(
+            DiagnosticCode::AssignTypeMismatch,
+            r#"
+            ---@type string|number
+            local val
+
+            ---@cast val + boolean
+            if val == "a" then
+                val = true
+            end
+            "#
+        ));
+    }
+
+    #[test]
+    fn test_cast_add_type_allows_assignment_after_branch_join() {
+        let mut ws = VirtualWorkspace::new();
+        assert!(ws.has_no_diagnostic_in_namespace(
+            DiagnosticCode::AssignTypeMismatch,
+            r#"
+            ---@type string
+            local val
+
+            ---@cast val + boolean
+            local cond ---@type boolean
+            if cond then
+                local branch = 1
+            end
+
+            val = true
+            "#
+        ));
+    }
+
+    #[test]
+    fn test_branch_local_cast_does_not_allow_assignment_after_join() {
+        let mut ws = VirtualWorkspace::new();
+        assert!(!ws.has_no_diagnostic_in_namespace(
+            DiagnosticCode::AssignTypeMismatch,
+            r#"
+            ---@type string
+            local val
+
+            local cond ---@type boolean
+            if cond then
+                ---@cast val + boolean
+                local branch = 1
+            end
+
+            val = true
+            "#
+        ));
+    }
+
+    #[test]
+    fn test_field_cast_add_type_allows_assignment() {
+        let mut ws = VirtualWorkspace::new();
+        assert!(ws.has_no_diagnostic_in_namespace(
+            DiagnosticCode::AssignTypeMismatch,
+            r#"
+            ---@class CastField
+            ---@field value string
+
+            local obj ---@type CastField
+
+            ---@cast obj.value + boolean
+            obj.value = true
+            "#
+        ));
+    }
+
     // #[test]
     // fn test_3() {
     //     let mut ws = VirtualWorkspace::new();

--- a/crates/emmylua_code_analysis/src/semantic/cache/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/cache/mod.rs
@@ -26,19 +26,51 @@ pub(in crate::semantic) struct FlowAssignmentInfo {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(in crate::semantic) enum FlowMode {
-    WithConditions,
-    WithoutConditions,
+    Normal,
+    // Query one predecessor of a merge label; if that walk reaches an
+    // unreachable condition edge, it contributes `never` to the merged type.
+    MergeBranch,
+    // Re-query assignment antecedents without applying condition narrows.
+    IgnoreConditions,
 }
 
 impl FlowMode {
-    pub fn uses_conditions(self) -> bool {
-        matches!(self, Self::WithConditions)
+    pub(in crate::semantic) fn for_merge_contribution(self) -> Self {
+        match self {
+            Self::Normal | Self::MergeBranch => Self::MergeBranch,
+            Self::IgnoreConditions => Self::IgnoreConditions,
+        }
+    }
+
+    pub(in crate::semantic) fn for_point_dependency(self) -> Self {
+        match self {
+            Self::MergeBranch => Self::MergeBranch,
+            Self::Normal | Self::IgnoreConditions => Self::Normal,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(in crate::semantic) enum FlowQueryResult {
+    Type(LuaType),
+    // A merge contribution crossed an impossible condition edge. Keep this
+    // separate from `Type(Never)` because reachable code can still have a real
+    // never-typed value and assign over it before the merge.
+    Unreachable,
+}
+
+impl FlowQueryResult {
+    pub(in crate::semantic) fn into_type(self) -> LuaType {
+        match self {
+            Self::Type(typ) => typ,
+            Self::Unreachable => LuaType::Never,
+        }
     }
 }
 
 #[derive(Debug, Default)]
 pub(in crate::semantic) struct FlowVarCache {
-    pub type_cache: HashMap<(FlowId, FlowMode), CacheEntry<LuaType>>,
+    pub type_cache: HashMap<(FlowId, FlowMode), CacheEntry<FlowQueryResult>>,
     pub condition_cache: HashMap<(FlowId, InferConditionFlow), CacheEntry<ConditionFlowAction>>,
 }
 

--- a/crates/emmylua_code_analysis/src/semantic/infer/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/mod.rs
@@ -28,6 +28,7 @@ use infer_table::infer_table_expr;
 pub use infer_table::{infer_table_field_value_should_be, infer_table_should_be};
 use infer_unary::infer_unary_expr;
 pub use narrow::VarRefId;
+pub(super) use narrow::apply_assignment_target_casts;
 pub(in crate::semantic) use narrow::{ConditionFlowAction, InferConditionFlow};
 
 use rowan::TextRange;

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/mod.rs
@@ -119,6 +119,7 @@ pub(in crate::semantic) enum CorrelatedDiscriminantNarrow {
 #[derive(Debug, Clone)]
 pub(in crate::semantic) enum ConditionFlowAction {
     Continue,
+    Unreachable,
     Result(LuaType),
     Pending(PendingConditionNarrow),
     NeedExprType {
@@ -610,7 +611,7 @@ pub(super) fn get_type_at_condition_flow(
                                 };
 
                             if unreachable_branch {
-                                ConditionFlowAction::Result(LuaType::Never)
+                                ConditionFlowAction::Unreachable
                             } else {
                                 ConditionFlowAction::Continue
                             }

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/get_type_at_cast_flow.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/get_type_at_cast_flow.rs
@@ -1,8 +1,12 @@
-use emmylua_parser::{BinaryOperator, LuaAstNode, LuaCallExpr, LuaChunk, LuaDocOpType};
+use emmylua_parser::{BinaryOperator, LuaAstNode, LuaCallExpr, LuaChunk, LuaDocOpType, LuaExpr};
+use hashbrown::HashSet;
 
 use crate::{
-    DbIndex, FileId, FlowId, FlowNodeKind, FlowTree, InFiled, InferFailReason, LuaInferCache,
-    LuaType, LuaTypeOwner, TypeOps, semantic::infer::narrow::condition_flow::InferConditionFlow,
+    DbIndex, FileId, FlowAntecedent, FlowId, FlowNodeKind, FlowTree, InFiled, InferFailReason,
+    LuaInferCache, LuaType, LuaTypeOwner, TypeOps,
+    semantic::infer::narrow::{
+        VarRefId, condition_flow::InferConditionFlow, get_var_expr_var_ref_id,
+    },
 };
 
 pub fn get_type_at_call_expr_inline_cast(
@@ -35,6 +39,99 @@ pub fn get_type_at_call_expr_inline_cast(
     }
 
     Some(return_type)
+}
+
+pub(in crate::semantic) fn apply_assignment_target_casts(
+    db: &DbIndex,
+    cache: &mut LuaInferCache,
+    target_expr: LuaExpr,
+    mut source_type: LuaType,
+) -> LuaType {
+    let file_id = cache.get_file_id();
+    let Some(flow_tree) = db.get_flow_index().get_flow_tree(&file_id) else {
+        return source_type;
+    };
+    if !flow_tree.has_tag_cast() {
+        return source_type;
+    }
+
+    let target_syntax_id = target_expr.get_syntax_id();
+    let target_root = target_expr.get_root();
+    let Some(target_ref_id) = get_var_expr_var_ref_id(db, cache, target_expr) else {
+        return source_type;
+    };
+    let Some(flow_id) = flow_tree.get_flow_id(target_syntax_id) else {
+        return source_type;
+    };
+    let Some(root) = LuaChunk::cast(target_root) else {
+        return source_type;
+    };
+
+    for cast_op_types in
+        collect_assignment_target_casts(db, cache, flow_tree, &root, &target_ref_id, flow_id)
+            .into_iter()
+            .rev()
+    {
+        for cast_op_type in cast_op_types {
+            source_type = cast_type(
+                db,
+                file_id,
+                cast_op_type,
+                source_type.clone(),
+                InferConditionFlow::TrueCondition,
+            )
+            .unwrap_or(source_type);
+        }
+    }
+
+    source_type
+}
+
+fn collect_assignment_target_casts(
+    db: &DbIndex,
+    cache: &mut LuaInferCache,
+    flow_tree: &FlowTree,
+    root: &LuaChunk,
+    target_ref_id: &VarRefId,
+    mut flow_id: FlowId,
+) -> Vec<Vec<LuaDocOpType>> {
+    // Assignment diagnostics compare against the target's declared/member contract,
+    // not its current flow-narrowed read type. Reapply only explicit target casts
+    // reachable on the current path; at joins, continue from the nearest common
+    // predecessor so branch-local assertions do not leak out.
+    let mut visited = HashSet::new();
+    let mut cast_groups = Vec::new();
+    while visited.insert(flow_id) {
+        let Some(flow_node) = flow_tree.get_flow_node(flow_id) else {
+            break;
+        };
+        if let FlowNodeKind::TagCast(cast_ptr) = &flow_node.kind
+            && let Some(tag_cast) = cast_ptr.to_node(root)
+            && let Some(key_expr) = tag_cast.get_key_expr()
+            && get_var_expr_var_ref_id(db, cache, key_expr).as_ref() == Some(target_ref_id)
+        {
+            cast_groups.push(tag_cast.get_op_types().collect());
+        }
+
+        match flow_node.antecedent.as_ref() {
+            Some(FlowAntecedent::Single(antecedent_flow_id)) => {
+                flow_id = *antecedent_flow_id;
+            }
+            Some(FlowAntecedent::Multiple(multi_id)) => {
+                let Some(branch_flow_ids) = flow_tree.get_multi_antecedents(*multi_id) else {
+                    break;
+                };
+                let Some(common_flow_id) = flow_tree.get_nearest_common_antecedent(branch_flow_ids)
+                else {
+                    break;
+                };
+                flow_id = common_flow_id;
+            }
+            None => break,
+        }
+    }
+
+    cast_groups
 }
 
 enum CastAction {

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/get_type_at_flow.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/get_type_at_flow.rs
@@ -1,6 +1,6 @@
 use emmylua_parser::{
-    BinaryOperator, LuaAssignStat, LuaAstNode, LuaChunk, LuaDocOpType, LuaExpr, LuaIndexKey,
-    LuaIndexMemberExpr, LuaSyntaxId, LuaTableExpr, LuaVarExpr,
+    BinaryOperator, LuaAssignStat, LuaAstNode, LuaCallExprStat, LuaChunk, LuaDocOpType, LuaExpr,
+    LuaIndexKey, LuaIndexMemberExpr, LuaSyntaxId, LuaTableExpr, LuaVarExpr,
 };
 use hashbrown::HashSet;
 use std::{rc::Rc, sync::Arc};
@@ -9,7 +9,7 @@ use crate::{
     CacheEntry, DbIndex, FlowId, FlowNode, FlowNodeKind, FlowTree, InferFailReason, LuaDeclId,
     LuaInferCache, LuaMemberId, LuaSignatureId, LuaType, TypeOps, check_type_compact,
     semantic::{
-        cache::{FlowAssignmentInfo, FlowMode, FlowVarCache},
+        cache::{FlowAssignmentInfo, FlowMode, FlowQueryResult, FlowVarCache},
         infer::{
             InferResult, VarRefId,
             infer_name::infer_global_type,
@@ -36,8 +36,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-// One cached flow query: one ref at one flow node, optionally without replaying
-// pending condition narrows.
+// One cached flow query: one ref at one flow node under one flow mode.
 // Example: "what is `x` at flow 42, with current guards applied?"
 struct FlowQuery {
     var_ref_id: VarRefId,
@@ -52,7 +51,7 @@ impl FlowQuery {
             var_ref_id: var_ref_id.clone(),
             var_cache_idx: get_flow_cache_var_ref_id(cache, var_ref_id),
             flow_id,
-            mode: FlowMode::WithConditions,
+            mode: FlowMode::Normal,
         }
     }
 
@@ -99,6 +98,12 @@ enum Continuation {
         antecedent_flow_id: FlowId,
         expr_type: LuaType,
         reuse_antecedent_narrowing: bool,
+    },
+    // Resume an assignment result after proving the branch can reach the
+    // assignment. An impossible branch must not contribute this result to a merge.
+    AssignmentReachability {
+        walk: QueryWalk,
+        result_type: LuaType,
     },
     // Resume structural expression replay after resolving the flow-aware refs
     // it depends on. The replay itself stays no-flow; only this continuation
@@ -412,7 +417,7 @@ fn collect_expr_dependency_queries(
 // `StartQuery` begins one query, optionally saving the current query first.
 // `ContinueWalk` keeps scanning backward through the current query.
 // `ResumeNext(result)` pops one suspended query from `stack` and resumes it
-// with the result of the dependency query that just finished.
+// with the internal result of the dependency query that just finished.
 enum SchedulerStep {
     // Start or reuse one `(var_ref, flow_id, mode)` query.
     // If `continuation` is present, save that suspended query first so this
@@ -431,8 +436,10 @@ enum SchedulerStep {
     // query result.
     // Example: after querying `shape.kind`, continue narrowing
     // `if shape.kind == "circle" then`.
-    ResumeNext(InferResult),
+    ResumeNext(FlowResult),
 }
+
+type FlowResult = Result<FlowQueryResult, InferFailReason>;
 
 // Single owner of flow evaluation. Only this engine is allowed to schedule
 // follow-up queries, which keeps the flow path iterative.
@@ -488,11 +495,25 @@ impl<'a> FlowTypeEngine<'a> {
                         reuse_antecedent_narrowing,
                         query_result,
                     ),
+                    Some(Continuation::AssignmentReachability { walk, result_type }) => {
+                        match query_result {
+                            Ok(FlowQueryResult::Unreachable) => {
+                                Ok(self.finish_unreachable_branch(walk))
+                            }
+                            Ok(FlowQueryResult::Type(_)) => Ok(self.finish_walk(walk, result_type)),
+                            Err(err) => self.fail_query(&walk.query, err),
+                        }
+                    }
                     Some(Continuation::ExprReplay {
                         walk,
                         replay,
                         replay_query,
-                    }) => self.resume_expr_replay(walk, replay, replay_query, query_result),
+                    }) => self.resume_expr_replay(
+                        walk,
+                        replay,
+                        replay_query,
+                        query_result.map(FlowQueryResult::into_type),
+                    ),
                     Some(Continuation::TagCastAntecedent {
                         walk,
                         cast_op_types,
@@ -507,7 +528,7 @@ impl<'a> FlowTypeEngine<'a> {
                         flow_id,
                         condition_flow,
                         subquery,
-                        query_result,
+                        query_result.map(FlowQueryResult::into_type),
                     ),
                     Some(Continuation::FieldLiteralSiblingDependency {
                         walk,
@@ -519,7 +540,7 @@ impl<'a> FlowTypeEngine<'a> {
                         flow_id,
                         condition_flow,
                         subquery,
-                        query_result,
+                        query_result.map(FlowQueryResult::into_type),
                     ),
                     Some(Continuation::CorrelatedSearchRoot {
                         walk,
@@ -533,12 +554,12 @@ impl<'a> FlowTypeEngine<'a> {
                         advance_pending_correlated_condition(
                             self.db,
                             pending_correlated_condition,
-                            query_result,
+                            query_result.map(FlowQueryResult::into_type),
                         ),
                     ),
                     // No suspended query is waiting on this result, so it is the
                     // final answer for the original `run(...)` request.
-                    None => break query_result,
+                    None => break query_result.map(FlowQueryResult::into_type),
                 },
             }
             .unwrap_or_else(|err| SchedulerStep::ResumeNext(Err(err)));
@@ -557,7 +578,7 @@ impl<'a> FlowTypeEngine<'a> {
             .and_then(|var_cache| var_cache.type_cache.get(&type_cache_key))
         {
             Ok(SchedulerStep::ResumeNext(match cache_entry {
-                CacheEntry::Cache(narrow_type) => Ok(narrow_type.clone()),
+                CacheEntry::Cache(query_result) => Ok(query_result.clone()),
                 CacheEntry::Ready => Err(InferFailReason::RecursiveInfer),
             }))
         } else {
@@ -591,10 +612,10 @@ impl<'a> FlowTypeEngine<'a> {
         branch_flow_ids: Arc<[FlowId]>,
         next_pending_idx: usize,
         merged_type: LuaType,
-        branch_result: InferResult,
+        branch_result: FlowResult,
     ) -> Result<SchedulerStep, InferFailReason> {
         let branch_type = match branch_result {
-            Ok(branch_type) => branch_type,
+            Ok(branch_result) => branch_result.into_type(),
             Err(err) => return self.fail_query(&walk.query, err),
         };
 
@@ -606,10 +627,12 @@ impl<'a> FlowTypeEngine<'a> {
         // Branches are resumed from the end because the initial merge setup
         // schedules the last incoming branch first.
         let branch_idx = next_pending_idx - 1;
+        // The remaining predecessor is still a merge contribution. Preserve
+        // MergeBranch so an unreachable condition edge contributes `never`
+        // instead of continuing to the type from before the merge.
+        let branch_mode = walk.query.mode.for_merge_contribution();
         Ok(SchedulerStep::StartQuery {
-            query: walk
-                .query
-                .at_flow(branch_flow_ids[branch_idx], walk.query.mode),
+            query: walk.query.at_flow(branch_flow_ids[branch_idx], branch_mode),
             continuation: Some(Continuation::Merge {
                 walk,
                 branch_flow_ids,
@@ -629,10 +652,13 @@ impl<'a> FlowTypeEngine<'a> {
         antecedent_flow_id: FlowId,
         expr_type: LuaType,
         reuse_antecedent_narrowing: bool,
-        antecedent_result: InferResult,
+        antecedent_result: FlowResult,
     ) -> Result<SchedulerStep, InferFailReason> {
         let antecedent_type = match antecedent_result {
-            Ok(antecedent_type) => antecedent_type,
+            Ok(FlowQueryResult::Type(antecedent_type)) => antecedent_type,
+            Ok(FlowQueryResult::Unreachable) => {
+                return Ok(self.finish_unreachable_branch(walk));
+            }
             Err(err) => return self.fail_query(&walk.query, err),
         };
 
@@ -641,7 +667,7 @@ impl<'a> FlowTypeEngine<'a> {
         {
             let next_query = walk
                 .query
-                .at_flow(antecedent_flow_id, FlowMode::WithoutConditions);
+                .at_flow(antecedent_flow_id, FlowMode::IgnoreConditions);
             return Ok(SchedulerStep::StartQuery {
                 query: next_query,
                 continuation: Some(Continuation::AssignmentAntecedent {
@@ -843,10 +869,13 @@ impl<'a> FlowTypeEngine<'a> {
         &mut self,
         walk: QueryWalk,
         cast_op_types: Vec<LuaDocOpType>,
-        antecedent_result: InferResult,
+        antecedent_result: FlowResult,
     ) -> Result<SchedulerStep, InferFailReason> {
         let mut cast_input_type = match antecedent_result {
-            Ok(resolved_type) => resolved_type,
+            Ok(FlowQueryResult::Type(resolved_type)) => resolved_type,
+            Ok(FlowQueryResult::Unreachable) => {
+                return Ok(self.finish_unreachable_branch(walk));
+            }
             // `---@cast` is an explicit assertion, so unresolved source types
             // should still be narrowed by applying the cast from `unknown`.
             Err(_) => LuaType::Unknown,
@@ -1123,6 +1152,20 @@ impl<'a> FlowTypeEngine<'a> {
         self.finish_assignment_expr_type(walk, antecedent_flow_id, explicit_var_type, expr_type)
     }
 
+    fn start_assignment_reachability(
+        walk: QueryWalk,
+        antecedent_flow_id: FlowId,
+        result_type: LuaType,
+    ) -> SchedulerStep {
+        let query = walk
+            .query
+            .at_flow(antecedent_flow_id, FlowMode::MergeBranch);
+        SchedulerStep::StartQuery {
+            query,
+            continuation: Some(Continuation::AssignmentReachability { walk, result_type }),
+        }
+    }
+
     fn finish_assignment_expr_type(
         &mut self,
         walk: QueryWalk,
@@ -1141,20 +1184,31 @@ impl<'a> FlowTypeEngine<'a> {
                 true,
                 Some(explicit_var_type.clone()),
             );
+            if matches!(walk.query.mode, FlowMode::MergeBranch) {
+                return Ok(Self::start_assignment_reachability(
+                    walk,
+                    antecedent_flow_id,
+                    result_type,
+                ));
+            }
+
             return Ok(self.finish_walk(walk, result_type));
         }
 
         // Broad RHS types replace the previous runtime type. The old path still
         // queried the antecedent and then discarded it in finish_assignment_result.
         let reuse_antecedent_narrowing = preserves_assignment_expr_type(&expr_type);
-        if !expr_type.is_unknown() && !reuse_antecedent_narrowing {
+        if !expr_type.is_unknown()
+            && !reuse_antecedent_narrowing
+            && !matches!(walk.query.mode, FlowMode::MergeBranch)
+        {
             return Ok(self.finish_walk(walk, expr_type));
         }
 
-        let mode = if reuse_antecedent_narrowing {
-            FlowMode::WithConditions
-        } else {
-            FlowMode::WithoutConditions
+        let mode = match (walk.query.mode, reuse_antecedent_narrowing) {
+            (FlowMode::MergeBranch, _) => FlowMode::MergeBranch,
+            (_, true) => FlowMode::Normal,
+            (_, false) => FlowMode::IgnoreConditions,
         };
         let subquery = walk.query.at_flow(antecedent_flow_id, mode);
         Ok(SchedulerStep::StartQuery {
@@ -1176,26 +1230,40 @@ impl<'a> FlowTypeEngine<'a> {
         err: InferFailReason,
     ) -> Result<SchedulerStep, InferFailReason> {
         if let Some(explicit_var_type) = explicit_var_type {
-            return Ok(self.finish_walk(walk, explicit_var_type));
+            return self.finish_assignment_expr_type(
+                walk,
+                antecedent_flow_id,
+                Some(explicit_var_type),
+                LuaType::Unknown,
+            );
         }
 
         let var_ref_id = walk.query.var_ref_id.clone();
-        if matches!(var_ref_id, VarRefId::IndexRef(_, _))
+        let fallback_type = if matches!(var_ref_id, VarRefId::IndexRef(_, _))
             && let Ok(origin_type) = get_var_ref_type(self.db, self.cache, &var_ref_id)
         {
             let non_nil_origin = TypeOps::Remove.apply(self.db, &origin_type, &LuaType::Nil);
-            return Ok(self.finish_walk(
-                walk,
-                if non_nil_origin.is_never() {
-                    origin_type
-                } else {
-                    non_nil_origin
-                },
-            ));
-        }
+            Some(if non_nil_origin.is_never() {
+                origin_type
+            } else {
+                non_nil_origin
+            })
+        } else if matches!(err, InferFailReason::FieldNotFound | InferFailReason::None) {
+            Some(LuaType::Nil)
+        } else {
+            None
+        };
 
-        if matches!(err, InferFailReason::FieldNotFound | InferFailReason::None) {
-            return Ok(self.finish_walk(walk, LuaType::Nil));
+        if let Some(fallback_type) = fallback_type {
+            if matches!(walk.query.mode, FlowMode::MergeBranch) {
+                return Ok(Self::start_assignment_reachability(
+                    walk,
+                    antecedent_flow_id,
+                    fallback_type,
+                ));
+            }
+
+            return Ok(self.finish_walk(walk, fallback_type));
         }
 
         walk.antecedent_flow_id = antecedent_flow_id;
@@ -1210,7 +1278,7 @@ impl<'a> FlowTypeEngine<'a> {
         condition_flow: InferConditionFlow,
     ) -> Result<SchedulerStep, InferFailReason> {
         let antecedent_flow_id = get_single_antecedent(flow_node)?;
-        if !walk.query.mode.uses_conditions() {
+        if matches!(walk.query.mode, FlowMode::IgnoreConditions) {
             walk.antecedent_flow_id = antecedent_flow_id;
             return Ok(SchedulerStep::ContinueWalk(walk));
         }
@@ -1264,7 +1332,10 @@ impl<'a> FlowTypeEngine<'a> {
         if cached_action {
             return match action {
                 ConditionFlowAction::Continue => Ok(SchedulerStep::ContinueWalk(walk)),
-                ConditionFlowAction::Result(result_type) => Ok(self.finish_walk(walk, result_type)),
+                ConditionFlowAction::Unreachable => Ok(self.finish_unreachable_condition(walk)),
+                ConditionFlowAction::Result(result_type) => {
+                    Ok(self.finish_condition_result(walk, result_type))
+                }
                 ConditionFlowAction::Pending(pending_condition_narrow) => {
                     let mut walk = walk;
                     walk.pending_condition_narrows
@@ -1306,9 +1377,8 @@ impl<'a> FlowTypeEngine<'a> {
         }
 
         let antecedent_flow_id = get_single_antecedent(flow_node)?;
-        let subquery = walk
-            .query
-            .at_flow(antecedent_flow_id, FlowMode::WithConditions);
+        let mode = walk.query.mode.for_point_dependency();
+        let subquery = walk.query.at_flow(antecedent_flow_id, mode);
         Ok(SchedulerStep::StartQuery {
             query: subquery,
             continuation: Some(Continuation::TagCastAntecedent {
@@ -1327,7 +1397,7 @@ impl<'a> FlowTypeEngine<'a> {
             // that another query already finished. Use that cached type instead
             // of walking back through the same replay chain again.
             if walk.antecedent_flow_id != walk.query.flow_id
-                && let Some(CacheEntry::Cache(narrow_type)) = self
+                && let Some(cached_result) = self
                     .cache
                     .flow_var_caches
                     .get(walk.query.var_cache_idx as usize)
@@ -1336,8 +1406,15 @@ impl<'a> FlowTypeEngine<'a> {
                             .type_cache
                             .get(&(walk.antecedent_flow_id, walk.query.mode))
                     })
+                    .and_then(|cache_entry| match cache_entry {
+                        CacheEntry::Cache(query_result) => Some(query_result.clone()),
+                        CacheEntry::Ready => None,
+                    })
             {
-                return Ok(self.finish_walk(walk, narrow_type.clone()));
+                return Ok(match cached_result {
+                    FlowQueryResult::Type(narrow_type) => self.finish_walk(walk, narrow_type),
+                    FlowQueryResult::Unreachable => self.finish_unreachable_branch(walk),
+                });
             }
 
             let flow_node = self
@@ -1358,19 +1435,46 @@ impl<'a> FlowTypeEngine<'a> {
                 | FlowNodeKind::ForIStat(_) => {
                     walk.antecedent_flow_id = get_single_antecedent(flow_node)?;
                 }
+                FlowNodeKind::CallExprStat(call_stat_ptr) => {
+                    let antecedent_flow_id = get_single_antecedent(flow_node)?;
+                    if matches!(walk.query.mode, FlowMode::MergeBranch)
+                        && call_expr_stat_returns_never(
+                            self.db,
+                            self.cache,
+                            self.root,
+                            call_stat_ptr,
+                        )
+                    {
+                        return Ok(self.finish_unreachable_branch(walk));
+                    }
+
+                    walk.antecedent_flow_id = antecedent_flow_id;
+                }
                 FlowNodeKind::BranchLabel | FlowNodeKind::NamedLabel(_) => {
                     let branch_flow_ids = if matches!(&flow_node.kind, FlowNodeKind::BranchLabel) {
                         get_branch_label_flow_ids(self.tree, self.cache, flow_node)?
                     } else {
                         Arc::<[FlowId]>::from(get_multi_antecedents(self.tree, flow_node)?)
                     };
-                    let Some(next_pending_idx) = branch_flow_ids.len().checked_sub(1) else {
-                        return Ok(self.finish_walk(walk, LuaType::Never));
-                    };
+                    match branch_flow_ids.len() {
+                        0 => return Ok(self.finish_unreachable_branch(walk)),
+                        // A single predecessor is just a branch-entry label, not a merge.
+                        // Keep the current mode so queries inside an impossible then/else
+                        // body can still resolve unrelated symbols from their declarations.
+                        1 => {
+                            walk.antecedent_flow_id = branch_flow_ids[0];
+                            continue;
+                        }
+                        _ => {}
+                    }
+                    let next_pending_idx = branch_flow_ids.len() - 1;
                     let q = &walk.query;
-                    let next_query = q.at_flow(branch_flow_ids[next_pending_idx], q.mode);
+                    // Multiple predecessors make this a merge. Query each
+                    // predecessor as a merge contribution so an unreachable
+                    // condition edge contributes `never` to the final union.
+                    let branch_mode = q.mode.for_merge_contribution();
                     return Ok(SchedulerStep::StartQuery {
-                        query: next_query,
+                        query: q.at_flow(branch_flow_ids[next_pending_idx], branch_mode),
                         continuation: Some(Continuation::Merge {
                             walk,
                             branch_flow_ids,
@@ -1502,6 +1606,15 @@ impl<'a> FlowTypeEngine<'a> {
                     );
                 Ok(SchedulerStep::ContinueWalk(walk))
             }
+            ConditionFlowAction::Unreachable => {
+                get_flow_var_cache(self.cache, walk.query.var_cache_idx)
+                    .condition_cache
+                    .insert(
+                        (flow_id, condition_flow),
+                        CacheEntry::Cache(ConditionFlowAction::Unreachable),
+                    );
+                Ok(self.finish_unreachable_condition(walk))
+            }
             ConditionFlowAction::Result(result_type) => {
                 get_flow_var_cache(self.cache, walk.query.var_cache_idx)
                     .condition_cache
@@ -1509,7 +1622,7 @@ impl<'a> FlowTypeEngine<'a> {
                         (flow_id, condition_flow),
                         CacheEntry::Cache(ConditionFlowAction::Result(result_type.clone())),
                     );
-                Ok(self.finish_walk(walk, result_type))
+                Ok(self.finish_condition_result(walk, result_type))
             }
             ConditionFlowAction::Pending(pending_condition_narrow) => self.start_pending_condition(
                 walk,
@@ -1547,9 +1660,10 @@ impl<'a> FlowTypeEngine<'a> {
                 self.start_field_literal_sibling_subquery(walk, flow_id, condition_flow, subquery)
             ),
             ConditionFlowAction::NeedCorrelated(pending_correlated_condition) => {
+                let mode = walk.query.mode.for_point_dependency();
                 let subquery = walk.query.at_flow(
                     pending_correlated_condition.current_search_root_flow_id,
-                    FlowMode::WithConditions,
+                    mode,
                 );
                 Ok(SchedulerStep::StartQuery {
                     query: subquery,
@@ -1564,6 +1678,39 @@ impl<'a> FlowTypeEngine<'a> {
         }
     }
 
+    fn finish_unreachable_condition(&mut self, walk: QueryWalk) -> SchedulerStep {
+        // Unreachable describes the condition edge, not the queried symbol. A
+        // merge query asks what this branch contributes, so the answer is
+        // `never`; point queries continue to the antecedent so unrelated
+        // symbols inside impossible branches keep their declared types.
+        match walk.query.mode {
+            FlowMode::MergeBranch => self.finish_unreachable_branch(walk),
+            FlowMode::Normal | FlowMode::IgnoreConditions => SchedulerStep::ContinueWalk(walk),
+        }
+    }
+
+    fn finish_condition_result(&mut self, walk: QueryWalk, result_type: LuaType) -> SchedulerStep {
+        // Condition results describe a guard edge. If the guard removes every
+        // possible type while calculating a merge contribution, the branch is
+        // unreachable rather than an ordinary `never`-typed value.
+        if matches!(walk.query.mode, FlowMode::MergeBranch) && result_type.is_never() {
+            self.finish_unreachable_branch(walk)
+        } else {
+            self.finish_walk(walk, result_type)
+        }
+    }
+
+    fn finish_unreachable_branch(&mut self, walk: QueryWalk) -> SchedulerStep {
+        let query = walk.query;
+        get_flow_var_cache(self.cache, query.var_cache_idx)
+            .type_cache
+            .insert(
+                (query.flow_id, query.mode),
+                CacheEntry::Cache(FlowQueryResult::Unreachable),
+            );
+        SchedulerStep::ResumeNext(Ok(FlowQueryResult::Unreachable))
+    }
+
     fn finish_walk(&mut self, walk: QueryWalk, narrow_type: LuaType) -> SchedulerStep {
         let QueryWalk {
             query,
@@ -1571,18 +1718,28 @@ impl<'a> FlowTypeEngine<'a> {
             ..
         } = walk;
         let mut final_type = narrow_type;
-        if query.mode.uses_conditions() {
+        let mut condition_made_unreachable = false;
+        if !matches!(query.mode, FlowMode::IgnoreConditions) {
             for pending_condition_narrow in pending_condition_narrows.into_iter().rev() {
+                let was_possible = !final_type.is_never();
                 final_type = pending_condition_narrow.apply(self.db, self.cache, final_type);
+                condition_made_unreachable |= matches!(query.mode, FlowMode::MergeBranch)
+                    && was_possible
+                    && final_type.is_never();
             }
         }
+        let query_result = if condition_made_unreachable {
+            FlowQueryResult::Unreachable
+        } else {
+            FlowQueryResult::Type(final_type)
+        };
         get_flow_var_cache(self.cache, query.var_cache_idx)
             .type_cache
             .insert(
                 (query.flow_id, query.mode),
-                CacheEntry::Cache(final_type.clone()),
+                CacheEntry::Cache(query_result.clone()),
             );
-        SchedulerStep::ResumeNext(Ok(final_type))
+        SchedulerStep::ResumeNext(Ok(query_result))
     }
 
     fn fail_query<T>(
@@ -1798,6 +1955,28 @@ fn get_branch_label_flow_ids(
     let branch_flow_ids = Arc::<[FlowId]>::from(branch_flow_ids);
     cache.flow_branch_inputs_cache[flow_index] = Some(branch_flow_ids.clone());
     Ok(branch_flow_ids)
+}
+
+fn call_expr_stat_returns_never(
+    db: &DbIndex,
+    cache: &mut LuaInferCache,
+    root: &LuaChunk,
+    call_stat_ptr: &emmylua_parser::LuaAstPtr<LuaCallExprStat>,
+) -> bool {
+    let Some(call_stat) = call_stat_ptr.to_node(root) else {
+        return false;
+    };
+    let Some(call_expr) = call_stat.get_call_expr() else {
+        return false;
+    };
+    let Ok(Some(call_type)) = try_infer_expr_no_flow(db, cache, LuaExpr::CallExpr(call_expr))
+    else {
+        return false;
+    };
+
+    call_type
+        .get_result_slot_type(0)
+        .is_some_and(|ret| ret.is_never())
 }
 
 fn get_flow_assignment_info(

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/mod.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 pub(in crate::semantic) use condition_flow::{ConditionFlowAction, InferConditionFlow};
 use emmylua_parser::{LuaAstNode, LuaChunk, LuaExpr};
+pub(in crate::semantic) use get_type_at_cast_flow::apply_assignment_target_casts;
 pub use get_type_at_cast_flow::get_type_at_call_expr_inline_cast;
 pub use narrow_type::{narrow_down_type, narrow_false_or_nil, remove_false_or_nil};
 pub use var_ref_id::{VarRefId, get_var_expr_var_ref_id};

--- a/crates/emmylua_code_analysis/src/semantic/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/mod.rs
@@ -21,7 +21,7 @@ use emmylua_parser::{
     LuaSyntaxToken, LuaTableExpr,
 };
 pub use infer::infer_index_expr;
-use infer::{infer_bind_value_type, infer_expr_list_types};
+use infer::{apply_assignment_target_casts, infer_bind_value_type, infer_expr_list_types};
 pub use infer::{infer_table_field_value_should_be, infer_table_should_be};
 use lsp_types::Uri;
 pub use member::LuaMemberInfo;
@@ -130,6 +130,19 @@ impl<'a> SemanticModel<'a> {
 
     pub fn infer_expr(&self, expr: LuaExpr) -> Result<LuaType, InferFailReason> {
         infer_expr(self.db, &mut self.infer_cache.borrow_mut(), expr)
+    }
+
+    pub(crate) fn apply_assignment_target_casts(
+        &self,
+        target_expr: LuaExpr,
+        source_type: LuaType,
+    ) -> LuaType {
+        apply_assignment_target_casts(
+            self.db,
+            &mut self.infer_cache.borrow_mut(),
+            target_expr,
+            source_type,
+        )
     }
 
     pub fn infer_table_should_be(&self, table: LuaTableExpr) -> Option<LuaType> {


### PR DESCRIPTION
## Problem

Flow queries used `never` for two different ideas:

- a value whose real type is `never`
- a condition edge that cannot be reached

Those are not equivalent. A query for a symbol inside an impossible branch still needs to be able to walk past the impossible condition and find the symbol's declared or assigned type.

For example, this branch is unreachable, but `value` itself is still a `string`:

```lua
---@return false
local function always_false()
    return false
end

---@type string
local value = "ok"

if always_false() then
    inner = value -- should be string, not never
end
```

The same issue could show up as bogus diagnostics for unrelated call targets inside impossible branches:

```lua
---@return true
local function always_true()
    return true
end

local function b() end

if always_true() then
else
    b() -- should not become call-non-callable
end
```

At the same time, merge queries must still treat impossible predecessors as contributing nothing. In this case, the assignment in the impossible branch must not leak into the joined type:

```lua
---@return false
local function always_false()
    return false
end

local value = "before"

if always_false() then
    value = 1
end

after = value -- should be string, not string|1
```

## Solution

Separate unreachable condition edges from ordinary `never` values in flow-query results:

```rust
enum FlowQueryResult {
    Type(LuaType),
    Unreachable,
}
```

Then interpret `Unreachable` based on the kind of query being answered:

```rust
match flow_mode {
    FlowMode::Normal => continue_to_antecedent(),
    FlowMode::IgnoreConditions => continue_to_antecedent(),
    FlowMode::MergeBranch => contribute_never_to_merge(),
}
```

That gives the two cases different behavior:

- Point queries continue through impossible condition edges so unrelated symbols keep their real type.
- Merge-branch queries turn impossible predecessors into `never`, so unreachable assignments, casts, annotations, and fallback RHS values do not contribute to the joined type.

The change also preserves `MergeBranch` mode through the paths that can otherwise reintroduce unreachable branch facts:

```lua
local value = "before"

if always_false() then
    value = 1                  -- assignment ignored at merge
    ---@cast value integer      -- cast ignored at merge
    ---@type integer
    value = 1                  -- annotated assignment ignored at merge
end

after = value -- remains string
```

Reachable real `never` values are still distinct from unreachable branches. This still works because `never` is not treated as an unreachable edge by itself:

```lua
---@class NeverBox
---@field value never

---@return NeverBox
local function make_box() end

local value = make_box().value
local cond ---@type boolean

if cond then
    value = 1
end

after = value -- should be 1
```