### PR TITLE
chore(doc_cli): Format JS and CSS with Prettier

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,11 @@ jobs:
     - name: Run style check
       run: pre-commit run --all --hook-stage manual
 
+    - name: Install Prettier
+      run: npm i -g prettier
+    - name: Check formatting with Prettier
+      run: prettier -c .
+
   clippy:
     name: Clippy Lint Check
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,14 @@ repos:
         language: system
         files: ^tools/schema_json_gen/src/main\.rs$
         pass_filenames: false
+      - id: prettier
+        name: prettier
+        entry: prettier
+        args: [--write, --ignore-unknown]
+        language: node
+        types: [text]
+        additional_dependencies:
+          - prettier@3.9.6
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,13 @@
+# Only format in /crates/emmylua_doc_cli/template.
+/*
+!/crates
+/crates/*
+!/crates/emmylua_doc_cli
+/crates/emmylua_doc_cli/*
+!/crates/emmylua_doc_cli/template
+
+*.md
+*.html
+
+# Re-include .prettierrc
+!.prettierrc

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "printWidth": 120
+}

--- a/crates/emmylua_doc_cli/template/static/main.js
+++ b/crates/emmylua_doc_cli/template/static/main.js
@@ -17,7 +17,13 @@
 
   function escapeHtml(s) {
     return String(s).replace(/[&<>"']/g, function (c) {
-      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+      return {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;',
+      }[c];
     });
   }
 
@@ -51,7 +57,9 @@
       document.documentElement.setAttribute('data-theme', next);
       try {
         localStorage.setItem(THEME_KEY, next);
-      } catch (e) { /* private mode etc. */ }
+      } catch (e) {
+        /* private mode etc. */
+      }
       syncButton();
     });
   }
@@ -134,7 +142,9 @@
         var text = pre.textContent || '';
         function done() {
           btn.classList.add('copied');
-          setTimeout(function () { btn.classList.remove('copied'); }, 1500);
+          setTimeout(function () {
+            btn.classList.remove('copied');
+          }, 1500);
         }
         if (navigator.clipboard && navigator.clipboard.writeText) {
           navigator.clipboard.writeText(text).then(done, function () {
@@ -157,7 +167,9 @@
       ta.select();
       try {
         document.execCommand('copy');
-      } catch (e) { /* best effort */ }
+      } catch (e) {
+        /* best effort */
+      }
       document.body.removeChild(ta);
     }
   }
@@ -208,11 +220,19 @@
       resultsPanel.innerHTML = matches
         .map(function (entry, i) {
           var href = rootPrefix() + entry.href;
-          return '<a class="search-result' + (i === selected ? ' selected' : '') +
-            '" role="option" aria-selected="' + (i === selected ? 'true' : 'false') +
-            '" href="' + escapeHtml(href) + '"><span class="search-result-kind">' +
-            escapeHtml(entry.kind || '') + '</span><span class="search-result-name">' +
-            entry.nameHtml + '</span></a>';
+          return (
+            '<a class="search-result' +
+            (i === selected ? ' selected' : '') +
+            '" role="option" aria-selected="' +
+            (i === selected ? 'true' : 'false') +
+            '" href="' +
+            escapeHtml(href) +
+            '"><span class="search-result-kind">' +
+            escapeHtml(entry.kind || '') +
+            '</span><span class="search-result-name">' +
+            entry.nameHtml +
+            '</span></a>'
+          );
         })
         .join('');
       input.setAttribute('aria-expanded', 'true');
@@ -239,9 +259,13 @@
       if (idx === -1) {
         return escapeHtml(name);
       }
-      return escapeHtml(name.slice(0, idx)) +
-        '<mark>' + escapeHtml(name.slice(idx, idx + query.length)) + '</mark>' +
-        escapeHtml(name.slice(idx + query.length));
+      return (
+        escapeHtml(name.slice(0, idx)) +
+        '<mark>' +
+        escapeHtml(name.slice(idx, idx + query.length)) +
+        '</mark>' +
+        escapeHtml(name.slice(idx + query.length))
+      );
     }
 
     function updateSearch() {
@@ -268,14 +292,13 @@
               href: entry.href,
               kind: entry.kind,
               name: entry.name,
-              nameHtml: highlight(entry.name, query)
+              nameHtml: highlight(entry.name, query),
             };
           });
         selected = -1;
         if (matches.length === 0) {
           resultsPanel.innerHTML =
-            '<div class="search-result-empty">No results for &ldquo;' +
-            escapeHtml(input.value) + '&rdquo;</div>';
+            '<div class="search-result-empty">No results for &ldquo;' + escapeHtml(input.value) + '&rdquo;</div>';
           resultsPanel.hidden = false;
           return;
         }
