### PR TITLE
Fix: `undefined-field` false positive for `table<K,V>` when value type is generic and key is not `string`/`integer`

### DIFF
--- a/crates/emmylua_code_analysis/src/diagnostic/checker/check_field.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/checker/check_field.rs
@@ -274,6 +274,8 @@ pub(super) fn is_valid_member(
                             }
                         } else if typ.is_integer() && key_types.iter().any(|typ| typ.is_integer()) {
                             return Some(());
+                        } else if key_types.iter().any(|kt| kt == typ) {
+                            return Some(());
                         }
                     }
                     LuaMemberKey::Name(_) => {
@@ -376,6 +378,9 @@ fn get_key_types(db: &DbIndex, typ: &LuaType) -> HashSet<LuaType> {
                 type_set.insert(current_type);
             }
             LuaType::DocStringConst(_) | LuaType::DocIntegerConst(_) => {
+                type_set.insert(current_type);
+            }
+            LuaType::Boolean | LuaType::Thread | LuaType::Number | LuaType::Userdata => {
                 type_set.insert(current_type);
             }
             LuaType::Call(alias_call) => {

--- a/crates/emmylua_code_analysis/src/diagnostic/test/undefined_field_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/undefined_field_test.rs
@@ -900,4 +900,48 @@ mod test {
         assert_eq!(ws.expr_ty("alias_result"), ws.ty("string?"));
         assert_eq!(ws.expr_ty("numeric_result"), ws.ty("string?"));
     }
+
+    #[test]
+    fn test_table_generic_value_with_thread_key() {
+        let mut ws = VirtualWorkspace::new();
+        assert!(ws.has_no_diagnostic(
+            DiagnosticCode::UndefinedField,
+            r#"
+                ---@class Box<T>
+                ---@field value T
+
+                ---@class Container
+                ---@field items table<thread, Box<unknown>?>
+                local Container = {}
+
+                ---@param co thread
+                function Container:get(co)
+                    local item = self.items[co]
+                    return item
+                end
+            "#
+        ));
+    }
+
+    #[test]
+    fn test_table_generic_value_with_boolean_key() {
+        let mut ws = VirtualWorkspace::new();
+        assert!(ws.has_no_diagnostic(
+            DiagnosticCode::UndefinedField,
+            r#"
+                ---@class Box<T>
+                ---@field value T
+
+                ---@class Container
+                ---@field items table<boolean, Box<unknown>?>
+                local Container = {}
+
+                ---@param key boolean
+                function Container:get(key)
+                    local item = self.items[key]
+                    return item
+                end
+            "#
+        ));
+    }
 }


### PR DESCRIPTION
## Related Issue

Fixes #1108 

## Problem

The bug has two layers in `check_field.rs`:

### Layer 1: `get_key_types()` drops non-string/integer built-in types

```rust
// Before (check_field.rs, get_key_types function, around line 355)
match &current_type {
    LuaType::String => { type_set.insert(current_type); }
    LuaType::Integer => { type_set.insert(current_type); }
    LuaType::Union(union_typ) => { /* expand union */ }
    LuaType::StrTplRef(_) | LuaType::Ref(_) => { type_set.insert(current_type); }
    LuaType::DocStringConst(_) | LuaType::DocIntegerConst(_) => { type_set.insert(current_type); }
    LuaType::Call(alias_call) => { /* expand keyof */ }
    _ => {}  // ← thread, boolean, number, userdata silently dropped!
}
```

When the key type is `thread`, `get_key_types()` returns an empty set → `key_types.is_empty()` → early return → reports `undefined-field`.

### Layer 2: `ExprType` matching only handles `string` and `integer`

```rust
// Before (check_field.rs, is_valid_member function, around line 266)
LuaMemberKey::ExprType(typ) => {
    if typ.is_string() { /* pass */ }
    else if typ.is_integer() { /* pass */ }
    // ← thread, boolean, etc. fall through without any check
}
```

## Fix

### Fix 1: Add built-in types to `get_key_types()`

```rust
// After
LuaType::Boolean | LuaType::Thread | LuaType::Number | LuaType::Userdata => {
    type_set.insert(current_type);
}
```

### Fix 2: Add fallback equality check in `ExprType` matching

```rust
// After
} else if key_types.iter().any(|kt| kt == typ) {
    return Some(());
}
```

## Files Changed

- `crates/emmylua_code_analysis/src/diagnostic/checker/check_field.rs` — fix both layers
- `crates/emmylua_code_analysis/src/diagnostic/test/undefined_field_test.rs` — add 2 test cases

## Test

Add test cases in `undefined_field_test.rs`:

```rust
#[test]
fn test_table_generic_value_with_thread_key() {
    let mut ws = VirtualWorkspace::new();
    assert!(ws.has_no_diagnostic(
        DiagnosticCode::UndefinedField,
        r#"
            ---@class Box<T>
            ---@field value T

            ---@class Container
            ---@field items table<thread, Box<unknown>?>
            local Container = {}

            ---@param co thread
            function Container:get(co)
                local item = self.items[co]
                return item
            end
        "#
    ));
}

#[test]
fn test_table_generic_value_with_boolean_key() {
    let mut ws = VirtualWorkspace::new();
    assert!(ws.has_no_diagnostic(
        DiagnosticCode::UndefinedField,
        r#"
            ---@class Box<T>
            ---@field value T

            ---@class Container
            ---@field items table<boolean, Box<unknown>?>
            local Container = {}

            ---@param key boolean
            function Container:get(key)
                local item = self.items[key]
                return item
            end
        "#
    ));
}
```

## Verification

Before fix:
```
---@class Box<T>
---@field value T

---@class Container
---@field items table<thread, Box<unknown>?>
local Container = {}
---@param co thread
function Container:get(co)
    local item = self.items[co]  -- ⚠️ Undefined field `[co]`
    return item
end
```

After fix: No warning.
