### PR TITLE
fix compound assignment alignment formatting

### DIFF
--- a/crates/emmylua_formatter/src/formatter/render/statements.rs
+++ b/crates/emmylua_formatter/src/formatter/render/statements.rs
@@ -1015,7 +1015,7 @@ fn render_assign_stat_align_split(
 
     let expr_list_plan = plan.layout.statement_expr_lists.get(&syntax_id).copied()?;
     let comma_token = first_direct_token(stat.syntax(), LuaTokenKind::TkComma);
-    let assign_token = first_direct_token(stat.syntax(), LuaTokenKind::TkAssign);
+    let assign_token = stat.get_assign_op().map(|op| op.syntax().clone());
 
     let mut before = Vec::new();
     for (index, var) in vars.iter().enumerate() {

--- a/crates/emmylua_formatter/src/test/statement_tests.rs
+++ b/crates/emmylua_formatter/src/test/statement_tests.rs
@@ -1905,6 +1905,26 @@ end
         );
     }
 
+    // ========== LuaJIT extension: compound assignment ==========
+
+    #[test]
+    fn test_compound_assignment_with_continuous_assignment_alignment() {
+        use crate::format_text;
+        use emmylua_parser::LuaLanguageLevel;
+
+        let config = LuaFormatConfig {
+            align: crate::config::AlignConfig {
+                continuous_assign_statement: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let input = "self.test += 1\n";
+        let expected = "self.test += 1\n";
+        let result = format_text(input, LuaLanguageLevel::LuaJIT, &config).formatted;
+        assert_eq!(result, expected);
+    }
+
     // ========== LuaJIT extension: const ==========
 
     #[test]


### PR DESCRIPTION
`self.test += 1` was incorrectly formatted as `self.test =1`