@@ -294,10 +317,9 @@
         link.style.display = query === '' || name.indexOf(query) !== -1 ? '' : 'none';
       });
       sidebar.querySelectorAll('details').forEach(function (details) {
-        var anyVisible = Array.prototype.some.call(
-          details.querySelectorAll('a[data-name]'),
-          function (a) { return a.style.display !== 'none'; }
-        );
+        var anyVisible = Array.prototype.some.call(details.querySelectorAll('a[data-name]'), function (a) {
+          return a.style.display !== 'none';
+        });
         if (query !== '' && anyVisible && !details.open) {
           details.open = true;
         }
@@ -424,19 +446,25 @@
         return;
       }
       current = best;
-      links.forEach(function (l) { l.classList.remove('active'); });
+      links.forEach(function (l) {
+        l.classList.remove('active');
+      });
       best.link.classList.add('active');
     }
     var ticking = false;
-    document.addEventListener('scroll', function () {
-      if (!ticking) {
-        ticking = true;
-        requestAnimationFrame(function () {
-          update();
-          ticking = false;
-        });
-      }
-    }, { passive: true });
+    document.addEventListener(
+      'scroll',
+      function () {
+        if (!ticking) {
+          ticking = true;
+          requestAnimationFrame(function () {
+            update();
+            ticking = false;
+          });
+        }
+      },
+      { passive: true },
+    );
     update();
   }
 

--- a/crates/emmylua_doc_cli/template/static/rustdoc.css
+++ b/crates/emmylua_doc_cli/template/static/rustdoc.css
@@ -7,7 +7,9 @@
   font-family: 'Fira Sans';
   font-style: normal;
   font-weight: 400;
-  src: local('Fira Sans'), url("fonts/FiraSans-Regular-0fe48ade.woff2") format("woff2");
+  src:
+    local('Fira Sans'),
+    url('fonts/FiraSans-Regular-0fe48ade.woff2') format('woff2');
   font-display: swap;
 }
 
@@ -15,7 +17,9 @@
   font-family: 'Fira Sans';
   font-style: italic;
   font-weight: 400;
-  src: local('Fira Sans Italic'), url("fonts/FiraSans-Italic-81dc35de.woff2") format("woff2");
+  src:
+    local('Fira Sans Italic'),
+    url('fonts/FiraSans-Italic-81dc35de.woff2') format('woff2');
   font-display: swap;
 }
 
@@ -23,7 +27,9 @@
   font-family: 'Fira Sans';
   font-style: normal;
   font-weight: 500;
-  src: local('Fira Sans Medium'), url("fonts/FiraSans-Medium-e1aa3f0a.woff2") format("woff2");
+  src:
+    local('Fira Sans Medium'),
+    url('fonts/FiraSans-Medium-e1aa3f0a.woff2') format('woff2');
   font-display: swap;
 }
 
@@ -31,7 +37,9 @@
   font-family: 'Fira Sans';
   font-style: italic;
   font-weight: 500;
-  src: local('Fira Sans Medium Italic'), url("fonts/FiraSans-MediumItalic-ccf7e434.woff2") format("woff2");
+  src:
+    local('Fira Sans Medium Italic'),
+    url('fonts/FiraSans-MediumItalic-ccf7e434.woff2') format('woff2');
   font-display: swap;
 }
 
@@ -39,7 +47,9 @@
   font-family: 'Source Serif 4';
   font-style: normal;
   font-weight: 400;
-  src: local('Source Serif 4'), url("fonts/SourceSerif4-Regular-6b053e98.ttf.woff2") format("woff2");
+  src:
+    local('Source Serif 4'),
+    url('fonts/SourceSerif4-Regular-6b053e98.ttf.woff2') format('woff2');
   font-display: swap;
 }
 
@@ -47,7 +57,9 @@
   font-family: 'Source Serif 4';
   font-style: italic;
   font-weight: 400;
-  src: local('Source Serif 4 Italic'), url("fonts/SourceSerif4-It-ca3b17ed.ttf.woff2") format("woff2");
+  src:
+    local('Source Serif 4 Italic'),
+    url('fonts/SourceSerif4-It-ca3b17ed.ttf.woff2') format('woff2');
   font-display: swap;
 }
 
