### PR TITLE
Fix runtime versions for math.randomseed()

### DIFF
--- a/crates/emmylua_code_analysis/resources/std/math.lua
+++ b/crates/emmylua_code_analysis/resources/std/math.lua
@@ -160,8 +160,6 @@ function math.rad(x) end
 --- @return integer
 function math.random(m, n) end
 
---- @version 5.1, 5.2, 5.3
----
 --- Sets `x` as the "seed" for the pseudo-random generator: equal seeds
 --- produce equal sequences of numbers.
 --- @param x integer


### PR DESCRIPTION
Fixes #1213