### PR TITLE
fix: add Union branch to check_generic_type_compact to prevent param-type-mismatch false positives

### DIFF
--- a/crates/emmylua_code_analysis/src/semantic/type_check/generic_type.rs
+++ b/crates/emmylua_code_analysis/src/semantic/type_check/generic_type.rs
@@ -99,6 +99,19 @@ pub fn check_generic_type_compact(
                 check_guard.next_level()?,
             )
         }
+        LuaType::Union(union_type) => {
+            // When compact_type is a Union, every member of the union must be
+            // assignable to the source generic type for the assignment to be safe.
+            for member_type in union_type.into_vec() {
+                check_generic_type_compact(
+                    context,
+                    source_generic,
+                    &member_type,
+                    check_guard.next_level()?,
+                )?;
+            }
+            Ok(())
+        }
         _ => Err(TypeCheckFailReason::TypeNotMatch),
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1106 

When a method returning a generic type has both `@field` declaration and `function` implementation, the return value is internally wrapped in a Union type. `check_generic_type_compact` lacks a `LuaType::Union` branch, causing false `param-type-mismatch` / `assign-type-mismatch` warnings even when types are identical.

## Root Cause

In `check_generic_type_compact` (`crates/emmylua_code_analysis/src/semantic/type_check/generic_type.rs`, line 99), the `match` statement handles `GenericType`, `TableConst`, `Ref`/`Def`, but has no `LuaType::Union` branch. When `compact_type` is a Union (produced by merging `@field` and `function` sources in `resolve_member_type`), it falls through to `_ => Err(TypeCheckFailReason::TypeNotMatch)`.

## Changes

| File | Change |
|------|--------|
| `crates/emmylua_code_analysis/src/semantic/type_check/generic_type.rs` | Add `LuaType::Union` branch in `check_generic_type_compact` that iterates all union members and checks each against the source generic type (+13 lines) |

## Code Change

Insert before the `_ => Err(TypeCheckFailReason::TypeNotMatch)` arm in `check_generic_type_compact`:

```rust
        LuaType::Union(union_type) => {
            // When compact_type is a Union, every member of the union must be
            // assignable to the source generic type for the assignment to be safe.
            for member_type in union_type.into_vec() {
                check_generic_type_compact(
                    context,
                    source_generic,
                    &member_type,
                    check_guard.next_level()?,
                )?;
            }
            Ok(())
        }
```

## Rationale

A Union type `A | B` assigned to a generic parameter `T` requires **all** members to satisfy `T`'s constraints for the assignment to be safe. This is standard covariant semantics — the Union is a "wider" type, so each member must individually be valid.

## Example

```lua
---@class Item
---@field id integer
---@class Box<T>
---@field value T
---@class Service
---@field execute fun(self:Service, box:Box<Item>)
---@field fetch fun(self:Service):Box<Item>
local Service = {}
function Service:execute(_box) end
function Service:fetch() return {} --[[@as Box<Item>]] end
function Service:run()
    local b = self:fetch()
    self:execute(b)
end
```

## Verification

Before fix (commit `d7d5dcbf`):

```text
---  [1 warning]
warning: expected `Box<Item>` but found `Box<Item>`. [param-type-mismatch]
  --> :17:18

 16 |     local b = self:fetch()
 17 |     self:execute(b)

Summary
  1 warning

Check completed with warnings
Check finished
```

After fix:

```text
No issues found
Check finished
```
