### PR TITLE
fix: stop repeated assignments from hanging

### DIFF
--- a/crates/emmylua_code_analysis/src/compilation/test/flow.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/flow.rs
@@ -8,6 +8,8 @@ mod test {
     const LARGE_LINEAR_ASSIGNMENT_STEPS: usize = 2048;
     const MAXWELLHOME_ARRAY_VALUES: usize = 2048;
     const ISSUE_1100_HIGHLIGHT_GROUPS: usize = 2048;
+    const REPEATED_SELF_ASSIGNMENT_STEPS: usize = 512;
+    const REPEATED_SELF_ASSIGNMENT_VARIANT_STEPS: usize = 128;
 
     #[test]
     fn test_closure_return() {
@@ -2940,6 +2942,187 @@ _2 = a[1]
         );
         let after_assign = ws.expr_ty("after_assign");
         assert_eq!(ws.humanize_type(after_assign), "Pattern");
+    }
+
+    #[test]
+    fn test_assignment_binary_rhs_replays_non_self_dependency() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+        ---@class FooValue
+        ---@field kind "foo"
+        ---@field value integer
+
+        ---@class BarValue
+        ---@field kind "bar"
+        ---@field value string
+
+        local right ---@type FooValue|BarValue
+
+        if right.kind == "foo" then
+            local value
+            value = right.value + 1
+            after_assign = value
+        end
+        "#,
+        );
+
+        let after_assign = ws.expr_ty("after_assign");
+        assert_eq!(ws.humanize_type(after_assign), "integer");
+    }
+
+    #[test]
+    fn test_assignment_rhs_keeps_flow_dependent_concat_operator() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+        ---@class Rope
+        ---@operator concat(Rope): Rope
+
+        local left ---@type Rope?
+        local right ---@type Rope?
+
+        if not left then return end
+        if not right then return end
+        left = left .. right
+        after_assign = left
+        "#,
+        );
+
+        let after_assign = ws.expr_ty("after_assign");
+        assert_eq!(ws.humanize_type(after_assign), "Rope");
+    }
+
+    #[test]
+    fn test_assignment_rhs_keeps_flow_dependent_add_operator() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+        ---@class Counter
+        ---@operator add(Counter): Counter
+
+        local left ---@type Counter?
+        local right ---@type Counter?
+
+        if not left then return end
+        if not right then return end
+        left = left + right
+        after_assign = left
+        "#,
+        );
+
+        let after_assign = ws.expr_ty("after_assign");
+        assert_eq!(ws.humanize_type(after_assign), "Counter");
+    }
+
+    #[test]
+    #[timeout(5000)]
+    fn test_issue_1114_repeated_self_dependent_assignments_build_semantic_model() {
+        let cases = [
+            (
+                "concat",
+                r#"local value = """#,
+                "value = value .. config.pic[idx][index]",
+                REPEATED_SELF_ASSIGNMENT_STEPS,
+            ),
+            (
+                "add",
+                "local value = 0",
+                "value = value + config.pic[idx][index]",
+                REPEATED_SELF_ASSIGNMENT_VARIANT_STEPS,
+            ),
+            (
+                "parenthesized concat",
+                r#"local value = """#,
+                "value = (value .. config.pic[idx][index])",
+                REPEATED_SELF_ASSIGNMENT_VARIANT_STEPS,
+            ),
+            (
+                "unary",
+                "local value = 0",
+                "value = -(value + config.pic[idx][index])",
+                REPEATED_SELF_ASSIGNMENT_VARIANT_STEPS,
+            ),
+            (
+                "comparison",
+                "local value = true",
+                "value = value == config.pic[idx][index]",
+                REPEATED_SELF_ASSIGNMENT_VARIANT_STEPS,
+            ),
+        ];
+
+        for (name, init, assignment, steps) in cases {
+            let mut ws = VirtualWorkspace::new();
+            let repeated_assignments = format!("{assignment}\n").repeat(steps);
+            let block = format!(
+                r#"
+            function f(config, idx, index)
+                {init}
+                {repeated_assignments}
+                return value
+            end
+            "#
+            );
+
+            let file_id = ws.def(&block);
+
+            assert!(
+                ws.analysis
+                    .compilation
+                    .get_semantic_model(file_id)
+                    .is_some(),
+                "expected semantic model for repeated self-dependent {name} assignment"
+            );
+        }
+    }
+
+    #[test]
+    #[timeout(5000)]
+    fn test_issue_1116_generic_call_index_replay_builds_semantic_model() {
+        let mut ws = VirtualWorkspace::new();
+        let repeated_assignments =
+            "value = id(value .. config.pic[idx][index])\n".repeat(REPEATED_SELF_ASSIGNMENT_STEPS);
+        let block = format!(
+            r#"
+        ---@generic T
+        ---@param value T
+        ---@return T
+        local function id(value)
+            return value
+        end
+
+        function f(config, idx, index)
+            local value
+            {repeated_assignments}
+            return value
+        end
+        "#
+        );
+
+        let file_id = ws.def(&block);
+
+        assert!(
+            ws.analysis
+                .compilation
+                .get_semantic_model(file_id)
+                .is_some(),
+            "expected semantic model for generic call index replay repro"
+        );
+    }
+
+    #[test]
+    fn test_binary_assignment_infer_error_keeps_previous_type() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+        local value = "prior"
+        value = config.pic + 1
+        after_assign = value
+        "#,
+        );
+
+        let after_assign = ws.expr_ty("after_assign");
+        assert_eq!(ws.humanize_type(after_assign), "string");
     }
 
     #[test]

