### PR TITLE
fix(generic): preserve variadic return tails

### DIFF
--- a/crates/emmylua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/generic_test.rs
@@ -1672,6 +1672,24 @@ mod test {
     }
 
     #[test]
+    fn test_generic_variadic_return_after_fixed_return_keeps_deep_slots() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@generic T
+            ---@param value T
+            ---@return integer, T...
+            local function some_func(value)
+            end
+
+            First, Second, Third = some_func("")
+            "#,
+        );
+
+        assert_eq!(ws.expr_ty("Third"), ws.ty("string"));
+    }
+
+    #[test]
     fn test_nested_function_keeps_unresolved_variadic_return_generic() {
         let mut ws = VirtualWorkspace::new();
         ws.def(

--- a/crates/emmylua_code_analysis/src/compilation/test/return_overload_generic_test.rs
+++ b/crates/emmylua_code_analysis/src/compilation/test/return_overload_generic_test.rs
@@ -61,6 +61,24 @@ mod test {
     }
 
     #[test]
+    fn test_generic_variadic_return_overload_after_fixed_return_keeps_deep_slots() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@generic T
+            ---@param value T
+            ---@return_overload integer, T...
+            local function some_func(value)
+            end
+
+            First, Second, Third, Fourth = some_func("")
+            "#,
+        );
+
+        assert_eq!(ws.expr_ty("Fourth"), ws.ty("string"));
+    }
+
+    #[test]
     fn test_return_overload_variadic_tpl_tail_pads_missing_slots_with_nil() {
         let mut ws = VirtualWorkspace::new();
         ws.def(

--- a/crates/emmylua_code_analysis/src/semantic/generic/instantiate_type/mod.rs
+++ b/crates/emmylua_code_analysis/src/semantic/generic/instantiate_type/mod.rs
@@ -665,7 +665,8 @@ fn instantiate_variadic_type(
                     match t {
                         LuaType::Never => {}
                         LuaType::Variadic(variadic) => match variadic.deref() {
-                            VariadicType::Base(base) => new_types.push(base.clone()),
+                            // A base variadic is unbounded; unwrapping it turns `T...` into one `T`.
+                            VariadicType::Base(_) => new_types.push(LuaType::Variadic(variadic)),
                             VariadicType::Multi(multi) => {
                                 for mt in multi {
                                     new_types.push(mt.clone());


### PR DESCRIPTION
## Problem

`T...` variadic return tails were unwrapped to one `T` when they followed
fixed return values. Deeper assignment slots therefore became unknown,
including for `@return_overload`.

## Solution

- Keep instantiated unbounded base variadics wrapped in multi-return rows.
- Continue expanding finite multi-return substitutions.

## Tests

- `cargo test -p emmylua_code_analysis`
- `cargo fmt --all --check`
- `cargo clippy -p emmylua_code_analysis --all-targets --all-features --locked -- -D warnings`

Fixes #1227
