### PR TITLE
fix: avoid flow replay for unrelated call conditions

### DIFF
--- a/crates/emmylua_code_analysis/src/compilation/test/flow.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/flow.rs
@@ -7,6 +7,7 @@ mod test {
     const STACKED_TYPE_GUARDS: usize = 180;
     const LARGE_LINEAR_ASSIGNMENT_STEPS: usize = 2048;
     const MAXWELLHOME_ARRAY_VALUES: usize = 2048;
+    const ISSUE_1100_HIGHLIGHT_GROUPS: usize = 2048;
 
     #[test]
     fn test_closure_return() {
@@ -498,6 +499,47 @@ mod test {
                 .is_some(),
             "expected semantic model for repeated self-call fallback stress repro"
         );
+    }
+
+    #[test]
+    #[timeout(5000)]
+    fn test_issue_1100_repeated_table_field_index_reads_after_unrelated_conditions() {
+        let mut ws = VirtualWorkspace::new();
+        let repeated_groups = (0..ISSUE_1100_HIGHLIGHT_GROUPS)
+            .map(|i| {
+                format!(
+                    "if enabled('group_{i}') then\n  hi('Group{i}', {{ fg = p.base0E, bg = p.base01, attr = nil, sp = nil }})\nend\n"
+                )
+            })
+            .collect::<String>();
+        let block = format!(
+            r#"
+        ---@type {{ base01: string, base0E: string }}
+        local palette = {{ base01 = "a", base0E = "b" }}
+
+        local function enabled(name)
+            return name ~= ""
+        end
+
+        local function hi(group, args)
+        end
+
+        local p = palette
+        {repeated_groups}
+        result = p.base0E
+        "#
+        );
+
+        let file_id = ws.def(&block);
+
+        assert!(
+            ws.analysis
+                .compilation
+                .get_semantic_model(file_id)
+                .is_some(),
+            "expected semantic model for repeated palette field reads"
+        );
+        assert_eq!(ws.expr_ty("result"), ws.ty("string"));
     }
 
     #[test]

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/condition_flow/mod.rs
@@ -35,6 +35,7 @@ use crate::{
             narrow_down_type, narrow_false_or_nil, remove_false_or_nil,
             var_ref_id::get_var_expr_var_ref_id,
         },
+        try_infer_expr_no_flow,
     },
     semantic::type_check::is_sub_type_of,
 };
@@ -63,9 +64,6 @@ pub(in crate::semantic) enum ExprTypeContinuation {
     ReceiverMethodCall {
         idx: LuaIndexMemberExpr,
         call_expr: LuaCallExpr,
-        condition_flow: InferConditionFlow,
-    },
-    Truthiness {
         condition_flow: InferConditionFlow,
     },
     ArrayLen {
@@ -596,12 +594,30 @@ pub(super) fn get_type_at_condition_flow(
                     return Ok(action);
                 }
 
-                let antecedent_flow_id = get_single_antecedent(flow_node)?;
-                return Ok(ConditionFlowAction::NeedExprType {
-                    flow_id: antecedent_flow_id,
-                    expr: LuaExpr::CallExpr(call_expr),
-                    resume: ExprTypeContinuation::Truthiness { condition_flow },
-                });
+                // The call does not narrow this ref. Only branch reachability
+                // matters here, so avoid starting another flow-aware replay.
+                return Ok(
+                    match try_infer_expr_no_flow(db, cache, LuaExpr::CallExpr(call_expr)) {
+                        Ok(Some(expr_type)) => {
+                            let unreachable_branch = expr_type.is_never()
+                                || match condition_flow {
+                                    InferConditionFlow::TrueCondition => {
+                                        expr_type.is_always_falsy()
+                                    }
+                                    InferConditionFlow::FalseCondition => {
+                                        expr_type.is_always_truthy()
+                                    }
+                                };
+
+                            if unreachable_branch {
+                                ConditionFlowAction::Result(LuaType::Never)
+                            } else {
+                                ConditionFlowAction::Continue
+                            }
+                        }
+                        _ => ConditionFlowAction::Continue,
+                    },
+                );
             }
             LuaExpr::IndexExpr(index_expr) => {
                 return get_type_at_index_expr(db, cache, var_ref_id, index_expr, condition_flow);
@@ -711,16 +727,6 @@ pub(in crate::semantic::infer::narrow) fn resolve_expr_type_continuation(
             call_expr,
             condition_flow,
         ),
-        ExprTypeContinuation::Truthiness { condition_flow } => Ok(match condition_flow {
-            _ if expr_type.is_never() => ConditionFlowAction::Result(LuaType::Never),
-            InferConditionFlow::TrueCondition if expr_type.is_always_falsy() => {
-                ConditionFlowAction::Result(LuaType::Never)
-            }
-            InferConditionFlow::FalseCondition if expr_type.is_always_truthy() => {
-                ConditionFlowAction::Result(LuaType::Never)
-            }
-            _ => ConditionFlowAction::Continue,
-        }),
         ExprTypeContinuation::ArrayLen {
             subquery_condition_flow,
             max_adjustment,


### PR DESCRIPTION
## Problem

Repeated unrelated call conditions like `if enabled(...) then` could make condition flow replay the call's expression type against prior flow for every branch. Large generated highlight tables then spent too much time repeatedly re-inferring unrelated table field reads.

## Solution

When a call condition does not narrow the queried ref, infer the call without flow and only use the result to reject impossible branches. The existing flow-aware call paths still handle calls that narrow the queried ref, such as type guards and return casts.

## Tests

- `cargo test -p emmylua_code_analysis`
- `cargo test -p emmylua_code_analysis flow`
- `cargo fmt --all --check`
- `git diff --check`