--- a/crates/emmylua_code_analysis/src/semantic/infer/narrow/get_type_at_flow.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/narrow/get_type_at_flow.rs
@@ -1,6 +1,6 @@
 use emmylua_parser::{
-    LuaAssignStat, LuaAstNode, LuaChunk, LuaDocOpType, LuaExpr, LuaIndexKey, LuaIndexMemberExpr,
-    LuaSyntaxId, LuaTableExpr, LuaVarExpr,
+    BinaryOperator, LuaAssignStat, LuaAstNode, LuaChunk, LuaDocOpType, LuaExpr, LuaIndexKey,
+    LuaIndexMemberExpr, LuaSyntaxId, LuaTableExpr, LuaVarExpr,
 };
 use hashbrown::HashSet;
 use std::{rc::Rc, sync::Arc};
@@ -200,6 +200,26 @@ impl FlowReplayQuery {
         self.dependency_queries.get(self.next_dependency_idx)
     }
 
+    fn accept_resolved_dependencies(&mut self) -> Result<(), InferFailReason> {
+        while let Some(typ) = self
+            .dependency_queries
+            .get(self.next_dependency_idx)
+            .and_then(|query| query.resolved_type.clone())
+        {
+            self.accept_result(Ok(typ))?;
+        }
+
+        Ok(())
+    }
+
+    fn resolve_dependencies(&mut self, var_ref_id: &VarRefId, typ: LuaType) {
+        for query in &mut self.dependency_queries {
+            if query.var_ref_id == *var_ref_id {
+                query.resolved_type = Some(typ.clone());
+            }
+        }
+    }
+
     fn accept_result(&mut self, dependency_result: InferResult) -> Result<(), InferFailReason> {
         let dependency_query = self
             .dependency_queries
@@ -269,6 +289,7 @@ struct FlowExprTypeQuery {
     syntax_id: LuaSyntaxId,
     literal_shape_type: Option<LuaType>,
     next_dependency_idx_on_success: Option<usize>,
+    resolved_type: Option<LuaType>,
 }
 
 fn collect_expr_dependency_queries(
@@ -294,6 +315,7 @@ fn collect_expr_dependency_queries(
                 syntax_id: expr.get_syntax_id(),
                 literal_shape_type: None,
                 next_dependency_idx_on_success: None,
+                resolved_type: None,
             });
         }
         return;
