### PR TITLE
fix(type-check): accept exhaustive boolean unions

### DIFF
--- a/crates/emmylua_code_analysis/src/compilation/analyzer/doc/infer_type.rs
+++ b/crates/emmylua_code_analysis/src/compilation/analyzer/doc/infer_type.rs
@@ -511,27 +511,9 @@ fn infer_binary_type(
         let right_type = infer_type(analyzer, right);
         if let Some(op) = binary_type.get_op_token() {
             match op.get_op() {
-                LuaTypeBinaryOperator::Union => match (left_type, right_type) {
-                    (LuaType::Union(left_type_union), LuaType::Union(right_type_union)) => {
-                        let mut left_type_set = left_type_union.into_vec();
-                        let right_types = right_type_union.into_vec();
-                        left_type_set.extend(right_types);
-                        return LuaType::from_vec(left_type_set);
-                    }
-                    (LuaType::Union(left_type_union), right) => {
-                        let mut left_types = (*left_type_union).into_vec();
-                        left_types.push(right);
-                        return LuaType::from_vec(left_types);
-                    }
-                    (left, LuaType::Union(right_type_union)) => {
-                        let mut right_types = (*right_type_union).into_vec();
-                        right_types.push(left);
-                        return LuaType::from_vec(right_types);
-                    }
-                    (left, right) => {
-                        return LuaType::from_vec(vec![left, right]);
-                    }
-                },
+                LuaTypeBinaryOperator::Union => {
+                    return LuaType::from_vec(vec![left_type, right_type]);
+                }
                 LuaTypeBinaryOperator::Intersection => match (left_type, right_type) {
                     (
                         LuaType::Intersection(left_type_union),

--- a/crates/emmylua_code_analysis/src/diagnostic/test/return_type_mismatch_test.rs
+++ b/crates/emmylua_code_analysis/src/diagnostic/test/return_type_mismatch_test.rs
@@ -3,6 +3,26 @@ mod tests {
     use crate::{DiagnosticCode, VirtualWorkspace};
 
     #[test]
+    fn test_issue_1226() {
+        let mut ws = VirtualWorkspace::new();
+
+        assert!(ws.has_no_diagnostic(
+            DiagnosticCode::ReturnTypeMismatch,
+            r#"
+            ---@return boolean
+            local function test1()
+                return true ---@as true | false
+            end
+
+            ---@return true | false
+            local function test2()
+                return true ---@as boolean
+            end
+            "#,
+        ));
+    }
+
+    #[test]
     fn test_issue_242() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
         assert!(ws.has_no_diagnostic_in_namespace(

--- a/crates/emmylua_code_analysis/src/semantic/infer/infer_doc_type.rs
+++ b/crates/emmylua_code_analysis/src/semantic/infer/infer_doc_type.rs
@@ -323,27 +323,9 @@ fn infer_binary_type(ctx: DocTypeInferContext<'_>, binary_type: &LuaDocBinaryTyp
         let right_type = infer_doc_type(ctx, &right);
         if let Some(op) = binary_type.get_op_token() {
             match op.get_op() {
-                LuaTypeBinaryOperator::Union => match (left_type, right_type) {
-                    (LuaType::Union(left_type_union), LuaType::Union(right_type_union)) => {
-                        let mut left_types = left_type_union.into_vec();
-                        let right_types = right_type_union.into_vec();
-                        left_types.extend(right_types);
-                        return LuaType::from_vec(left_types);
-                    }
-                    (LuaType::Union(left_type_union), right) => {
-                        let mut left_types = left_type_union.into_vec();
-                        left_types.push(right);
-                        return LuaType::from_vec(left_types);
-                    }
-                    (left, LuaType::Union(right_type_union)) => {
-                        let mut right_types = right_type_union.into_vec();
-                        right_types.push(left);
-                        return LuaType::from_vec(right_types);
-                    }
-                    (left, right) => {
-                        return LuaType::from_vec(vec![left, right]);
-                    }
-                },
+                LuaTypeBinaryOperator::Union => {
+                    return LuaType::from_vec(vec![left_type, right_type]);
+                }
                 LuaTypeBinaryOperator::Intersection => match (left_type, right_type) {
                     (
                         LuaType::Intersection(left_type_union),

--- a/crates/emmylua_code_analysis/src/semantic/type_check/complex_type/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/type_check/complex_type/mod.rs
@@ -81,7 +81,21 @@ pub fn check_complex_type_compact(
                     check_guard.next_level()?,
                 );
             }
-            for sub_type in union_type.into_vec() {
+
+            let sub_types = union_type.into_vec();
+            if matches!(compact_type, LuaType::Boolean) {
+                let contains_literal = |value| {
+                    sub_types.contains(&LuaType::BooleanConst(value))
+                        || sub_types.contains(&LuaType::DocBooleanConst(value))
+                };
+
+                // A boolean has only two possible values, so both literals cover it.
+                if contains_literal(true) && contains_literal(false) {
+                    return Ok(());
+                }
+            }
+
+            for sub_type in sub_types {
                 match check_general_type_compact(
                     context,
                     &sub_type,


### PR DESCRIPTION
## Problem

`boolean` values were rejected where the equivalent `true | false` literal
union was expected.

## Solution

- Treat unions containing both boolean literals as exhaustive during type
  checking.
- Reuse structural union construction in both document type inference paths.

## Tests

- `cargo test -p emmylua_code_analysis`
- `cargo fmt --all -- --check`
- `cargo clippy -p emmylua_code_analysis --all-targets --all-features --locked -- -D warnings`

Fixes #1226