@@ -55,7 +67,9 @@
   font-family: 'Source Serif 4';
   font-style: normal;
   font-weight: 500;
-  src: local('Source Serif 4 Semibold'), url("fonts/SourceSerif4-Semibold-457a13ac.ttf.woff2") format("woff2");
+  src:
+    local('Source Serif 4 Semibold'),
+    url('fonts/SourceSerif4-Semibold-457a13ac.ttf.woff2') format('woff2');
   font-display: swap;
 }
 
@@ -63,7 +77,9 @@
   font-family: 'Source Serif 4';
   font-style: normal;
   font-weight: 700;
-  src: local('Source Serif 4 Bold'), url("fonts/SourceSerif4-Bold-6d4fd4c0.ttf.woff2") format("woff2");
+  src:
+    local('Source Serif 4 Bold'),
+    url('fonts/SourceSerif4-Bold-6d4fd4c0.ttf.woff2') format('woff2');
   font-display: swap;
 }
 
@@ -71,7 +87,7 @@
   font-family: 'Source Code Pro';
   font-style: normal;
   font-weight: 400;
-  src: url("fonts/SourceCodePro-Regular-8badfe75.ttf.woff2") format("woff2");
+  src: url('fonts/SourceCodePro-Regular-8badfe75.ttf.woff2') format('woff2');
   font-display: swap;
 }
 
@@ -79,7 +95,7 @@
   font-family: 'Source Code Pro';
   font-style: italic;
   font-weight: 400;
-  src: url("fonts/SourceCodePro-It-fc8b9304.ttf.woff2") format("woff2");
+  src: url('fonts/SourceCodePro-It-fc8b9304.ttf.woff2') format('woff2');
   font-display: swap;
 }
 
@@ -87,21 +103,21 @@
   font-family: 'Source Code Pro';
   font-style: normal;
   font-weight: 600;
-  src: url("fonts/SourceCodePro-Semibold-aa29a496.ttf.woff2") format("woff2");
+  src: url('fonts/SourceCodePro-Semibold-aa29a496.ttf.woff2') format('woff2');
   font-display: swap;
 }
 
 :root {
   /* Serif body text is rustdoc's signature look; UI chrome (sidebar, top
      bar, headings, search) uses sans. */
-  --font-body: "Source Serif 4", Georgia, "Times New Roman", serif;
-  --font-sans: "Fira Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif;
-  --font-mono: "Source Code Pro", "SFMono-Regular", Consolas, Menlo, monospace;
+  --font-body: 'Source Serif 4', Georgia, 'Times New Roman', serif;
+  --font-sans: 'Fira Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif;
+  --font-mono: 'Source Code Pro', 'SFMono-Regular', Consolas, Menlo, monospace;
 }
 
 /* Begin theme: light (rustdoc defaults) */
 :root,