@@ -341,6 +363,7 @@ fn collect_expr_dependency_queries(
                     syntax_id: expr.get_syntax_id(),
                     literal_shape_type,
                     next_dependency_idx_on_success: None,
+                    resolved_type: None,
                 });
                 Some(query_idx)
             } else {
@@ -646,8 +669,10 @@ impl<'a> FlowTypeEngine<'a> {
         &mut self,
         walk: QueryWalk,
         replay: FlowExprReplay,
-        replay_query: FlowReplayQuery,
+        mut replay_query: FlowReplayQuery,
     ) -> Result<SchedulerStep, InferFailReason> {
+        replay_query.accept_resolved_dependencies()?;
+
         let next_query = replay_query
             .next_query()
             .map(|query| (query.var_ref_id.clone(), query.flow_id));
@@ -1044,14 +1069,20 @@ impl<'a> FlowTypeEngine<'a> {
             let expr_idx = i.min(last_expr_idx);
             let result_slot = i.saturating_sub(last_expr_idx);
             let expr = assignment_info.exprs[expr_idx].clone();
-            let replay_query = FlowReplayQuery::new(
+            let mut replay_query = FlowReplayQuery::new(
                 self.db,
                 Some(self.tree),
                 self.cache,
                 antecedent_flow_id,
-                expr,
+                expr.clone(),
                 true,
             );
+            // A plain self-dependent RHS would replay this assignment while
+            // trying to type itself. Treat that self read as unknown; `and`/`or`
+            // assignments still need the antecedent value for their semantics.
+            if explicit_var_type.is_none() && !contains_short_circuit_binary_expr(&expr) {
+                replay_query.resolve_dependencies(&var_ref_id, LuaType::Unknown);
+            }
             return self.start_expr_replay(
                 walk,
                 FlowExprReplay::Assignment {
@@ -1292,6 +1323,23 @@ impl<'a> FlowTypeEngine<'a> {
     // continuation point like a branch merge.
     fn evaluate_walk(&mut self, mut walk: QueryWalk) -> Result<SchedulerStep, InferFailReason> {
         loop {
+            // Replays can suspend a query and later revisit an older antecedent
+            // that another query already finished. Use that cached type instead
+            // of walking back through the same replay chain again.
+            if walk.antecedent_flow_id != walk.query.flow_id
+                && let Some(CacheEntry::Cache(narrow_type)) = self
+                    .cache
+                    .flow_var_caches
+                    .get(walk.query.var_cache_idx as usize)
+                    .and_then(|var_cache| {
+                        var_cache
+                            .type_cache
+                            .get(&(walk.antecedent_flow_id, walk.query.mode))
+                    })
+            {
+                return Ok(self.finish_walk(walk, narrow_type.clone()));
+            }
+
             let flow_node = self
                 .tree
                 .get_flow_node(walk.antecedent_flow_id)
@@ -1645,6 +1693,17 @@ fn can_reuse_narrowed_assignment_source(
 
 fn preserves_assignment_expr_type(typ: &LuaType) -> bool {
     matches!(typ, LuaType::TableConst(_) | LuaType::Object(_)) || is_exact_assignment_expr_type(typ)
+}
+
+fn contains_short_circuit_binary_expr(expr: &LuaExpr) -> bool {
+    expr.descendants::<LuaExpr>().any(|expr| {
+        let LuaExpr::BinaryExpr(binary_expr) = expr else {
+            return false;
+        };
+        binary_expr.get_op_token().is_some_and(|token| {
+            matches!(token.get_op(), BinaryOperator::OpAnd | BinaryOperator::OpOr)
+        })
+    })
 }
 
 fn is_partial_assignment_expr_compatible(


### PR DESCRIPTION
## Problem

Repeated self-dependent assignments can make semantic model building replay the same assignment while it is still resolving the RHS:

```lua
value = value .. config.pic[idx][index]
value = value .. config.pic[idx][index]
```

The dependency replay for `value` asks for `value` again at the same assignment path, so long chains can stall analysis.

## Solution

Resolve plain self-dependencies inside assignment RHS replay as `unknown` before scheduling the dependent replay. This breaks the recursive dependency cycle at the point where the RHS reads the value being assigned.

The handling stays narrow: non-self RHS dependencies keep normal flow replay, and `and`/`or` assignments still use the antecedent value because short-circuiting depends on it.

Fixes #1114
