### PR TITLE
Fix nix flake build with current rust and openssl

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746904237,
-        "narHash": "sha256-3e+AVBczosP5dCLQmMoMEogM57gmZ2qrVSrmq9aResQ=",
+        "lastModified": 1784120854,
+        "narHash": "sha256-KesHgItiZPgGX740axSiQLcIQ8D24MDqNpkKYWIek8k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d89fc19e405cb2d55ce7cc114356846a0ee5e956",
+        "rev": "753cc8a3a87467296ddd1fa93f0cc3e81120ee46",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747017456,
-        "narHash": "sha256-C/U12fcO+HEF071b5mK65lt4XtAIZyJSSJAg9hdlvTk=",
+        "lastModified": 1784216271,
+        "narHash": "sha256-bvaxxdk7mmMQ88AuXQGTUtk+PcUujHpgxqpryqTWvTU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "5b07506ae89b025b14de91f697eba23b48654c52",
+        "rev": "1f69c7203034a4a974d7a4eac0f19b54af30804d",
         "type": "github"
       },
       "original": {

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -3,10 +3,9 @@ let
   mkPackage =
     x:
     {
-      lib,
       rustPlatform,
-      stdenv,
       pkg-config,
+      openssl,
     }:
     let
       cargoToml = builtins.fromTOML (builtins.readFile /${root}/crates/${x}/Cargo.toml);
@@ -15,17 +14,18 @@ let
       pname = cargoToml.package.name;
       version = cargoToml.package.version;
 
+      strictDeps = true;
+
       src = root;
       cargoLock.lockFile = root + /Cargo.lock;
 
       nativeBuildInputs = [ pkg-config ];
-      buildInputs = [ stdenv.cc.cc.lib ];
+      buildInputs = [ openssl ];
+
+      # Needed to get openssl-sys to use pkg-config.
+      env.OPENSSL_NO_VENDOR = 1;
 
       buildAndTestSubdir = "crates/${x}";
-
-      postFixup = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
-        patchelf --set-rpath "${stdenv.cc.cc.lib}/lib" $out/bin/${x}
-      '';
     };
 in
 (builtins.listToAttrs (


### PR DESCRIPTION
## Issue

The current `flake.lock` pins an older rust toolchain which no longer builds the current `Cargo.lock` dependencies.

Furthermore `openssl-sys` started using vendored openssl and failed because `perl` wasn't in the nix build environment.

## Fix

- Update the flake inputs to provide a newer rust toolchain.
- Set `OPENSSL_NO_VENDOR=1` so `openssl-sys` uses the openssl provided by nixpkgs via `pkg-config`.

## Tests

- `nix flake check`
- `nix build`
- `nix shell`
- `nix develop`