-:root[data-theme="light"] {
+:root[data-theme='light'] {
   color-scheme: light;
   --bg: #ffffff;
   --bg-elevated: #ffffff;
@@ -120,7 +136,7 @@
   --header-bg: #f5f5f5;
   --header-fg: #000000;
   --signature-bg: #f5f5f5;
-  --shadow: 0 1px 2px rgba(0, 0, 0, .08);
+  --shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
   --radius: 2px;
   /* Syntax highlighting (rustdoc light = Tomorrow) */
   --hl-str: #718c00;
@@ -151,7 +167,7 @@
 /* Dark palette. Kept in sync between the explicit [data-theme="dark"] override
      and the system dark preference (used when no explicit light choice exists). */
 /* Begin theme: dark (rustdoc defaults) */
-:root[data-theme="dark"] {
+:root[data-theme='dark'] {
   color-scheme: dark;
   --bg: #353535;
   --bg-elevated: #3c3c3c;
@@ -164,13 +180,13 @@
   --border-strong: #999999;
   --accent: #d2991d;
   --accent-strong: #d2991d;
-  --accent-soft: rgba(210, 153, 29, .18);
+  --accent-soft: rgba(210, 153, 29, 0.18);
   --code-bg: #2a2a2a;
   --deprecated: #f85149;
   --header-bg: #505050;
   --header-fg: #dddddd;
   --signature-bg: #2a2a2a;
-  --shadow: 0 1px 2px rgba(0, 0, 0, .4);
+  --shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
   --hl-str: #83a300;
   --hl-num: #83a300;
   --hl-kw: #ab8ac1;
@@ -196,7 +212,7 @@
 /* End theme: dark */
 
 @media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) {
+  :root:not([data-theme='light']) {
     color-scheme: dark;
     --bg: #353535;
     --bg-elevated: #3c3c3c;
@@ -209,13 +225,13 @@
     --border-strong: #999999;
     --accent: #d2991d;
     --accent-strong: #d2991d;
-    --accent-soft: rgba(210, 153, 29, .18);
+    --accent-soft: rgba(210, 153, 29, 0.18);
     --code-bg: #2a2a2a;
     --deprecated: #f85149;
     --header-bg: #505050;
     --header-fg: #dddddd;
     --signature-bg: #2a2a2a;
-    --shadow: 0 1px 2px rgba(0, 0, 0, .4);
+    --shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
     --hl-str: #83a300;
     --hl-num: #83a300;
     --hl-kw: #ab8ac1;
@@ -259,7 +275,7 @@ body {
   color: var(--fg);
   background: var(--bg);
   line-height: 1.5;
-  font-feature-settings: "kern", "liga";
+  font-feature-settings: 'kern', 'liga';
   -webkit-font-smoothing: antialiased;
 }
 
@@ -296,14 +312,14 @@ a:hover {
   font-family: var(--font-sans);
   font-weight: 500;
   font-size: 15px;
-  letter-spacing: .01em;
+  letter-spacing: 0.01em;
   color: var(--header-fg);
   white-space: nowrap;
 }
 
 .docbar-title:hover {
   text-decoration: none;
-  opacity: .85;
+  opacity: 0.85;
 }
 
 /* The search box is the visual anchor of the top bar: centered, stretched
@@ -326,7 +342,9 @@ a:hover {
   color: var(--fg);
   font-size: 14px;
   outline: none;
-  transition: border-color .15s ease, box-shadow .15s ease;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
 }
 
 .search input::placeholder {
@@ -366,8 +384,8 @@ a:hover {
   pointer-events: none;
 }
 
-.search input:focus~.search-hint,
-.search input:not(:placeholder-shown)~.search-hint {
+.search input:focus ~ .search-hint,
+.search input:not(:placeholder-shown) ~ .search-hint {
   display: none;
 }
 
@@ -383,7 +401,7 @@ a:hover {
   background: var(--bg-elevated);
   border: 1px solid var(--border-strong);
   border-radius: 3px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, .15);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
   padding: 2px;
 }
 
@@ -475,7 +493,7 @@ a:hover {
   font-size: 11px;
   font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: .08em;
+  letter-spacing: 0.08em;
   color: var(--fg-muted);
   padding: 10px 16px 4px;
 }
@@ -507,7 +525,7 @@ a:hover {
   padding: 2px 18px;
   user-select: none;
   list-style: none;
-  transition: color .12s ease;
+  transition: color 0.12s ease;
 }
 
 .sidebar summary.group-label::-webkit-details-marker {
@@ -526,10 +544,10 @@ a:hover {
   border-left: 4px solid currentColor;
   border-top: 3.5px solid transparent;
   border-bottom: 3.5px solid transparent;
-  transition: transform .15s ease;
+  transition: transform 0.15s ease;
 }
 
-.sidebar details[open]>summary.group-label .group-caret {
+.sidebar details[open] > summary.group-label .group-caret {
   transform: rotate(90deg);
 }
 
@@ -543,13 +561,13 @@ a:hover {
   margin: 0;
 }
 
-.sidebar details>ul {
+.sidebar details > ul {
   padding-left: 12px;
   border-left: 1px solid var(--border);
   margin-left: 21px;
 }
 
-.sidebar details[open]>ul {
+.sidebar details[open] > ul {
   margin-bottom: 2px;
 }
 
@@ -564,7 +582,9 @@ a:hover {
   font-size: 13px;
   color: var(--sidebar-link);
   overflow: hidden;
-  transition: background .12s ease, color .12s ease;
+  transition:
+    background 0.12s ease,
+    color 0.12s ease;
 }
 
 .sidebar a.nav-item:hover {
@@ -823,7 +843,7 @@ a:hover {
 
 .member-overloads .member-signature pre.signature {
   margin-top: 4px;
-  opacity: .92;
+  opacity: 0.92;
 }
 
 .docblock blockquote {
@@ -979,7 +999,7 @@ pre.signature a:hover {
   font-size: 11px;
   font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: .08em;
+  letter-spacing: 0.08em;
   color: var(--fg-muted);
   margin-bottom: 4px;
 }
@@ -1038,7 +1058,7 @@ pre.signature a:hover {
   margin: 0;
 }
 
-.param-row dd p+p {
+.param-row dd p + p {
   margin-top: 4px;
 }
 
@@ -1066,7 +1086,7 @@ pre.signature a:hover {
   margin: 0 0 6px;
   font-size: 34px;
   font-weight: 500;
-  letter-spacing: -.01em;
+  letter-spacing: -0.01em;
 }
 
 .hero-lead {
@@ -1198,7 +1218,9 @@ pre.signature a:hover {
   background: transparent;
   color: var(--header-fg);
   cursor: pointer;
-  transition: background .15s ease, border-color .15s ease;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease;
 }
 
 .icon-btn:hover {
@@ -1239,8 +1261,8 @@ pre.signature a:hover {
 }
 
 /* Deprecated emphasis */
-.member.is-deprecated>.member-head .member-signature {
-  opacity: .75;
+.member.is-deprecated > .member-head .member-signature {
+  opacity: 0.75;
 }
 
 /* rustdoc renders stability badges as soft-highlighted "stab" chips rather
@@ -1278,7 +1300,7 @@ pre.signature a:hover {
 }
 
 .breadcrumb .sep {
-  opacity: .6;
+  opacity: 0.6;
 }
 
 .breadcrumb .crumb-current {
@@ -1307,7 +1329,7 @@ pre.signature a:hover {
   background: var(--bg-elevated);
   color: var(--fg);
   font-family: var(--font-sans);
-  transition: border-color .15s ease;
+  transition: border-color 0.15s ease;
 }
 
 .stat-card:hover {
@@ -1325,7 +1347,7 @@ pre.signature a:hover {
   font-size: 11px;
   font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: .07em;
+  letter-spacing: 0.07em;
   color: var(--fg-muted);
 }
 
@@ -1349,7 +1371,10 @@ pre.signature a:hover {
   color: var(--fg-muted);
   cursor: pointer;
   opacity: 0;
-  transition: opacity .15s ease, color .15s ease, border-color .15s ease;
+  transition:
+    opacity 0.15s ease,
+    color 0.15s ease,
+    border-color 0.15s ease;
 }
 
 .code-wrap:hover .copy-btn,
@@ -1394,7 +1419,7 @@ pre.signature a:hover {
   font-size: 11px;
   font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: .08em;
+  letter-spacing: 0.08em;
   color: var(--fg-muted);
   margin-bottom: 6px;
   padding-left: 12px;
@@ -1458,7 +1483,7 @@ pre.signature a:hover {
   position: fixed;
   inset: 52px 0 0 0;
   z-index: 35;
-  background: rgba(0, 0, 0, .45);
+  background: rgba(0, 0, 0, 0.45);
 }
 
 #sidebar-backdrop[hidden] {
@@ -1494,13 +1519,13 @@ pre.signature a:hover {
     z-index: 40;
     height: auto;
     transform: translateX(-102%);
-    transition: transform .2s ease;
+    transition: transform 0.2s ease;
     background: var(--bg-sidebar);
   }
 
   body.drawer-open .sidebar {
     transform: translateX(0);
-    box-shadow: 0 8px 28px rgba(0, 0, 0, .3);
+    box-shadow: 0 8px 28px rgba(0, 0, 0, 0.3);
   }
 
   .content {
@@ -1518,7 +1543,6 @@ pre.signature a:hover {
 
 /* ─── Print ───────────────────────────────────────────── */
 @media print {
-
   .docbar,
   .sidebar,
   .toc,
@@ -1540,7 +1564,7 @@ pre.signature a:hover {
     display: block !important;
   }
 
-  .member>.member-head .group-caret {
+  .member > .member-head .group-caret {
     display: none;
   }
 


### PR DESCRIPTION
I mentioned formatting in https://github.com/EmmyLuaLs/emmylua-analyzer-rust/pull/1209#issuecomment-5221539985. This PR adds Prettier as the formatter for the files in `crates/emmylua_doc_cli/templates`. Technically, it can also format Markdown (`docs/`) and Yaml (`.github/`), but I disabled that to avoid too many changes in one PR.

There isn't much difference between Prettier and Biome. Prettier is probably more widespread as it's the defacto default formatter in the JS ecosystem.