### PR TITLE
fix(docs): wrap and indent overflowing signatures

### DIFF
--- a/crates/emmylua_doc_cli/template/static/rustdoc.css
+++ b/crates/emmylua_doc_cli/template/static/rustdoc.css
@@ -588,11 +588,12 @@ pre.signature {
   border-left: 3px solid var(--accent);
   border-radius: var(--radius);
   padding: 9px 14px;
-  overflow-x: auto;
   font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
   font-size: 13px;
   line-height: 1.55;
   margin: 10px 0;
+  text-wrap: wrap;
+  text-indent: 3em hanging each-line;
 }
 pre.signature code { background: transparent; padding: 0; }
 pre.signature a { color: var(--accent); font-weight: 500; }


### PR DESCRIPTION
Long signatures would cut off, and you'd need to scroll/select the text to see everything. With this change, the text wraps. The wrapped text is indented.

Before: 
<img src="https://github.com/user-attachments/assets/c6f1968d-240a-4a44-8935-59b255671aba" />
After:
<img src="https://github.com/user-attachments/assets/e64372e0-9164-4fd1-aa29-8ca8a1b0a86c" />

