### PR TITLE
fixed safe-navigation assignment formatting

### DIFF
--- a/crates/emmylua_formatter/src/test/statement_tests.rs
+++ b/crates/emmylua_formatter/src/test/statement_tests.rs
@@ -2001,6 +2001,39 @@ end
         assert_eq!(result, expected);
     }
 
+    #[test]
+    fn test_safe_navigation_continuous_assign_alignment() {
+        use crate::format_text;
+        use emmylua_parser::LuaLanguageLevel;
+
+        let config = LuaFormatConfig {
+            indent: crate::config::IndentConfig {
+                kind: crate::config::IndentKind::Space,
+                width: 2,
+            },
+            align: crate::config::AlignConfig {
+                continuous_assign_statement: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let input = "\
+function func()
+    self.foo?.bar = true
+    self.foo?.barbar  = 0.250
+end
+";
+        let expected = "\
+function func()
+  self.foo?.bar    = true
+  self.foo?.barbar = 0.250
+end
+";
+        let result = format_text(input, LuaLanguageLevel::LuaJIT, &config).formatted;
+        assert_eq!(result, expected);
+    }
+
     // ========== LuaJIT extension: nil-coalescing ==========
 
     #[test]

--- a/crates/emmylua_parser/src/syntax/node/lua/expr.rs
+++ b/crates/emmylua_parser/src/syntax/node/lua/expr.rs
@@ -117,7 +117,10 @@ impl LuaAstNode for LuaVarExpr {
     where
         Self: Sized,
     {
-        matches!(kind, LuaSyntaxKind::NameExpr | LuaSyntaxKind::IndexExpr)
+        matches!(
+            kind,
+            LuaSyntaxKind::NameExpr | LuaSyntaxKind::IndexExpr | LuaSyntaxKind::SafeIndexExpr
+        )
     }
 
     fn cast(syntax: LuaSyntaxNode) -> Option<Self>
@@ -126,7 +129,9 @@ impl LuaAstNode for LuaVarExpr {
     {
         match syntax.kind().into() {
             LuaSyntaxKind::NameExpr => LuaNameExpr::cast(syntax).map(LuaVarExpr::NameExpr),
-            LuaSyntaxKind::IndexExpr => LuaIndexExpr::cast(syntax).map(LuaVarExpr::IndexExpr),
+            LuaSyntaxKind::IndexExpr | LuaSyntaxKind::SafeIndexExpr => {
+                LuaIndexExpr::cast(syntax).map(LuaVarExpr::IndexExpr)
+            }
             _ => None,
         }
     }


### PR DESCRIPTION
had an issue where the formatter mangles some lines

eg.

```lua
function func()
  self.foo?.bar    = true
  self.foo?.barbar = 0.250
end
```

to

```lua
function func()
   = true
   = 0.250
end
```

(i have no idea what I'm doing)