### PR TITLE
Use version number for GitHub release name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
-          name: emmylua_ls
+          name: ${{ github.ref_name }}
           draft: false
           generate_release_notes: true
           files: |


### PR DESCRIPTION
Currently every GitHub release has the same hard coded name: `emmylua_ls`.
So it's a pain to actually see the version list:

<img width="727" height="554" alt="Screenshot 2026-08-14 at 13 16 15" src="https://github.com/user-attachments/assets/659d0189-6755-4c7e-903e-28f50934f40f" />

This PR fixes the GitHub action and you can easily rename historical releases with:
```shell
gh release edit 0.25.1 --title 0.25.1
gh release edit 0.25.0 --title 0.25.0
gh release edit 0.24.0 --title 0.24.0
gh release edit 0.23.2 --title 0.23.2
gh release edit 0.23.1 --title 0.23.1
gh release edit 0.23.0 --title 0.23.0
gh release edit 0.22.0 --title 0.22.0
gh release edit 0.21.0 --title 0.21.0
gh release edit 0.20.0 --title 0.20.0
gh release edit 0.19.0 --title 0.19.0
gh release edit 0.18.0 --title 0.18.0
gh release edit 0.17.0 --title 0.17.0
gh release edit 0.16.0 --title 0.16.0
gh release edit 0.15.0 --title 0.15.0
gh release edit 0.14.0 --title 0.14.0
gh release edit 0.13.0 --title 0.13.0
gh release edit 0.12.0 --title 0.12.0
gh release edit 0.11.0 --title 0.11.0
gh release edit 0.10.0 --title 0.10.0
gh release edit 0.9.1 --title 0.9.1
gh release edit 0.9.0 --title 0.9.0
gh release edit 0.8.2 --title 0.8.2
gh release edit 0.8.1 --title 0.8.1
gh release edit 0.8.0 --title 0.8.0
gh release edit 0.7.3 --title 0.7.3
gh release edit 0.7.2 --title 0.7.2
gh release edit 0.7.1 --title 0.7.1
gh release edit 0.7.0 --title 0.7.0
gh release edit 0.6.0 --title 0.6.0
gh release edit 0.5.4 --title 0.5.4
gh release edit 0.5.3 --title 0.5.3
gh release edit 0.5.2 --title 0.5.2
gh release edit 0.5.1 --title 0.5.1
gh release edit 0.5.0 --title 0.5.0
gh release edit 0.4.6 --title 0.4.6
gh release edit 0.4.5 --title 0.4.5
gh release edit 0.4.4 --title 0.4.4
gh release edit 0.4.3 --title 0.4.3
gh release edit 0.4.2 --title 0.4.2
gh release edit 0.4.1 --title 0.4.1
gh release edit 0.3.3 --title 0.3.3
gh release edit 0.3.2 --title 0.3.2
gh release edit 0.3.1 --title 0.3.1
gh release edit 0.3.0 --title 0.3.0
gh release edit 0.2.9 --title 0.2.9
gh release edit 0.2.8 --title 0.2.8
gh release edit 0.2.7 --title 0.2.7
gh release edit 0.2.6 --title 0.2.6
gh release edit 0.2.5 --title 0.2.5
gh release edit 0.2.4 --title 0.2.4
gh release edit 0.2.2 --title 0.2.2
gh release edit 0.2.1 --title 0.2.1
gh release edit 0.2.0 --title 0.2.0
gh release edit 0.1.7 --title 0.1.7
gh release edit 0.1.6 --title 0.1.6
gh release edit 0.1.5 --title 0.1.5
gh release edit 0.1.4 --title 0.1.4
gh release edit 0.1.3 --title 0.1.3
gh release edit 0.1.2 --title 0.1.2
gh release edit 0.1.1 --title 0.1.1
gh release edit 0.1.0 --title 0.1.0
```