### PR TITLE
fix: prioritize explicit @field over inherited table<K,V> index in infer_generic_member

### DIFF
--- a/crates/emmylua_code_analysis/src/semantic/infer/infer_index/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/infer_index/mod.rs
@@ -705,7 +705,16 @@ fn infer_generic_member(
         {
             return infer_member_by_lookup(db, cache, &origin_type, lookup, &infer_guard.fork());
         }
-
+        
+        // First, try to find the member directly on the type itself (explicit @field declarations).
+        // This ensures that explicit @field definitions take priority over inherited table index semantics.
+        let owner = LuaMemberOwner::Type(base_type_decl_id.clone());
+        if let Some(member_item) = db.get_member_index().get_member_item(&owner, &lookup.key) {
+            if let Ok(member_type) = member_item.resolve_type(db) {
+                return Ok(instantiate_type_generic(db, &member_type, &substitutor));
+            }
+        }
+        
         let result = infer_generic_members_from_super_generics(
             db,
             cache,


### PR DESCRIPTION
## Summary

Fixes #xxx

When a generic class inherits `table<K,V>` (K=string), explicit `@field` declarations are overridden by the parent's index semantics, causing `call-non-callable` false positives.

## Root Cause

In `infer_generic_member` (`crates/emmylua_code_analysis/src/semantic/infer/infer_index/mod.rs`, line 688), `infer_generic_members_from_super_generics` is called **before** checking the type's own `@field` declarations. When K=string and the lookup key is a string (e.g. `"create"`), the parent's `table<string, V>` index rule returns `Some(V)` immediately, making the subsequent `@field` check unreachable.

## Changes

| File | Change |
|------|--------|
| `crates/emmylua_code_analysis/src/semantic/infer/infer_index/mod.rs` | In `infer_generic_member`, move explicit `@field` lookup (`get_member_item` + `resolve_type`) before `infer_generic_members_from_super_generics` call (+9 lines) |

## Rationale

Explicit `@field` declarations represent the developer's intentional type specification for a specific member. They should always take precedence over inherited generic index semantics, following the standard OOP principle that subclass members override parent behavior.

## Example

```lua
---@class Container<K,V> : table<K,V>
---@field create fun(data: table): Container<K,V>
local Container = {}
function Container:create(_data) return self end

---@type Container<string, boolean>
local c
c.create({})
```

## Verification

Before fix (commit `d7d5dcbf`):

```text
---  [1 warning]
warning: Cannot call expression of type `boolean`. [call-non-callable]
  --> :7:1

  6 | local c
  7 | c.create({})

Summary
  1 warning

Check completed with warnings
Check finished
```

After fix:

```text
No issues found
Check finished
```
