### PR TITLE
Add more information about formatter to docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ Our project is organized into several crates:
 | [🖥️ **emmylua_ls**](./crates/emmylua_ls)                       | [![emmylua_ls](https://img.shields.io/crates/v/emmylua_ls.svg?style=flat-square)](https://crates.io/crates/emmylua_ls)                                  | The complete Language Server Protocol implementation offering rich IDE features across all major editors. |
 | [📚 **emmylua_doc_cli**](./crates/emmylua_doc_cli/)            | [![emmylua_doc_cli](https://img.shields.io/crates/v/emmylua_doc_cli.svg?style=flat-square)](https://crates.io/crates/emmylua_doc_cli)                   | Professional documentation generator creating beautiful, searchable API docs from your Lua code and annotations. |
 | [✅ **emmylua_check**](./crates/emmylua_check)                 | [![emmylua_check](https://img.shields.io/crates/v/emmylua_check.svg?style=flat-square)](https://crates.io/crates/emmylua_check)                         | Comprehensive static analysis tool for code quality assurance, catching bugs before they reach production. |
+| [✅ **emmylua_formatter**](./crates/emmylua_formatter)         | [![emmylua_formatter](https://img.shields.io/crates/v/emmylua_formatter.svg?style=flat-square)](https://crates.io/crates/emmylua_formatter)             | The Lua formatter used by the EmmyLua Analyzer Rust workspace. |
 
 
 ## Testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Our project is organized into several crates:
 | [🖥️ **emmylua_ls**](./crates/emmylua_ls)                       | [![emmylua_ls](https://img.shields.io/crates/v/emmylua_ls.svg?style=flat-square)](https://crates.io/crates/emmylua_ls)                                  | The complete Language Server Protocol implementation offering rich IDE features across all major editors. |
 | [📚 **emmylua_doc_cli**](./crates/emmylua_doc_cli/)            | [![emmylua_doc_cli](https://img.shields.io/crates/v/emmylua_doc_cli.svg?style=flat-square)](https://crates.io/crates/emmylua_doc_cli)                   | Professional documentation generator creating beautiful, searchable API docs from your Lua code and annotations. |
 | [✅ **emmylua_check**](./crates/emmylua_check)                 | [![emmylua_check](https://img.shields.io/crates/v/emmylua_check.svg?style=flat-square)](https://crates.io/crates/emmylua_check)                         | Comprehensive static analysis tool for code quality assurance, catching bugs before they reach production. |
-| [✅ **emmylua_formatter**](./crates/emmylua_formatter)         | [![emmylua_formatter](https://img.shields.io/crates/v/emmylua_formatter.svg?style=flat-square)](https://crates.io/crates/emmylua_formatter)             | The Lua formatter used by the EmmyLua Analyzer Rust workspace. |
+| [🧹 **emmylua_formatter**](./crates/emmylua_formatter)         | [![emmylua_formatter](https://img.shields.io/crates/v/emmylua_formatter.svg?style=flat-square)](https://crates.io/crates/emmylua_formatter)             | The Lua formatter used by the EmmyLua Analyzer Rust workspace. |
 
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # EmmyLua Analyzer Rust
 
-**A high-performance Lua language server, linter, and documentation generator — built with Rust.**
+**A high-performance Lua language server, code formatter, linter, and documentation generator — built with Rust.**
 
 [![GitHub stars](https://img.shields.io/github/stars/CppCXY/emmylua-analyzer-rust?style=flat-square&logo=github)](https://github.com/CppCXY/emmylua-analyzer-rust/stargazers)
 [![License](https://img.shields.io/github/license/CppCXY/emmylua-analyzer-rust?style=flat-square)](https://github.com/CppCXY/emmylua-analyzer-rust/blob/main/LICENSE)
@@ -31,6 +31,7 @@
 ```bash
 # Via Cargo
 cargo install emmylua_ls          # Language server
+cargo install emmylua_formatter   # Code formatter
 cargo install emmylua_check       # Static analyzer / linter
 cargo install emmylua_doc_cli     # Documentation generator
 ```
@@ -169,6 +170,12 @@ emmylua_ls -c tcp --port 5007 --log-level debug --log-path ./logs
 | `--port` | TCP port (default: 5007) |
 | `--log-level` | `debug` / `info` / `warn` / `error` |
 | `--log-path` | Log output directory |
+
+### Code Formatter
+
+```bash
+luafmt src --write                      # Format src directory
+```
 
 ### Static Analyzer
 


### PR DESCRIPTION
For being a seemingly-major part of the toolchain, `emmylua_formatter`/`luafmt` wasn't explicitly named in `README.md` or `CONTRIBUTING.md`.