### PR TITLE
fix LuaJIT name in warnings

### DIFF
--- a/crates/emmylua_parser/src/kind/lua_version.rs
+++ b/crates/emmylua_parser/src/kind/lua_version.rs
@@ -60,7 +60,7 @@ impl Ord for LuaVersionNumber {
 impl fmt::Display for LuaVersionNumber {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            LuaVersionNumber::LUA_JIT => write!(f, "Lua JIT"),
+            LuaVersionNumber::LUA_JIT => write!(f, "LuaJIT"),
             LuaVersionNumber { major, minor, .. } => write!(f, "Lua {}.{}", major, minor),
         }
     }


### PR DESCRIPTION
emmylua_check usually misspells LuaJIT name in warnings. The patch fixes that.

Closes #1170